### PR TITLE
add v1beta draft for designs

### DIFF
--- a/schemas/constructs/v1beta2-draft/designs-v1beta1.json
+++ b/schemas/constructs/v1beta2-draft/designs-v1beta1.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Design Schema",
+  "description": "Schema for design  in v1Beta1",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "description": "Name of the design"
+    },
+    "schemaVersion": {
+      "$ref": "https://schemas.meshery.io/v1alpha2/core.json#versionString",
+      "description": "Specifies the version of the schema to which the design  conforms."
+    },
+    "version": {
+      "$ref": "https://schemas.meshery.io/v1alpha2/core.json#semverString",
+      "description": "Version of the design",
+      "minLength": 1,
+      "maxLength": 50
+    },
+    "components": {
+      "type": "object",
+      "description": "Map of component IDs to their corresponding component declarations",
+      "additionalProperties": {
+        "$ref": "#/definitions/Component"
+      }
+    },
+    "preferences": {
+      "type": "object",
+      "description": "Design-level preferences",
+      "properties": {
+        "Layers": {
+          "type": "array",
+          "description": "List of available layers",
+          "items": {
+            "type": "string",
+            "enum": ["components", "edges", "tagsets", "children", "grandchildren", "badges"]
+          }
+        },
+        "Relationship_configurations": {
+          "type": "object",
+          "description": "Configuration for different relationship types",
+          "patternProperties": {
+            "^(.*)-(.*)-(.*)$": {
+              "type": "object",
+              "properties": {
+                "Enabled": {
+                  "type": "boolean",
+                  "description": "Whether this relationship type is enabled"
+                },
+                "relation-specific-config": {
+                  "type": "object",
+                  "description": "Optional relation-specific configuration (implementation dependent)"
+                }
+              }
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": ["Layers"]
+    },
+    "Relationships": {
+      "type": "array",
+      "description": "List of relationships between components",
+      "items": {
+        "type": "object",
+        "properties": {
+          "From": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID (UUID) of the source component"
+          },
+          "To": {
+            "type": "string",
+            "format": "uuid",
+            "description": "ID (UUID) of the target component"
+          },
+          "Kind": {
+            "type": "string",
+            "description": "Kind of the relationship"
+          },
+          "Type": {
+            "type": "string",
+            "description": "Type of the relationship"
+          },
+          "Subtype": {
+            "type": "string",
+            "description": "Subtype of the relationship (optional)"
+          },
+          "Status": {
+            "type": "string",
+            "enum": ["evaluating", "valid", "invalid"],
+            "description": "Status of the relationship"
+          }
+        },
+        "required": ["From", "To", "Kind", "Type", "Status"]
+      }
+    }
+  },
+  "required": ["Name", "Components", "Preferences", "Relationships"]
+}


### PR DESCRIPTION
**Notes for Reviewers**

This PR is a proposal for v1beta1 for designs . some parts might not be technically correct !! 

## Motivation

The current design schema, although undocumented, is a mix of our internal model constructs, deprecated Open Application Model (OAM) elements, and Cytoscape objects. This inconsistency makes it difficult to manage and analyze data effectively.

This revision proposes a stricter schema based on our well-defined internal constructs like models, components, and relationships.

**Example of Current Design (replace with an actual example)**

Much of the current content, particularly traits, lacks a defined schema and acts as a repository for Cytoscape-specific information.

## New in V1 Beta 1

**Removal of Services and Traits:**

The revamped component schema in V1 Beta 1 enhances component versatility for representing infrastructure entities, annotations, and presentation. This allows us to remove the need for both services and traits.

**Design-Level Control:**

V1 Beta 1 introduces the ability to store design-level preferences, including specifying permitted relationships between components.

**Explicit Relationships:**

The current schema relies on implicit Cytoscape constructs to define relationships. V1 Beta 1 introduces a dedicated "relationships stanza" for explicitly defining connections. This stanza uses a structured format with attributes like `<from>`, `<to>`, `<kind>`, `<type>`, `<subtype>`, and `<status>` to improve clarity.

## Versioning of Design

Designs now have version information stored as an integer (`int`) independent of the specific versioning system used. This means the version number itself is an integer, and the logic for assigning and incrementing it can differ depending on the chosen system.



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
