### PR TITLE
240: 241: fix missing colon, fix selector.json reference

### DIFF
--- a/schemas/constructs/v1alpha1/relationship.json
+++ b/schemas/constructs/v1alpha1/relationship.json
@@ -50,10 +50,10 @@
             "description": "Optional selectors used to define relationships which should not be created / is restricted.",
             "properties": {
               "from": {
-                "$ref": "./selectors.json#/from"
+                "$ref": "./selector.json#/from"
               },
               "to": {
-                "$ref": "./selectors.json#/to"
+                "$ref": "./selector.json#/to"
               }
             }
           },
@@ -62,10 +62,10 @@
             "description": "Selectors used to define relationships which are allowed",
             "properties": {
               "from": {
-                "$ref": "./selectors.json#/from"
+                "$ref": "./selector.json#/from"
               },
               "to": {
-                "$ref": "./selectors.json#/to"
+                "$ref": "./selector.json#/to"
               }
             }
           }

--- a/schemas/constructs/v1alpha1/selector.json
+++ b/schemas/constructs/v1alpha1/selector.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.meshery.io/selectors.json",
+  "$id": "https://schemas.meshery.io/selector.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Reusable relationships selectors schema elements",
   "from": {

--- a/schemas/constructs/v1alpha2/relationship.json
+++ b/schemas/constructs/v1alpha2/relationship.json
@@ -78,10 +78,10 @@
             ],
             "properties": {
               "from": {
-                "$ref": "./selectors.json#/from"
+                "$ref": "./selector.json#/from"
               },
               "to": {
-                "$ref": "./selectors.json#/to"
+                "$ref": "./selector.json#/to"
               }
             }
           },
@@ -94,10 +94,10 @@
             ],
             "properties": {
               "from": {
-                "$ref": "./selectors.json#/from"
+                "$ref": "./selector.json#/from"
               },
               "to": {
-                "$ref": "./selectors.json#/to"
+                "$ref": "./selector.json#/to"
               }
             }
           }

--- a/schemas/constructs/v1alpha2/selector.json
+++ b/schemas/constructs/v1alpha2/selector.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://schemas.meshery.io/selectors.json",
+  "$id": "https://schemas.meshery.io/selector.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Reusable relationships selectors schema elements",
   "$comment": "Sets of selectors are interpreted as a locical OR, while sets of allow/deny are interpreted a logical AND.",

--- a/schemas/constructs/v1alpha3/selector.json
+++ b/schemas/constructs/v1alpha3/selector.json
@@ -1,10 +1,10 @@
 {
-  "$id": "https://schemas.meshery.io/selectors.json",
+  "$id": "https://schemas.meshery.io/selector.json",
   "$schema": "http://json-schema.org/draft-07/schema#",
   "description": "Reusable relationships selectors schema elements",
   "$comment": "Sets of selectors are interpreted as a logical OR, while sets of allow/deny are interpreted a logical AND.",
   "definitions": {
-    "matchSelector"w {
+    "matchSelector": {
       "$comment": "Type is array so that mutliple bindings can be supported between 2 nodes",
       "type": "array",
       "items": {


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #240 and #241 

Looks like there are: 
- a colon missing in `schemas/constructs/v1alpha3/selector.json` line 7: [link](https://github.com/meshery/schemas/blob/master/schemas/constructs/v1alpha3/selector.json#L7)
- correct reference is `selector.json` instead of `selectors.json`, f.e.: [v1alpha3/selector.json ](https://github.com/meshery/schemas/blob/master/schemas/constructs/v1alpha3/selector.json)



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
