### PR TITLE
fix: Makefile missing separator: update spaces to tab

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ ifeq (,$(shell command -v oapi-codegen))
 	@echo "Dependency missing: oapi-codegen. Install oapi-codegen cli from
 	@echo "installing oapi-codegen"
 	# for the binary install
-    go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
 endif
 
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes Makefile missing separator error.

Right now when you try to run any Makefile target, f.e.
```sh
make generate-ts
```

you receive 
```sh
Makefile:102: *** missing separator. Stop.
```

Update 4 spaces on line 102 to one tab to fix the error. 


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
