### PR TITLE
fix: remove json_models folder from schema.go

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -4,5 +4,5 @@ import "embed"
 
 // Embedding schemas
 //
-//go:embed schemas json_models
+//go:embed schemas
 var Schemas embed.FS


### PR DESCRIPTION
**Notes for Reviewers**

Remove json_models from schema.go as the folder does not exists anymore. 



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
