### PR TITLE
feature: schema driven connections: owner in environment back to *uuid

### DIFF
--- a/models/v1beta1/environment/environment.go
+++ b/models/v1beta1/environment/environment.go
@@ -26,7 +26,7 @@ type Environment struct {
 	OrganizationID uuid.UUID `db:"org_id" json:"org_id" yaml:"org_id"`
 
 	// Owner Environment owner
-	Owner     *string       `db:"owner" json:"owner,omitempty" yaml:"owner,omitempty"`
+	Owner     *uuid.UUID    `db:"owner" json:"owner,omitempty" yaml:"owner,omitempty"`
 	CreatedAt time.Time     `db:"created_at" json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	Metadata  core.Map      `db:"metadata" json:"metadata,omitempty" yaml:"metadata,omitempty"`
 	UpdatedAt time.Time     `db:"updated_at" json:"updated_at,omitempty" yaml:"updated_at,omitempty"`

--- a/schemas/cloud_openapi.yml
+++ b/schemas/cloud_openapi.yml
@@ -1675,8 +1675,13 @@ paths:
                       db: owner
                       yaml: owner
                     x-order: 5
-                    type: string
                     description: Environment owner
+                    type: string
+                    format: uuid
+                    x-go-type: uuid.UUID
+                    x-go-type-import:
+                      path: github.com/gofrs/uuid
+                    default: 00000000-00000000-00000000-00000000
                   created_at:
                     x-oapi-codegen-extra-tags:
                       db: created_at
@@ -1840,8 +1845,13 @@ paths:
                             db: owner
                             yaml: owner
                           x-order: 5
-                          type: string
                           description: Environment owner
+                          type: string
+                          format: uuid
+                          x-go-type: uuid.UUID
+                          x-go-type-import:
+                            path: github.com/gofrs/uuid
+                          default: 00000000-00000000-00000000-00000000
                         created_at:
                           x-oapi-codegen-extra-tags:
                             db: created_at
@@ -2467,8 +2477,13 @@ components:
                                 db: owner
                                 yaml: owner
                               x-order: 5
-                              type: string
                               description: Environment owner
+                              type: string
+                              format: uuid
+                              x-go-type: uuid.UUID
+                              x-go-type-import:
+                                path: github.com/gofrs/uuid
+                              default: 00000000-00000000-00000000-00000000
                             created_at:
                               x-oapi-codegen-extra-tags:
                                 db: created_at
@@ -9168,8 +9183,13 @@ components:
                                     db: owner
                                     yaml: owner
                                   x-order: 5
-                                  type: string
                                   description: Environment owner
+                                  type: string
+                                  format: uuid
+                                  x-go-type: uuid.UUID
+                                  x-go-type-import:
+                                    path: github.com/gofrs/uuid
+                                  default: 00000000-00000000-00000000-00000000
                                 created_at:
                                   x-oapi-codegen-extra-tags:
                                     db: created_at
@@ -15986,8 +16006,13 @@ components:
                                           db: owner
                                           yaml: owner
                                         x-order: 5
-                                        type: string
                                         description: Environment owner
+                                        type: string
+                                        format: uuid
+                                        x-go-type: uuid.UUID
+                                        x-go-type-import:
+                                          path: github.com/gofrs/uuid
+                                        default: 00000000-00000000-00000000-00000000
                                       created_at:
                                         x-oapi-codegen-extra-tags:
                                           db: created_at
@@ -22933,8 +22958,13 @@ components:
                                         db: owner
                                         yaml: owner
                                       x-order: 5
-                                      type: string
                                       description: Environment owner
+                                      type: string
+                                      format: uuid
+                                      x-go-type: uuid.UUID
+                                      x-go-type-import:
+                                        path: github.com/gofrs/uuid
+                                      default: 00000000-00000000-00000000-00000000
                                     created_at:
                                       x-oapi-codegen-extra-tags:
                                         db: created_at
@@ -29576,8 +29606,13 @@ components:
                           db: owner
                           yaml: owner
                         x-order: 5
-                        type: string
                         description: Environment owner
+                        type: string
+                        format: uuid
+                        x-go-type: uuid.UUID
+                        x-go-type-import:
+                          path: github.com/gofrs/uuid
+                        default: 00000000-00000000-00000000-00000000
                       created_at:
                         x-oapi-codegen-extra-tags:
                           db: created_at
@@ -31437,8 +31472,13 @@ components:
                       db: owner
                       yaml: owner
                     x-order: 5
-                    type: string
                     description: Environment owner
+                    type: string
+                    format: uuid
+                    x-go-type: uuid.UUID
+                    x-go-type-import:
+                      path: github.com/gofrs/uuid
+                    default: 00000000-00000000-00000000-00000000
                   created_at:
                     x-oapi-codegen-extra-tags:
                       db: created_at
@@ -33590,8 +33630,13 @@ components:
             db: owner
             yaml: owner
           x-order: 5
-          type: string
           description: Environment owner
+          type: string
+          format: uuid
+          x-go-type: uuid.UUID
+          x-go-type-import:
+            path: github.com/gofrs/uuid
+          default: 00000000-00000000-00000000-00000000
         created_at:
           x-oapi-codegen-extra-tags:
             db: created_at
@@ -33779,8 +33824,13 @@ components:
                   db: owner
                   yaml: owner
                 x-order: 5
-                type: string
                 description: Environment owner
+                type: string
+                format: uuid
+                x-go-type: uuid.UUID
+                x-go-type-import:
+                  path: github.com/gofrs/uuid
+                default: 00000000-00000000-00000000-00000000
               created_at:
                 x-oapi-codegen-extra-tags:
                   db: created_at
@@ -34492,8 +34542,13 @@ components:
                                     db: owner
                                     yaml: owner
                                   x-order: 5
-                                  type: string
                                   description: Environment owner
+                                  type: string
+                                  format: uuid
+                                  x-go-type: uuid.UUID
+                                  x-go-type-import:
+                                    path: github.com/gofrs/uuid
+                                  default: 00000000-00000000-00000000-00000000
                                 created_at:
                                   x-oapi-codegen-extra-tags:
                                     db: created_at
@@ -41171,8 +41226,13 @@ components:
                                     db: owner
                                     yaml: owner
                                   x-order: 5
-                                  type: string
                                   description: Environment owner
+                                  type: string
+                                  format: uuid
+                                  x-go-type: uuid.UUID
+                                  x-go-type-import:
+                                    path: github.com/gofrs/uuid
+                                  default: 00000000-00000000-00000000-00000000
                                 created_at:
                                   x-oapi-codegen-extra-tags:
                                     db: created_at

--- a/schemas/constructs/v1beta1/component/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/component/merged-openapi.yml
@@ -457,8 +457,14 @@
                             "yaml": "owner"
                           },
                           "x-order": 5,
+                          "description": "Environment owner",
                           "type": "string",
-                          "description": "Environment owner"
+                          "format": "uuid",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
+                          },
+                          "default": "00000000-00000000-00000000-00000000"
                         },
                         "created_at": {
                           "x-oapi-codegen-extra-tags": {

--- a/schemas/constructs/v1beta1/connection/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/connection/merged-openapi.yml
@@ -239,8 +239,14 @@
                     "yaml": "owner"
                   },
                   "x-order": 5,
+                  "description": "Environment owner",
                   "type": "string",
-                  "description": "Environment owner"
+                  "format": "uuid",
+                  "x-go-type": "uuid.UUID",
+                  "x-go-type-import": {
+                    "path": "github.com/gofrs/uuid"
+                  },
+                  "default": "00000000-00000000-00000000-00000000"
                 },
                 "created_at": {
                   "x-oapi-codegen-extra-tags": {
@@ -543,8 +549,14 @@
                           "yaml": "owner"
                         },
                         "x-order": 5,
+                        "description": "Environment owner",
                         "type": "string",
-                        "description": "Environment owner"
+                        "format": "uuid",
+                        "x-go-type": "uuid.UUID",
+                        "x-go-type-import": {
+                          "path": "github.com/gofrs/uuid"
+                        },
+                        "default": "00000000-00000000-00000000-00000000"
                       },
                       "created_at": {
                         "x-oapi-codegen-extra-tags": {

--- a/schemas/constructs/v1beta1/environment/environment.json
+++ b/schemas/constructs/v1beta1/environment/environment.json
@@ -56,7 +56,7 @@
         "yaml": "owner"
       },
       "x-order": 5,
-      "type": "string",
+      "$ref": "../../core.json#/definitions/uuid",
       "description": "Environment owner"
     },
     "created_at": {

--- a/schemas/constructs/v1beta1/environment/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/environment/merged-openapi.yml
@@ -212,8 +212,14 @@
               "yaml": "owner"
             },
             "x-order": 5,
+            "description": "Environment owner",
             "type": "string",
-            "description": "Environment owner"
+            "format": "uuid",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/gofrs/uuid"
+            },
+            "default": "00000000-00000000-00000000-00000000"
           },
           "created_at": {
             "x-oapi-codegen-extra-tags": {
@@ -434,8 +440,14 @@
                     "yaml": "owner"
                   },
                   "x-order": 5,
+                  "description": "Environment owner",
                   "type": "string",
-                  "description": "Environment owner"
+                  "format": "uuid",
+                  "x-go-type": "uuid.UUID",
+                  "x-go-type-import": {
+                    "path": "github.com/gofrs/uuid"
+                  },
+                  "default": "00000000-00000000-00000000-00000000"
                 },
                 "created_at": {
                   "x-oapi-codegen-extra-tags": {
@@ -642,8 +654,14 @@
                         "yaml": "owner"
                       },
                       "x-order": 5,
+                      "description": "Environment owner",
                       "type": "string",
-                      "description": "Environment owner"
+                      "format": "uuid",
+                      "x-go-type": "uuid.UUID",
+                      "x-go-type-import": {
+                        "path": "github.com/gofrs/uuid"
+                      },
+                      "default": "00000000-00000000-00000000-00000000"
                     },
                     "created_at": {
                       "x-oapi-codegen-extra-tags": {
@@ -857,8 +875,14 @@
                               "yaml": "owner"
                             },
                             "x-order": 5,
+                            "description": "Environment owner",
                             "type": "string",
-                            "description": "Environment owner"
+                            "format": "uuid",
+                            "x-go-type": "uuid.UUID",
+                            "x-go-type-import": {
+                              "path": "github.com/gofrs/uuid"
+                            },
+                            "default": "00000000-00000000-00000000-00000000"
                           },
                           "created_at": {
                             "x-oapi-codegen-extra-tags": {

--- a/schemas/constructs/v1beta1/evaluation/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/evaluation/merged-openapi.yml
@@ -620,8 +620,14 @@
                                               "yaml": "owner"
                                             },
                                             "x-order": 5,
+                                            "description": "Environment owner",
                                             "type": "string",
-                                            "description": "Environment owner"
+                                            "format": "uuid",
+                                            "x-go-type": "uuid.UUID",
+                                            "x-go-type-import": {
+                                              "path": "github.com/gofrs/uuid"
+                                            },
+                                            "default": "00000000-00000000-00000000-00000000"
                                           },
                                           "created_at": {
                                             "x-oapi-codegen-extra-tags": {
@@ -7161,8 +7167,14 @@
                                                 "yaml": "owner"
                                               },
                                               "x-order": 5,
+                                              "description": "Environment owner",
                                               "type": "string",
-                                              "description": "Environment owner"
+                                              "format": "uuid",
+                                              "x-go-type": "uuid.UUID",
+                                              "x-go-type-import": {
+                                                "path": "github.com/gofrs/uuid"
+                                              },
+                                              "default": "00000000-00000000-00000000-00000000"
                                             },
                                             "created_at": {
                                               "x-oapi-codegen-extra-tags": {
@@ -13726,8 +13738,14 @@
                                       "yaml": "owner"
                                     },
                                     "x-order": 5,
+                                    "description": "Environment owner",
                                     "type": "string",
-                                    "description": "Environment owner"
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    },
+                                    "default": "00000000-00000000-00000000-00000000"
                                   },
                                   "created_at": {
                                     "x-oapi-codegen-extra-tags": {
@@ -20259,8 +20277,14 @@
                                       "yaml": "owner"
                                     },
                                     "x-order": 5,
+                                    "description": "Environment owner",
                                     "type": "string",
-                                    "description": "Environment owner"
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    },
+                                    "default": "00000000-00000000-00000000-00000000"
                                   },
                                   "created_at": {
                                     "x-oapi-codegen-extra-tags": {

--- a/schemas/constructs/v1beta1/model/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/model/merged-openapi.yml
@@ -558,8 +558,14 @@
                         "yaml": "owner"
                       },
                       "x-order": 5,
+                      "description": "Environment owner",
                       "type": "string",
-                      "description": "Environment owner"
+                      "format": "uuid",
+                      "x-go-type": "uuid.UUID",
+                      "x-go-type-import": {
+                        "path": "github.com/gofrs/uuid"
+                      },
+                      "default": "00000000-00000000-00000000-00000000"
                     },
                     "created_at": {
                       "x-oapi-codegen-extra-tags": {

--- a/schemas/constructs/v1beta1/pattern/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/pattern/merged-openapi.yml
@@ -684,8 +684,14 @@
                                   "yaml": "owner"
                                 },
                                 "x-order": 5,
+                                "description": "Environment owner",
                                 "type": "string",
-                                "description": "Environment owner"
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                },
+                                "default": "00000000-00000000-00000000-00000000"
                               },
                               "created_at": {
                                 "x-oapi-codegen-extra-tags": {
@@ -7300,8 +7306,14 @@
                                       "yaml": "owner"
                                     },
                                     "x-order": 5,
+                                    "description": "Environment owner",
                                     "type": "string",
-                                    "description": "Environment owner"
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    },
+                                    "default": "00000000-00000000-00000000-00000000"
                                   },
                                   "created_at": {
                                     "x-oapi-codegen-extra-tags": {
@@ -13948,8 +13960,14 @@
                                             "yaml": "owner"
                                           },
                                           "x-order": 5,
+                                          "description": "Environment owner",
                                           "type": "string",
-                                          "description": "Environment owner"
+                                          "format": "uuid",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          },
+                                          "default": "00000000-00000000-00000000-00000000"
                                         },
                                         "created_at": {
                                           "x-oapi-codegen-extra-tags": {
@@ -20628,8 +20646,14 @@
                                           "yaml": "owner"
                                         },
                                         "x-order": 5,
+                                        "description": "Environment owner",
                                         "type": "string",
-                                        "description": "Environment owner"
+                                        "format": "uuid",
+                                        "x-go-type": "uuid.UUID",
+                                        "x-go-type-import": {
+                                          "path": "github.com/gofrs/uuid"
+                                        },
+                                        "default": "00000000-00000000-00000000-00000000"
                                       },
                                       "created_at": {
                                         "x-oapi-codegen-extra-tags": {

--- a/schemas/merged_openapi.yml
+++ b/schemas/merged_openapi.yml
@@ -1675,8 +1675,13 @@ paths:
                       db: owner
                       yaml: owner
                     x-order: 5
-                    type: string
                     description: Environment owner
+                    type: string
+                    format: uuid
+                    x-go-type: uuid.UUID
+                    x-go-type-import:
+                      path: github.com/gofrs/uuid
+                    default: 00000000-00000000-00000000-00000000
                   created_at:
                     x-oapi-codegen-extra-tags:
                       db: created_at
@@ -1840,8 +1845,13 @@ paths:
                             db: owner
                             yaml: owner
                           x-order: 5
-                          type: string
                           description: Environment owner
+                          type: string
+                          format: uuid
+                          x-go-type: uuid.UUID
+                          x-go-type-import:
+                            path: github.com/gofrs/uuid
+                          default: 00000000-00000000-00000000-00000000
                         created_at:
                           x-oapi-codegen-extra-tags:
                             db: created_at
@@ -2494,8 +2504,13 @@ paths:
                                             db: owner
                                             yaml: owner
                                           x-order: 5
-                                          type: string
                                           description: Environment owner
+                                          type: string
+                                          format: uuid
+                                          x-go-type: uuid.UUID
+                                          x-go-type-import:
+                                            path: github.com/gofrs/uuid
+                                          default: 00000000-00000000-00000000-00000000
                                         created_at:
                                           x-oapi-codegen-extra-tags:
                                             db: created_at
@@ -9338,8 +9353,13 @@ paths:
                                               db: owner
                                               yaml: owner
                                             x-order: 5
-                                            type: string
                                             description: Environment owner
+                                            type: string
+                                            format: uuid
+                                            x-go-type: uuid.UUID
+                                            x-go-type-import:
+                                              path: github.com/gofrs/uuid
+                                            default: 00000000-00000000-00000000-00000000
                                           created_at:
                                             x-oapi-codegen-extra-tags:
                                               db: created_at
@@ -16195,8 +16215,13 @@ components:
                                 db: owner
                                 yaml: owner
                               x-order: 5
-                              type: string
                               description: Environment owner
+                              type: string
+                              format: uuid
+                              x-go-type: uuid.UUID
+                              x-go-type-import:
+                                path: github.com/gofrs/uuid
+                              default: 00000000-00000000-00000000-00000000
                             created_at:
                               x-oapi-codegen-extra-tags:
                                 db: created_at
@@ -22896,8 +22921,13 @@ components:
                                     db: owner
                                     yaml: owner
                                   x-order: 5
-                                  type: string
                                   description: Environment owner
+                                  type: string
+                                  format: uuid
+                                  x-go-type: uuid.UUID
+                                  x-go-type-import:
+                                    path: github.com/gofrs/uuid
+                                  default: 00000000-00000000-00000000-00000000
                                 created_at:
                                   x-oapi-codegen-extra-tags:
                                     db: created_at
@@ -29714,8 +29744,13 @@ components:
                                           db: owner
                                           yaml: owner
                                         x-order: 5
-                                        type: string
                                         description: Environment owner
+                                        type: string
+                                        format: uuid
+                                        x-go-type: uuid.UUID
+                                        x-go-type-import:
+                                          path: github.com/gofrs/uuid
+                                        default: 00000000-00000000-00000000-00000000
                                       created_at:
                                         x-oapi-codegen-extra-tags:
                                           db: created_at
@@ -36661,8 +36696,13 @@ components:
                                         db: owner
                                         yaml: owner
                                       x-order: 5
-                                      type: string
                                       description: Environment owner
+                                      type: string
+                                      format: uuid
+                                      x-go-type: uuid.UUID
+                                      x-go-type-import:
+                                        path: github.com/gofrs/uuid
+                                      default: 00000000-00000000-00000000-00000000
                                     created_at:
                                       x-oapi-codegen-extra-tags:
                                         db: created_at
@@ -43304,8 +43344,13 @@ components:
                           db: owner
                           yaml: owner
                         x-order: 5
-                        type: string
                         description: Environment owner
+                        type: string
+                        format: uuid
+                        x-go-type: uuid.UUID
+                        x-go-type-import:
+                          path: github.com/gofrs/uuid
+                        default: 00000000-00000000-00000000-00000000
                       created_at:
                         x-oapi-codegen-extra-tags:
                           db: created_at
@@ -45165,8 +45210,13 @@ components:
                       db: owner
                       yaml: owner
                     x-order: 5
-                    type: string
                     description: Environment owner
+                    type: string
+                    format: uuid
+                    x-go-type: uuid.UUID
+                    x-go-type-import:
+                      path: github.com/gofrs/uuid
+                    default: 00000000-00000000-00000000-00000000
                   created_at:
                     x-oapi-codegen-extra-tags:
                       db: created_at
@@ -47318,8 +47368,13 @@ components:
             db: owner
             yaml: owner
           x-order: 5
-          type: string
           description: Environment owner
+          type: string
+          format: uuid
+          x-go-type: uuid.UUID
+          x-go-type-import:
+            path: github.com/gofrs/uuid
+          default: 00000000-00000000-00000000-00000000
         created_at:
           x-oapi-codegen-extra-tags:
             db: created_at
@@ -47507,8 +47562,13 @@ components:
                   db: owner
                   yaml: owner
                 x-order: 5
-                type: string
                 description: Environment owner
+                type: string
+                format: uuid
+                x-go-type: uuid.UUID
+                x-go-type-import:
+                  path: github.com/gofrs/uuid
+                default: 00000000-00000000-00000000-00000000
               created_at:
                 x-oapi-codegen-extra-tags:
                   db: created_at
@@ -48220,8 +48280,13 @@ components:
                                     db: owner
                                     yaml: owner
                                   x-order: 5
-                                  type: string
                                   description: Environment owner
+                                  type: string
+                                  format: uuid
+                                  x-go-type: uuid.UUID
+                                  x-go-type-import:
+                                    path: github.com/gofrs/uuid
+                                  default: 00000000-00000000-00000000-00000000
                                 created_at:
                                   x-oapi-codegen-extra-tags:
                                     db: created_at
@@ -54899,8 +54964,13 @@ components:
                                     db: owner
                                     yaml: owner
                                   x-order: 5
-                                  type: string
                                   description: Environment owner
+                                  type: string
+                                  format: uuid
+                                  x-go-type: uuid.UUID
+                                  x-go-type-import:
+                                    path: github.com/gofrs/uuid
+                                  default: 00000000-00000000-00000000-00000000
                                 created_at:
                                   x-oapi-codegen-extra-tags:
                                     db: created_at

--- a/schemas/meshery_openapi.yml
+++ b/schemas/meshery_openapi.yml
@@ -711,8 +711,13 @@ paths:
                       db: owner
                       yaml: owner
                     x-order: 5
-                    type: string
                     description: Environment owner
+                    type: string
+                    format: uuid
+                    x-go-type: uuid.UUID
+                    x-go-type-import:
+                      path: github.com/gofrs/uuid
+                    default: 00000000-00000000-00000000-00000000
                   created_at:
                     x-oapi-codegen-extra-tags:
                       db: created_at
@@ -876,8 +881,13 @@ paths:
                             db: owner
                             yaml: owner
                           x-order: 5
-                          type: string
                           description: Environment owner
+                          type: string
+                          format: uuid
+                          x-go-type: uuid.UUID
+                          x-go-type-import:
+                            path: github.com/gofrs/uuid
+                          default: 00000000-00000000-00000000-00000000
                         created_at:
                           x-oapi-codegen-extra-tags:
                             db: created_at
@@ -1530,8 +1540,13 @@ paths:
                                             db: owner
                                             yaml: owner
                                           x-order: 5
-                                          type: string
                                           description: Environment owner
+                                          type: string
+                                          format: uuid
+                                          x-go-type: uuid.UUID
+                                          x-go-type-import:
+                                            path: github.com/gofrs/uuid
+                                          default: 00000000-00000000-00000000-00000000
                                         created_at:
                                           x-oapi-codegen-extra-tags:
                                             db: created_at
@@ -8374,8 +8389,13 @@ paths:
                                               db: owner
                                               yaml: owner
                                             x-order: 5
-                                            type: string
                                             description: Environment owner
+                                            type: string
+                                            format: uuid
+                                            x-go-type: uuid.UUID
+                                            x-go-type-import:
+                                              path: github.com/gofrs/uuid
+                                            default: 00000000-00000000-00000000-00000000
                                           created_at:
                                             x-oapi-codegen-extra-tags:
                                               db: created_at
@@ -15231,8 +15251,13 @@ components:
                                 db: owner
                                 yaml: owner
                               x-order: 5
-                              type: string
                               description: Environment owner
+                              type: string
+                              format: uuid
+                              x-go-type: uuid.UUID
+                              x-go-type-import:
+                                path: github.com/gofrs/uuid
+                              default: 00000000-00000000-00000000-00000000
                             created_at:
                               x-oapi-codegen-extra-tags:
                                 db: created_at
@@ -21932,8 +21957,13 @@ components:
                                     db: owner
                                     yaml: owner
                                   x-order: 5
-                                  type: string
                                   description: Environment owner
+                                  type: string
+                                  format: uuid
+                                  x-go-type: uuid.UUID
+                                  x-go-type-import:
+                                    path: github.com/gofrs/uuid
+                                  default: 00000000-00000000-00000000-00000000
                                 created_at:
                                   x-oapi-codegen-extra-tags:
                                     db: created_at
@@ -28750,8 +28780,13 @@ components:
                                           db: owner
                                           yaml: owner
                                         x-order: 5
-                                        type: string
                                         description: Environment owner
+                                        type: string
+                                        format: uuid
+                                        x-go-type: uuid.UUID
+                                        x-go-type-import:
+                                          path: github.com/gofrs/uuid
+                                        default: 00000000-00000000-00000000-00000000
                                       created_at:
                                         x-oapi-codegen-extra-tags:
                                           db: created_at
@@ -35697,8 +35732,13 @@ components:
                                         db: owner
                                         yaml: owner
                                       x-order: 5
-                                      type: string
                                       description: Environment owner
+                                      type: string
+                                      format: uuid
+                                      x-go-type: uuid.UUID
+                                      x-go-type-import:
+                                        path: github.com/gofrs/uuid
+                                      default: 00000000-00000000-00000000-00000000
                                     created_at:
                                       x-oapi-codegen-extra-tags:
                                         db: created_at
@@ -42340,8 +42380,13 @@ components:
                           db: owner
                           yaml: owner
                         x-order: 5
-                        type: string
                         description: Environment owner
+                        type: string
+                        format: uuid
+                        x-go-type: uuid.UUID
+                        x-go-type-import:
+                          path: github.com/gofrs/uuid
+                        default: 00000000-00000000-00000000-00000000
                       created_at:
                         x-oapi-codegen-extra-tags:
                           db: created_at
@@ -44201,8 +44246,13 @@ components:
                       db: owner
                       yaml: owner
                     x-order: 5
-                    type: string
                     description: Environment owner
+                    type: string
+                    format: uuid
+                    x-go-type: uuid.UUID
+                    x-go-type-import:
+                      path: github.com/gofrs/uuid
+                    default: 00000000-00000000-00000000-00000000
                   created_at:
                     x-oapi-codegen-extra-tags:
                       db: created_at
@@ -46354,8 +46404,13 @@ components:
             db: owner
             yaml: owner
           x-order: 5
-          type: string
           description: Environment owner
+          type: string
+          format: uuid
+          x-go-type: uuid.UUID
+          x-go-type-import:
+            path: github.com/gofrs/uuid
+          default: 00000000-00000000-00000000-00000000
         created_at:
           x-oapi-codegen-extra-tags:
             db: created_at
@@ -46543,8 +46598,13 @@ components:
                   db: owner
                   yaml: owner
                 x-order: 5
-                type: string
                 description: Environment owner
+                type: string
+                format: uuid
+                x-go-type: uuid.UUID
+                x-go-type-import:
+                  path: github.com/gofrs/uuid
+                default: 00000000-00000000-00000000-00000000
               created_at:
                 x-oapi-codegen-extra-tags:
                   db: created_at
@@ -47256,8 +47316,13 @@ components:
                                     db: owner
                                     yaml: owner
                                   x-order: 5
-                                  type: string
                                   description: Environment owner
+                                  type: string
+                                  format: uuid
+                                  x-go-type: uuid.UUID
+                                  x-go-type-import:
+                                    path: github.com/gofrs/uuid
+                                  default: 00000000-00000000-00000000-00000000
                                 created_at:
                                   x-oapi-codegen-extra-tags:
                                     db: created_at
@@ -53935,8 +54000,13 @@ components:
                                     db: owner
                                     yaml: owner
                                   x-order: 5
-                                  type: string
                                   description: Environment owner
+                                  type: string
+                                  format: uuid
+                                  x-go-type: uuid.UUID
+                                  x-go-type-import:
+                                    path: github.com/gofrs/uuid
+                                  default: 00000000-00000000-00000000-00000000
                                 created_at:
                                   x-oapi-codegen-extra-tags:
                                     db: created_at


### PR DESCRIPTION
**Notes for Reviewers**

This PR updates environment.owner type to be *uuid, according to the type in remote provider. 



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
