### PR TITLE
feature: schema driven connections: connection and environments updates to follow remote provider structure

### DIFF
--- a/models/v1beta1/connection/connection.go
+++ b/models/v1beta1/connection/connection.go
@@ -52,7 +52,7 @@ type Connection struct {
 	CreatedAt    time.Time                  `db:"created_at" json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	UpdatedAt    time.Time                  `db:"updated_at" json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
 	DeletedAt    core.NullTime              `db:"deleted_at" json:"deleted_at,omitempty" yaml:"deleted_at,omitempty"`
-	Environments []*environment.Environment `db:"environments" gorm:"-" json:"environments,omitempty" yaml:"environments,omitempty"`
+	Environments []*environment.Environment `db:"-" gorm:"-" json:"environments,omitempty" yaml:"environments,omitempty"`
 }
 
 // ConnectionStatus Connection Status

--- a/models/v1beta1/environment/environment.go
+++ b/models/v1beta1/environment/environment.go
@@ -23,7 +23,7 @@ type Environment struct {
 	Description string `db:"description" json:"description" yaml:"description"`
 
 	// OrganizationID Environment organization ID
-	OrganizationID uuid.UUID `db:"org_id" json:"org_id" yaml:"org_id"`
+	OrganizationID uuid.UUID `db:"organization_id" json:"organization_id" yaml:"organization_id"`
 
 	// Owner Environment owner
 	Owner     *uuid.UUID    `db:"owner" json:"owner,omitempty" yaml:"owner,omitempty"`

--- a/schemas/cloud_openapi.yml
+++ b/schemas/cloud_openapi.yml
@@ -2519,7 +2519,7 @@ components:
                               format: date-time
                               x-go-type-skip-optional-pointer: true
                         x-oapi-codegen-extra-tags:
-                          db: environments
+                          db: '-'
                           yaml: environments
                           gorm: '-'
                         x-go-type-skip-optional-pointer: true
@@ -9225,7 +9225,7 @@ components:
                                   format: date-time
                                   x-go-type-skip-optional-pointer: true
                             x-oapi-codegen-extra-tags:
-                              db: environments
+                              db: '-'
                               yaml: environments
                               gorm: '-'
                             x-go-type-skip-optional-pointer: true
@@ -16048,7 +16048,7 @@ components:
                                         format: date-time
                                         x-go-type-skip-optional-pointer: true
                                   x-oapi-codegen-extra-tags:
-                                    db: environments
+                                    db: '-'
                                     yaml: environments
                                     gorm: '-'
                                   x-go-type-skip-optional-pointer: true
@@ -23000,7 +23000,7 @@ components:
                                       format: date-time
                                       x-go-type-skip-optional-pointer: true
                                 x-oapi-codegen-extra-tags:
-                                  db: environments
+                                  db: '-'
                                   yaml: environments
                                   gorm: '-'
                                 x-go-type-skip-optional-pointer: true
@@ -29648,7 +29648,7 @@ components:
                         format: date-time
                         x-go-type-skip-optional-pointer: true
                   x-oapi-codegen-extra-tags:
-                    db: environments
+                    db: '-'
                     yaml: environments
                     gorm: '-'
                   x-go-type-skip-optional-pointer: true
@@ -31514,7 +31514,7 @@ components:
                     format: date-time
                     x-go-type-skip-optional-pointer: true
               x-oapi-codegen-extra-tags:
-                db: environments
+                db: '-'
                 yaml: environments
                 gorm: '-'
               x-go-type-skip-optional-pointer: true
@@ -34584,7 +34584,7 @@ components:
                                   format: date-time
                                   x-go-type-skip-optional-pointer: true
                             x-oapi-codegen-extra-tags:
-                              db: environments
+                              db: '-'
                               yaml: environments
                               gorm: '-'
                             x-go-type-skip-optional-pointer: true
@@ -41268,7 +41268,7 @@ components:
                                   format: date-time
                                   x-go-type-skip-optional-pointer: true
                             x-oapi-codegen-extra-tags:
-                              db: environments
+                              db: '-'
                               yaml: environments
                               gorm: '-'
                             x-go-type-skip-optional-pointer: true

--- a/schemas/cloud_openapi.yml
+++ b/schemas/cloud_openapi.yml
@@ -1659,9 +1659,8 @@ paths:
                   organization_id:
                     x-go-name: OrganizationID
                     x-oapi-codegen-extra-tags:
-                      db: org_id
-                      json: org_id
-                      yaml: org_id
+                      db: organization_id
+                      yaml: organization_id
                     x-order: 4
                     description: Environment organization ID
                     type: string
@@ -1829,9 +1828,8 @@ paths:
                         organization_id:
                           x-go-name: OrganizationID
                           x-oapi-codegen-extra-tags:
-                            db: org_id
-                            json: org_id
-                            yaml: org_id
+                            db: organization_id
+                            yaml: organization_id
                           x-order: 4
                           description: Environment organization ID
                           type: string
@@ -2461,9 +2459,8 @@ components:
                             organization_id:
                               x-go-name: OrganizationID
                               x-oapi-codegen-extra-tags:
-                                db: org_id
-                                json: org_id
-                                yaml: org_id
+                                db: organization_id
+                                yaml: organization_id
                               x-order: 4
                               description: Environment organization ID
                               type: string
@@ -9167,9 +9164,8 @@ components:
                                 organization_id:
                                   x-go-name: OrganizationID
                                   x-oapi-codegen-extra-tags:
-                                    db: org_id
-                                    json: org_id
-                                    yaml: org_id
+                                    db: organization_id
+                                    yaml: organization_id
                                   x-order: 4
                                   description: Environment organization ID
                                   type: string
@@ -15990,9 +15986,8 @@ components:
                                       organization_id:
                                         x-go-name: OrganizationID
                                         x-oapi-codegen-extra-tags:
-                                          db: org_id
-                                          json: org_id
-                                          yaml: org_id
+                                          db: organization_id
+                                          yaml: organization_id
                                         x-order: 4
                                         description: Environment organization ID
                                         type: string
@@ -22942,9 +22937,8 @@ components:
                                     organization_id:
                                       x-go-name: OrganizationID
                                       x-oapi-codegen-extra-tags:
-                                        db: org_id
-                                        json: org_id
-                                        yaml: org_id
+                                        db: organization_id
+                                        yaml: organization_id
                                       x-order: 4
                                       description: Environment organization ID
                                       type: string
@@ -29590,9 +29584,8 @@ components:
                       organization_id:
                         x-go-name: OrganizationID
                         x-oapi-codegen-extra-tags:
-                          db: org_id
-                          json: org_id
-                          yaml: org_id
+                          db: organization_id
+                          yaml: organization_id
                         x-order: 4
                         description: Environment organization ID
                         type: string
@@ -31456,9 +31449,8 @@ components:
                   organization_id:
                     x-go-name: OrganizationID
                     x-oapi-codegen-extra-tags:
-                      db: org_id
-                      json: org_id
-                      yaml: org_id
+                      db: organization_id
+                      yaml: organization_id
                     x-order: 4
                     description: Environment organization ID
                     type: string
@@ -33614,9 +33606,8 @@ components:
         organization_id:
           x-go-name: OrganizationID
           x-oapi-codegen-extra-tags:
-            db: org_id
-            json: org_id
-            yaml: org_id
+            db: organization_id
+            yaml: organization_id
           x-order: 4
           description: Environment organization ID
           type: string
@@ -33808,9 +33799,8 @@ components:
               organization_id:
                 x-go-name: OrganizationID
                 x-oapi-codegen-extra-tags:
-                  db: org_id
-                  json: org_id
-                  yaml: org_id
+                  db: organization_id
+                  yaml: organization_id
                 x-order: 4
                 description: Environment organization ID
                 type: string
@@ -34526,9 +34516,8 @@ components:
                                 organization_id:
                                   x-go-name: OrganizationID
                                   x-oapi-codegen-extra-tags:
-                                    db: org_id
-                                    json: org_id
-                                    yaml: org_id
+                                    db: organization_id
+                                    yaml: organization_id
                                   x-order: 4
                                   description: Environment organization ID
                                   type: string
@@ -41210,9 +41199,8 @@ components:
                                 organization_id:
                                   x-go-name: OrganizationID
                                   x-oapi-codegen-extra-tags:
-                                    db: org_id
-                                    json: org_id
-                                    yaml: org_id
+                                    db: organization_id
+                                    yaml: organization_id
                                   x-order: 4
                                   description: Environment organization ID
                                   type: string

--- a/schemas/constructs/v1beta1/component/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/component/merged-openapi.yml
@@ -511,7 +511,7 @@
                       }
                     },
                     "x-oapi-codegen-extra-tags": {
-                      "db": "environments",
+                      "db": "-",
                       "yaml": "environments",
                       "gorm": "-"
                     },

--- a/schemas/constructs/v1beta1/component/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/component/merged-openapi.yml
@@ -437,9 +437,8 @@
                         "organization_id": {
                           "x-go-name": "OrganizationID",
                           "x-oapi-codegen-extra-tags": {
-                            "db": "org_id",
-                            "json": "org_id",
-                            "yaml": "org_id"
+                            "db": "organization_id",
+                            "yaml": "organization_id"
                           },
                           "x-order": 4,
                           "description": "Environment organization ID",

--- a/schemas/constructs/v1beta1/connection/connection.json
+++ b/schemas/constructs/v1beta1/connection/connection.json
@@ -139,7 +139,7 @@
         "$ref": "../environment/environment.json"
       },
       "x-oapi-codegen-extra-tags": {
-        "db": "environments",
+        "db": "-",
         "yaml": "environments",
         "gorm": "-"
       },

--- a/schemas/constructs/v1beta1/connection/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/connection/merged-openapi.yml
@@ -293,7 +293,7 @@
               }
             },
             "x-oapi-codegen-extra-tags": {
-              "db": "environments",
+              "db": "-",
               "yaml": "environments",
               "gorm": "-"
             },
@@ -603,7 +603,7 @@
                     }
                   },
                   "x-oapi-codegen-extra-tags": {
-                    "db": "environments",
+                    "db": "-",
                     "yaml": "environments",
                     "gorm": "-"
                   },

--- a/schemas/constructs/v1beta1/connection/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/connection/merged-openapi.yml
@@ -219,9 +219,8 @@
                 "organization_id": {
                   "x-go-name": "OrganizationID",
                   "x-oapi-codegen-extra-tags": {
-                    "db": "org_id",
-                    "json": "org_id",
-                    "yaml": "org_id"
+                    "db": "organization_id",
+                    "yaml": "organization_id"
                   },
                   "x-order": 4,
                   "description": "Environment organization ID",
@@ -529,9 +528,8 @@
                       "organization_id": {
                         "x-go-name": "OrganizationID",
                         "x-oapi-codegen-extra-tags": {
-                          "db": "org_id",
-                          "json": "org_id",
-                          "yaml": "org_id"
+                          "db": "organization_id",
+                          "yaml": "organization_id"
                         },
                         "x-order": 4,
                         "description": "Environment organization ID",

--- a/schemas/constructs/v1beta1/environment/environment.json
+++ b/schemas/constructs/v1beta1/environment/environment.json
@@ -42,9 +42,8 @@
     "organization_id": {
       "x-go-name": "OrganizationID",
       "x-oapi-codegen-extra-tags": {
-        "db": "org_id",
-        "json": "org_id",
-        "yaml": "org_id"
+        "db": "organization_id",
+        "yaml": "organization_id"
       },
       "x-order": 4,
       "$ref": "../../core.json#/definitions/uuid",

--- a/schemas/constructs/v1beta1/environment/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/environment/merged-openapi.yml
@@ -192,9 +192,8 @@
           "organization_id": {
             "x-go-name": "OrganizationID",
             "x-oapi-codegen-extra-tags": {
-              "db": "org_id",
-              "json": "org_id",
-              "yaml": "org_id"
+              "db": "organization_id",
+              "yaml": "organization_id"
             },
             "x-order": 4,
             "description": "Environment organization ID",
@@ -420,9 +419,8 @@
                 "organization_id": {
                   "x-go-name": "OrganizationID",
                   "x-oapi-codegen-extra-tags": {
-                    "db": "org_id",
-                    "json": "org_id",
-                    "yaml": "org_id"
+                    "db": "organization_id",
+                    "yaml": "organization_id"
                   },
                   "x-order": 4,
                   "description": "Environment organization ID",
@@ -634,9 +632,8 @@
                     "organization_id": {
                       "x-go-name": "OrganizationID",
                       "x-oapi-codegen-extra-tags": {
-                        "db": "org_id",
-                        "json": "org_id",
-                        "yaml": "org_id"
+                        "db": "organization_id",
+                        "yaml": "organization_id"
                       },
                       "x-order": 4,
                       "description": "Environment organization ID",
@@ -855,9 +852,8 @@
                           "organization_id": {
                             "x-go-name": "OrganizationID",
                             "x-oapi-codegen-extra-tags": {
-                              "db": "org_id",
-                              "json": "org_id",
-                              "yaml": "org_id"
+                              "db": "organization_id",
+                              "yaml": "organization_id"
                             },
                             "x-order": 4,
                             "description": "Environment organization ID",

--- a/schemas/constructs/v1beta1/evaluation/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/evaluation/merged-openapi.yml
@@ -674,7 +674,7 @@
                                         }
                                       },
                                       "x-oapi-codegen-extra-tags": {
-                                        "db": "environments",
+                                        "db": "-",
                                         "yaml": "environments",
                                         "gorm": "-"
                                       },
@@ -7221,7 +7221,7 @@
                                           }
                                         },
                                         "x-oapi-codegen-extra-tags": {
-                                          "db": "environments",
+                                          "db": "-",
                                           "yaml": "environments",
                                           "gorm": "-"
                                         },
@@ -13792,7 +13792,7 @@
                                 }
                               },
                               "x-oapi-codegen-extra-tags": {
-                                "db": "environments",
+                                "db": "-",
                                 "yaml": "environments",
                                 "gorm": "-"
                               },
@@ -20331,7 +20331,7 @@
                                 }
                               },
                               "x-oapi-codegen-extra-tags": {
-                                "db": "environments",
+                                "db": "-",
                                 "yaml": "environments",
                                 "gorm": "-"
                               },

--- a/schemas/constructs/v1beta1/evaluation/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/evaluation/merged-openapi.yml
@@ -600,9 +600,8 @@
                                           "organization_id": {
                                             "x-go-name": "OrganizationID",
                                             "x-oapi-codegen-extra-tags": {
-                                              "db": "org_id",
-                                              "json": "org_id",
-                                              "yaml": "org_id"
+                                              "db": "organization_id",
+                                              "yaml": "organization_id"
                                             },
                                             "x-order": 4,
                                             "description": "Environment organization ID",
@@ -7147,9 +7146,8 @@
                                             "organization_id": {
                                               "x-go-name": "OrganizationID",
                                               "x-oapi-codegen-extra-tags": {
-                                                "db": "org_id",
-                                                "json": "org_id",
-                                                "yaml": "org_id"
+                                                "db": "organization_id",
+                                                "yaml": "organization_id"
                                               },
                                               "x-order": 4,
                                               "description": "Environment organization ID",
@@ -13718,9 +13716,8 @@
                                   "organization_id": {
                                     "x-go-name": "OrganizationID",
                                     "x-oapi-codegen-extra-tags": {
-                                      "db": "org_id",
-                                      "json": "org_id",
-                                      "yaml": "org_id"
+                                      "db": "organization_id",
+                                      "yaml": "organization_id"
                                     },
                                     "x-order": 4,
                                     "description": "Environment organization ID",
@@ -20257,9 +20254,8 @@
                                   "organization_id": {
                                     "x-go-name": "OrganizationID",
                                     "x-oapi-codegen-extra-tags": {
-                                      "db": "org_id",
-                                      "json": "org_id",
-                                      "yaml": "org_id"
+                                      "db": "organization_id",
+                                      "yaml": "organization_id"
                                     },
                                     "x-order": 4,
                                     "description": "Environment organization ID",

--- a/schemas/constructs/v1beta1/model/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/model/merged-openapi.yml
@@ -612,7 +612,7 @@
                   }
                 },
                 "x-oapi-codegen-extra-tags": {
-                  "db": "environments",
+                  "db": "-",
                   "yaml": "environments",
                   "gorm": "-"
                 },

--- a/schemas/constructs/v1beta1/model/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/model/merged-openapi.yml
@@ -538,9 +538,8 @@
                     "organization_id": {
                       "x-go-name": "OrganizationID",
                       "x-oapi-codegen-extra-tags": {
-                        "db": "org_id",
-                        "json": "org_id",
-                        "yaml": "org_id"
+                        "db": "organization_id",
+                        "yaml": "organization_id"
                       },
                       "x-order": 4,
                       "description": "Environment organization ID",

--- a/schemas/constructs/v1beta1/pattern/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/pattern/merged-openapi.yml
@@ -738,7 +738,7 @@
                             }
                           },
                           "x-oapi-codegen-extra-tags": {
-                            "db": "environments",
+                            "db": "-",
                             "yaml": "environments",
                             "gorm": "-"
                           },
@@ -7360,7 +7360,7 @@
                                 }
                               },
                               "x-oapi-codegen-extra-tags": {
-                                "db": "environments",
+                                "db": "-",
                                 "yaml": "environments",
                                 "gorm": "-"
                               },
@@ -14014,7 +14014,7 @@
                                       }
                                     },
                                     "x-oapi-codegen-extra-tags": {
-                                      "db": "environments",
+                                      "db": "-",
                                       "yaml": "environments",
                                       "gorm": "-"
                                     },
@@ -20700,7 +20700,7 @@
                                     }
                                   },
                                   "x-oapi-codegen-extra-tags": {
-                                    "db": "environments",
+                                    "db": "-",
                                     "yaml": "environments",
                                     "gorm": "-"
                                   },

--- a/schemas/constructs/v1beta1/pattern/merged-openapi.yml
+++ b/schemas/constructs/v1beta1/pattern/merged-openapi.yml
@@ -664,9 +664,8 @@
                               "organization_id": {
                                 "x-go-name": "OrganizationID",
                                 "x-oapi-codegen-extra-tags": {
-                                  "db": "org_id",
-                                  "json": "org_id",
-                                  "yaml": "org_id"
+                                  "db": "organization_id",
+                                  "yaml": "organization_id"
                                 },
                                 "x-order": 4,
                                 "description": "Environment organization ID",
@@ -7286,9 +7285,8 @@
                                   "organization_id": {
                                     "x-go-name": "OrganizationID",
                                     "x-oapi-codegen-extra-tags": {
-                                      "db": "org_id",
-                                      "json": "org_id",
-                                      "yaml": "org_id"
+                                      "db": "organization_id",
+                                      "yaml": "organization_id"
                                     },
                                     "x-order": 4,
                                     "description": "Environment organization ID",
@@ -13940,9 +13938,8 @@
                                         "organization_id": {
                                           "x-go-name": "OrganizationID",
                                           "x-oapi-codegen-extra-tags": {
-                                            "db": "org_id",
-                                            "json": "org_id",
-                                            "yaml": "org_id"
+                                            "db": "organization_id",
+                                            "yaml": "organization_id"
                                           },
                                           "x-order": 4,
                                           "description": "Environment organization ID",
@@ -20626,9 +20623,8 @@
                                       "organization_id": {
                                         "x-go-name": "OrganizationID",
                                         "x-oapi-codegen-extra-tags": {
-                                          "db": "org_id",
-                                          "json": "org_id",
-                                          "yaml": "org_id"
+                                          "db": "organization_id",
+                                          "yaml": "organization_id"
                                         },
                                         "x-order": 4,
                                         "description": "Environment organization ID",

--- a/schemas/merged_openapi.yml
+++ b/schemas/merged_openapi.yml
@@ -2546,7 +2546,7 @@ paths:
                                           format: date-time
                                           x-go-type-skip-optional-pointer: true
                                     x-oapi-codegen-extra-tags:
-                                      db: environments
+                                      db: '-'
                                       yaml: environments
                                       gorm: '-'
                                     x-go-type-skip-optional-pointer: true
@@ -9395,7 +9395,7 @@ paths:
                                             format: date-time
                                             x-go-type-skip-optional-pointer: true
                                       x-oapi-codegen-extra-tags:
-                                        db: environments
+                                        db: '-'
                                         yaml: environments
                                         gorm: '-'
                                       x-go-type-skip-optional-pointer: true
@@ -16257,7 +16257,7 @@ components:
                               format: date-time
                               x-go-type-skip-optional-pointer: true
                         x-oapi-codegen-extra-tags:
-                          db: environments
+                          db: '-'
                           yaml: environments
                           gorm: '-'
                         x-go-type-skip-optional-pointer: true
@@ -22963,7 +22963,7 @@ components:
                                   format: date-time
                                   x-go-type-skip-optional-pointer: true
                             x-oapi-codegen-extra-tags:
-                              db: environments
+                              db: '-'
                               yaml: environments
                               gorm: '-'
                             x-go-type-skip-optional-pointer: true
@@ -29786,7 +29786,7 @@ components:
                                         format: date-time
                                         x-go-type-skip-optional-pointer: true
                                   x-oapi-codegen-extra-tags:
-                                    db: environments
+                                    db: '-'
                                     yaml: environments
                                     gorm: '-'
                                   x-go-type-skip-optional-pointer: true
@@ -36738,7 +36738,7 @@ components:
                                       format: date-time
                                       x-go-type-skip-optional-pointer: true
                                 x-oapi-codegen-extra-tags:
-                                  db: environments
+                                  db: '-'
                                   yaml: environments
                                   gorm: '-'
                                 x-go-type-skip-optional-pointer: true
@@ -43386,7 +43386,7 @@ components:
                         format: date-time
                         x-go-type-skip-optional-pointer: true
                   x-oapi-codegen-extra-tags:
-                    db: environments
+                    db: '-'
                     yaml: environments
                     gorm: '-'
                   x-go-type-skip-optional-pointer: true
@@ -45252,7 +45252,7 @@ components:
                     format: date-time
                     x-go-type-skip-optional-pointer: true
               x-oapi-codegen-extra-tags:
-                db: environments
+                db: '-'
                 yaml: environments
                 gorm: '-'
               x-go-type-skip-optional-pointer: true
@@ -48322,7 +48322,7 @@ components:
                                   format: date-time
                                   x-go-type-skip-optional-pointer: true
                             x-oapi-codegen-extra-tags:
-                              db: environments
+                              db: '-'
                               yaml: environments
                               gorm: '-'
                             x-go-type-skip-optional-pointer: true
@@ -55006,7 +55006,7 @@ components:
                                   format: date-time
                                   x-go-type-skip-optional-pointer: true
                             x-oapi-codegen-extra-tags:
-                              db: environments
+                              db: '-'
                               yaml: environments
                               gorm: '-'
                             x-go-type-skip-optional-pointer: true

--- a/schemas/merged_openapi.yml
+++ b/schemas/merged_openapi.yml
@@ -1659,9 +1659,8 @@ paths:
                   organization_id:
                     x-go-name: OrganizationID
                     x-oapi-codegen-extra-tags:
-                      db: org_id
-                      json: org_id
-                      yaml: org_id
+                      db: organization_id
+                      yaml: organization_id
                     x-order: 4
                     description: Environment organization ID
                     type: string
@@ -1829,9 +1828,8 @@ paths:
                         organization_id:
                           x-go-name: OrganizationID
                           x-oapi-codegen-extra-tags:
-                            db: org_id
-                            json: org_id
-                            yaml: org_id
+                            db: organization_id
+                            yaml: organization_id
                           x-order: 4
                           description: Environment organization ID
                           type: string
@@ -2488,9 +2486,8 @@ paths:
                                         organization_id:
                                           x-go-name: OrganizationID
                                           x-oapi-codegen-extra-tags:
-                                            db: org_id
-                                            json: org_id
-                                            yaml: org_id
+                                            db: organization_id
+                                            yaml: organization_id
                                           x-order: 4
                                           description: Environment organization ID
                                           type: string
@@ -9337,9 +9334,8 @@ paths:
                                           organization_id:
                                             x-go-name: OrganizationID
                                             x-oapi-codegen-extra-tags:
-                                              db: org_id
-                                              json: org_id
-                                              yaml: org_id
+                                              db: organization_id
+                                              yaml: organization_id
                                             x-order: 4
                                             description: Environment organization ID
                                             type: string
@@ -16199,9 +16195,8 @@ components:
                             organization_id:
                               x-go-name: OrganizationID
                               x-oapi-codegen-extra-tags:
-                                db: org_id
-                                json: org_id
-                                yaml: org_id
+                                db: organization_id
+                                yaml: organization_id
                               x-order: 4
                               description: Environment organization ID
                               type: string
@@ -22905,9 +22900,8 @@ components:
                                 organization_id:
                                   x-go-name: OrganizationID
                                   x-oapi-codegen-extra-tags:
-                                    db: org_id
-                                    json: org_id
-                                    yaml: org_id
+                                    db: organization_id
+                                    yaml: organization_id
                                   x-order: 4
                                   description: Environment organization ID
                                   type: string
@@ -29728,9 +29722,8 @@ components:
                                       organization_id:
                                         x-go-name: OrganizationID
                                         x-oapi-codegen-extra-tags:
-                                          db: org_id
-                                          json: org_id
-                                          yaml: org_id
+                                          db: organization_id
+                                          yaml: organization_id
                                         x-order: 4
                                         description: Environment organization ID
                                         type: string
@@ -36680,9 +36673,8 @@ components:
                                     organization_id:
                                       x-go-name: OrganizationID
                                       x-oapi-codegen-extra-tags:
-                                        db: org_id
-                                        json: org_id
-                                        yaml: org_id
+                                        db: organization_id
+                                        yaml: organization_id
                                       x-order: 4
                                       description: Environment organization ID
                                       type: string
@@ -43328,9 +43320,8 @@ components:
                       organization_id:
                         x-go-name: OrganizationID
                         x-oapi-codegen-extra-tags:
-                          db: org_id
-                          json: org_id
-                          yaml: org_id
+                          db: organization_id
+                          yaml: organization_id
                         x-order: 4
                         description: Environment organization ID
                         type: string
@@ -45194,9 +45185,8 @@ components:
                   organization_id:
                     x-go-name: OrganizationID
                     x-oapi-codegen-extra-tags:
-                      db: org_id
-                      json: org_id
-                      yaml: org_id
+                      db: organization_id
+                      yaml: organization_id
                     x-order: 4
                     description: Environment organization ID
                     type: string
@@ -47352,9 +47342,8 @@ components:
         organization_id:
           x-go-name: OrganizationID
           x-oapi-codegen-extra-tags:
-            db: org_id
-            json: org_id
-            yaml: org_id
+            db: organization_id
+            yaml: organization_id
           x-order: 4
           description: Environment organization ID
           type: string
@@ -47546,9 +47535,8 @@ components:
               organization_id:
                 x-go-name: OrganizationID
                 x-oapi-codegen-extra-tags:
-                  db: org_id
-                  json: org_id
-                  yaml: org_id
+                  db: organization_id
+                  yaml: organization_id
                 x-order: 4
                 description: Environment organization ID
                 type: string
@@ -48264,9 +48252,8 @@ components:
                                 organization_id:
                                   x-go-name: OrganizationID
                                   x-oapi-codegen-extra-tags:
-                                    db: org_id
-                                    json: org_id
-                                    yaml: org_id
+                                    db: organization_id
+                                    yaml: organization_id
                                   x-order: 4
                                   description: Environment organization ID
                                   type: string
@@ -54948,9 +54935,8 @@ components:
                                 organization_id:
                                   x-go-name: OrganizationID
                                   x-oapi-codegen-extra-tags:
-                                    db: org_id
-                                    json: org_id
-                                    yaml: org_id
+                                    db: organization_id
+                                    yaml: organization_id
                                   x-order: 4
                                   description: Environment organization ID
                                   type: string

--- a/schemas/meshery_openapi.yml
+++ b/schemas/meshery_openapi.yml
@@ -1582,7 +1582,7 @@ paths:
                                           format: date-time
                                           x-go-type-skip-optional-pointer: true
                                     x-oapi-codegen-extra-tags:
-                                      db: environments
+                                      db: '-'
                                       yaml: environments
                                       gorm: '-'
                                     x-go-type-skip-optional-pointer: true
@@ -8431,7 +8431,7 @@ paths:
                                             format: date-time
                                             x-go-type-skip-optional-pointer: true
                                       x-oapi-codegen-extra-tags:
-                                        db: environments
+                                        db: '-'
                                         yaml: environments
                                         gorm: '-'
                                       x-go-type-skip-optional-pointer: true
@@ -15293,7 +15293,7 @@ components:
                               format: date-time
                               x-go-type-skip-optional-pointer: true
                         x-oapi-codegen-extra-tags:
-                          db: environments
+                          db: '-'
                           yaml: environments
                           gorm: '-'
                         x-go-type-skip-optional-pointer: true
@@ -21999,7 +21999,7 @@ components:
                                   format: date-time
                                   x-go-type-skip-optional-pointer: true
                             x-oapi-codegen-extra-tags:
-                              db: environments
+                              db: '-'
                               yaml: environments
                               gorm: '-'
                             x-go-type-skip-optional-pointer: true
@@ -28822,7 +28822,7 @@ components:
                                         format: date-time
                                         x-go-type-skip-optional-pointer: true
                                   x-oapi-codegen-extra-tags:
-                                    db: environments
+                                    db: '-'
                                     yaml: environments
                                     gorm: '-'
                                   x-go-type-skip-optional-pointer: true
@@ -35774,7 +35774,7 @@ components:
                                       format: date-time
                                       x-go-type-skip-optional-pointer: true
                                 x-oapi-codegen-extra-tags:
-                                  db: environments
+                                  db: '-'
                                   yaml: environments
                                   gorm: '-'
                                 x-go-type-skip-optional-pointer: true
@@ -42422,7 +42422,7 @@ components:
                         format: date-time
                         x-go-type-skip-optional-pointer: true
                   x-oapi-codegen-extra-tags:
-                    db: environments
+                    db: '-'
                     yaml: environments
                     gorm: '-'
                   x-go-type-skip-optional-pointer: true
@@ -44288,7 +44288,7 @@ components:
                     format: date-time
                     x-go-type-skip-optional-pointer: true
               x-oapi-codegen-extra-tags:
-                db: environments
+                db: '-'
                 yaml: environments
                 gorm: '-'
               x-go-type-skip-optional-pointer: true
@@ -47358,7 +47358,7 @@ components:
                                   format: date-time
                                   x-go-type-skip-optional-pointer: true
                             x-oapi-codegen-extra-tags:
-                              db: environments
+                              db: '-'
                               yaml: environments
                               gorm: '-'
                             x-go-type-skip-optional-pointer: true
@@ -54042,7 +54042,7 @@ components:
                                   format: date-time
                                   x-go-type-skip-optional-pointer: true
                             x-oapi-codegen-extra-tags:
-                              db: environments
+                              db: '-'
                               yaml: environments
                               gorm: '-'
                             x-go-type-skip-optional-pointer: true

--- a/schemas/meshery_openapi.yml
+++ b/schemas/meshery_openapi.yml
@@ -695,9 +695,8 @@ paths:
                   organization_id:
                     x-go-name: OrganizationID
                     x-oapi-codegen-extra-tags:
-                      db: org_id
-                      json: org_id
-                      yaml: org_id
+                      db: organization_id
+                      yaml: organization_id
                     x-order: 4
                     description: Environment organization ID
                     type: string
@@ -865,9 +864,8 @@ paths:
                         organization_id:
                           x-go-name: OrganizationID
                           x-oapi-codegen-extra-tags:
-                            db: org_id
-                            json: org_id
-                            yaml: org_id
+                            db: organization_id
+                            yaml: organization_id
                           x-order: 4
                           description: Environment organization ID
                           type: string
@@ -1524,9 +1522,8 @@ paths:
                                         organization_id:
                                           x-go-name: OrganizationID
                                           x-oapi-codegen-extra-tags:
-                                            db: org_id
-                                            json: org_id
-                                            yaml: org_id
+                                            db: organization_id
+                                            yaml: organization_id
                                           x-order: 4
                                           description: Environment organization ID
                                           type: string
@@ -8373,9 +8370,8 @@ paths:
                                           organization_id:
                                             x-go-name: OrganizationID
                                             x-oapi-codegen-extra-tags:
-                                              db: org_id
-                                              json: org_id
-                                              yaml: org_id
+                                              db: organization_id
+                                              yaml: organization_id
                                             x-order: 4
                                             description: Environment organization ID
                                             type: string
@@ -15235,9 +15231,8 @@ components:
                             organization_id:
                               x-go-name: OrganizationID
                               x-oapi-codegen-extra-tags:
-                                db: org_id
-                                json: org_id
-                                yaml: org_id
+                                db: organization_id
+                                yaml: organization_id
                               x-order: 4
                               description: Environment organization ID
                               type: string
@@ -21941,9 +21936,8 @@ components:
                                 organization_id:
                                   x-go-name: OrganizationID
                                   x-oapi-codegen-extra-tags:
-                                    db: org_id
-                                    json: org_id
-                                    yaml: org_id
+                                    db: organization_id
+                                    yaml: organization_id
                                   x-order: 4
                                   description: Environment organization ID
                                   type: string
@@ -28764,9 +28758,8 @@ components:
                                       organization_id:
                                         x-go-name: OrganizationID
                                         x-oapi-codegen-extra-tags:
-                                          db: org_id
-                                          json: org_id
-                                          yaml: org_id
+                                          db: organization_id
+                                          yaml: organization_id
                                         x-order: 4
                                         description: Environment organization ID
                                         type: string
@@ -35716,9 +35709,8 @@ components:
                                     organization_id:
                                       x-go-name: OrganizationID
                                       x-oapi-codegen-extra-tags:
-                                        db: org_id
-                                        json: org_id
-                                        yaml: org_id
+                                        db: organization_id
+                                        yaml: organization_id
                                       x-order: 4
                                       description: Environment organization ID
                                       type: string
@@ -42364,9 +42356,8 @@ components:
                       organization_id:
                         x-go-name: OrganizationID
                         x-oapi-codegen-extra-tags:
-                          db: org_id
-                          json: org_id
-                          yaml: org_id
+                          db: organization_id
+                          yaml: organization_id
                         x-order: 4
                         description: Environment organization ID
                         type: string
@@ -44230,9 +44221,8 @@ components:
                   organization_id:
                     x-go-name: OrganizationID
                     x-oapi-codegen-extra-tags:
-                      db: org_id
-                      json: org_id
-                      yaml: org_id
+                      db: organization_id
+                      yaml: organization_id
                     x-order: 4
                     description: Environment organization ID
                     type: string
@@ -46388,9 +46378,8 @@ components:
         organization_id:
           x-go-name: OrganizationID
           x-oapi-codegen-extra-tags:
-            db: org_id
-            json: org_id
-            yaml: org_id
+            db: organization_id
+            yaml: organization_id
           x-order: 4
           description: Environment organization ID
           type: string
@@ -46582,9 +46571,8 @@ components:
               organization_id:
                 x-go-name: OrganizationID
                 x-oapi-codegen-extra-tags:
-                  db: org_id
-                  json: org_id
-                  yaml: org_id
+                  db: organization_id
+                  yaml: organization_id
                 x-order: 4
                 description: Environment organization ID
                 type: string
@@ -47300,9 +47288,8 @@ components:
                                 organization_id:
                                   x-go-name: OrganizationID
                                   x-oapi-codegen-extra-tags:
-                                    db: org_id
-                                    json: org_id
-                                    yaml: org_id
+                                    db: organization_id
+                                    yaml: organization_id
                                   x-order: 4
                                   description: Environment organization ID
                                   type: string
@@ -53984,9 +53971,8 @@ components:
                                 organization_id:
                                   x-go-name: OrganizationID
                                   x-oapi-codegen-extra-tags:
-                                    db: org_id
-                                    json: org_id
-                                    yaml: org_id
+                                    db: organization_id
+                                    yaml: organization_id
                                   x-order: 4
                                   description: Environment organization ID
                                   type: string


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes the issue in remote provider,:
- mark Environments in connection  with db tag "-" as there is not supposed column in connections tables;
- update organisation ID tags to be organisation_id to follow remote provider structure; 


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
