### PR TITLE
add schema version to connections

### DIFF
--- a/schemas/constructs/v1beta1/connection/connection.json
+++ b/schemas/constructs/v1beta1/connection/connection.json
@@ -6,6 +6,7 @@
   "type": "object",
   "required": [
     "id",
+    "schemaVersion",
     "name",
     "type",
     "sub_type",
@@ -145,6 +146,17 @@
       },
       "x-go-type-skip-optional-pointer": true,
       "x-order": 13
+    },
+    "schemaVersion": {
+      "description": "Specifies the version of the schema used for the definition.",
+      "$ref": "../../core.json#/definitions/versionString",
+      "x-order": 14,
+      "x-oapi-codegen-extra-tags": {
+        "yaml": "schemaVersion",
+        "db": "-",
+        "gorm": "-"
+      },
+      "default": "components.meshery.io/v1beta1"
     }
   }
 }


### PR DESCRIPTION
**Notes for Reviewers**

This PR adds schema version property to connection

default value is intentionally here "components.meshery.io/v1beta1" because  of this code which expects only certain range of prefixes:
https://github.com/meshery/meshkit/blob/9ad0b7052cc5651e29ab413b38f85efb0edf1b17/utils/utils.go#L464  

(I will prepare auto generated code in a separate pr).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
