### PR TITLE
chore: meshsync deployment mode: if empty string - not fall to default value, undefined instead

### DIFF
--- a/models/v1beta1/connection/connection_helper.go
+++ b/models/v1beta1/connection/connection_helper.go
@@ -71,8 +71,6 @@ const (
 
 func MeshsyncDeploymentModeFromString(value string) MeshsyncDeploymentMode {
 	switch value {
-	case "":
-		return MeshsyncDeploymentModeDefault
 	case string(MeshsyncDeploymentModeOperator):
 		return MeshsyncDeploymentModeOperator
 	case string(MeshsyncDeploymentModeEmbedded):

--- a/models/v1beta1/connection/meshsync_deployment_mode_test.go
+++ b/models/v1beta1/connection/meshsync_deployment_mode_test.go
@@ -11,7 +11,7 @@ func TestMeshsyncDeploymentModeFromString(t *testing.T) {
 		input    string
 		expected MeshsyncDeploymentMode
 	}{
-		{"", MeshsyncDeploymentModeDefault},
+		{"", MeshsyncDeploymentModeUndefined},
 		{string(MeshsyncDeploymentModeOperator), MeshsyncDeploymentModeOperator},
 		{string(MeshsyncDeploymentModeEmbedded), MeshsyncDeploymentModeEmbedded},
 		{"unknown", MeshsyncDeploymentModeUndefined},
@@ -43,9 +43,9 @@ func TestMeshsyncDeploymentModeFromMetadata(t *testing.T) {
 			expected: MeshsyncDeploymentModeUndefined,
 		},
 		{
-			name:     "empty string (default)",
+			name:     "empty stringW",
 			metadata: map[string]any{MeshsyncDeploymentModeMetadataKey: ""},
-			expected: MeshsyncDeploymentModeDefault,
+			expected: MeshsyncDeploymentModeUndefined,
 		},
 		{
 			name:     "operator mode string",


### PR DESCRIPTION
**Notes for Reviewers**

Because it makes things more complicated to handle in meshery side. F.e. when submit kubeconfig, and value if not provided, if we use this method, it returns default on empty string. But this default is not the correct default. 

It is more simpler to return undefined and handle default value on client side :white_check_mark: 


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
