### PR TITLE
chore: switch meshsync default deployment mode to embedded

### DIFF
--- a/models/v1beta1/connection/connection_helper.go
+++ b/models/v1beta1/connection/connection_helper.go
@@ -66,7 +66,7 @@ const (
 	MeshsyncDeploymentModeOperator  MeshsyncDeploymentMode = "operator"
 	MeshsyncDeploymentModeEmbedded  MeshsyncDeploymentMode = "embedded"
 	MeshsyncDeploymentModeUndefined MeshsyncDeploymentMode = "undefined"
-	MeshsyncDeploymentModeDefault                          = MeshsyncDeploymentModeOperator
+	MeshsyncDeploymentModeDefault                          = MeshsyncDeploymentModeEmbedded
 )
 
 func MeshsyncDeploymentModeFromString(value string) MeshsyncDeploymentMode {


### PR DESCRIPTION
**Notes for Reviewers**

This PR switches meshsync deployment mode from operator to embedded :white_check_mark: .



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
