### PR TITLE
Remove no-duplicate-categories setting

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -21,7 +21,6 @@ categories:
     label: 'area/docs'
   - title: '🔒 Security'
     label: 'security'
-no-duplicate-categories: true
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 template: |
   ## What's New
@@ -40,4 +39,3 @@ autolabeler:
     branch:
       - '/.github/'
       - '/build/'
-no-duplicate-categories: true


### PR DESCRIPTION
This PR reverts #483 #484 
Removed duplicate categories setting from release drafter configuration.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
