### PR TITLE
regex changed for local scope

### DIFF
--- a/schemas/constructs/core.json
+++ b/schemas/constructs/core.json
@@ -36,8 +36,8 @@
     },
     "relationshipVersionString": {
       "type": "string",
-      "pattern": "^(>=|>)?v([0-9]+)(\\.[0-9]+)*(?:[.-][a-zA-Z0-9]+)*$",
-      "description": "Version string for Relationships selector. Supports 'v1.2.3', '>v1.2.3', '>=v1.2.3', and optional suffixes."
+      "pattern": "^(>=|<=|>|<)?v\\d+(\\.\\d+)*(?:[.-][a-zA-Z0-9]+)*$",
+      "description": "Version string for Relationships selector. Supports 'v1.2.3', '>v1.2.3', '>=v1.2.3', '<v1.2.3', '<=v1.2.3', and optional suffixes."
     },
     "time": {
       "type": "string",

--- a/schemas/constructs/core.json
+++ b/schemas/constructs/core.json
@@ -36,7 +36,7 @@
     },
     "relationshipVersionString": {
       "type": "string",
-      "pattern": "^(>=|>)?v([0-9]+)(\\.[0-9]+)*(?:[.-][a-z0-9]+)*$",
+      "pattern": "^(>=|>)?v([0-9]+)(\\.[0-9]+)*(?:[.-][a-zA-Z0-9]+)*$",
       "description": "Version string for Relationships selector. Supports 'v1.2.3', '>v1.2.3', '>=v1.2.3', and optional suffixes."
     },
     "time": {

--- a/schemas/constructs/core.json
+++ b/schemas/constructs/core.json
@@ -34,7 +34,7 @@
       },
       "default": "00000000-0000-0000-0000-000000000000"
     },
-    "relationshipVersionString": {
+    "versionConstraintString": {
       "type": "string",
       "pattern": "^(>=|<=|>|<)?v\\d+(\\.\\d+)*(?:[.-][a-zA-Z0-9]+)*$",
       "description": "Version string for Relationships selector. Supports 'v1.2.3', '>v1.2.3', '>=v1.2.3', '<v1.2.3', '<=v1.2.3', and optional suffixes."

--- a/schemas/constructs/core.json
+++ b/schemas/constructs/core.json
@@ -34,6 +34,11 @@
       },
       "default": "00000000-0000-0000-0000-000000000000"
     },
+    "relationshipVersionString": {
+      "type": "string",
+      "pattern": "^(>=|>)?v([0-9]+)(\\.[0-9]+)*(?:[.-][a-z0-9]+)*$",
+      "description": "Version string for Relationships selector. Supports 'v1.2.3', '>v1.2.3', '>=v1.2.3', and optional suffixes."
+    },
     "time": {
       "type": "string",
       "format": "date-time",

--- a/schemas/constructs/v1alpha1/selector.json
+++ b/schemas/constructs/v1alpha1/selector.json
@@ -15,7 +15,7 @@
           "type": "string"
         },
         "version": {
-          "$ref": "../core.json#/definitions/versionString"
+          "$ref": "../core.json#/definitions/relationshipVersionString"
         },
         "match": {
           "type": "object",
@@ -77,7 +77,7 @@
           "type": "string"
         },
         "version": {
-          "$ref": "../core.json#/definitions/versionString"
+          "$ref": "../core.json#/definitions/relationshipVersionString"
         },
         "match": {
           "type": "object",

--- a/schemas/constructs/v1alpha1/selector.json
+++ b/schemas/constructs/v1alpha1/selector.json
@@ -15,7 +15,7 @@
           "type": "string"
         },
         "version": {
-          "$ref": "../core.json#/definitions/relationshipVersionString"
+          "$ref": "../core.json#/definitions/versionConstraintString"
         },
         "match": {
           "type": "object",
@@ -77,7 +77,7 @@
           "type": "string"
         },
         "version": {
-          "$ref": "../core.json#/definitions/relationshipVersionString"
+          "$ref": "../core.json#/definitions/versionConstraintString"
         },
         "match": {
           "type": "object",

--- a/schemas/constructs/v1alpha2/relationship.json
+++ b/schemas/constructs/v1alpha2/relationship.json
@@ -61,13 +61,13 @@
     "selectors": {
       "type": "array",
       "description": "Selectors are organized as an array, with each item containing a distinct set of selectors that share a common functionality. This structure allows for flexibility in defining relationships, even when different components are involved.",
-      "$comment": "Sets of selectors are interpreted as a locical OR, while sets of allow/deny are interpreted a logical AND.",
+      "$comment": "Sets of selectors are interpreted as a logical OR, while sets of allow/deny are interpreted a logical AND.",
       "items": {
         "type": "object",
         "description": "Optional selectors used to match Components. Absence of a selector means that it is applied to all Components.",
         "additionalProperties": false,
         "required": [
-          "alllow"
+          "allow"
         ],
         "properties": {
           "deny": {

--- a/schemas/constructs/v1alpha2/selector.json
+++ b/schemas/constructs/v1alpha2/selector.json
@@ -17,7 +17,7 @@
           "description": "Model of the component. Learn more at https://docs.meshery.io/concepts/models"
         },
         "version": {
-          "$ref": "../core.json#/definitions/semverString"
+          "$ref": "../core.json#/definitions/relationshipVersionString"
         },
         "match": {
           "type": "object",
@@ -80,7 +80,7 @@
           "description": "Model of the component. Learn more at https://docs.meshery.io/concepts/models"
         },
         "version": {
-          "$ref": "../core.json#/definitions/semverString"
+          "$ref": "../core.json#/definitions/relationshipVersionString"
         },
         "match": {
           "type": "object",

--- a/schemas/constructs/v1alpha2/selector.json
+++ b/schemas/constructs/v1alpha2/selector.json
@@ -17,7 +17,7 @@
           "description": "Model of the component. Learn more at https://docs.meshery.io/concepts/models"
         },
         "version": {
-          "$ref": "../core.json#/definitions/relationshipVersionString"
+          "$ref": "../core.json#/definitions/versionConstraintString"
         },
         "match": {
           "type": "object",
@@ -80,7 +80,7 @@
           "description": "Model of the component. Learn more at https://docs.meshery.io/concepts/models"
         },
         "version": {
-          "$ref": "../core.json#/definitions/relationshipVersionString"
+          "$ref": "../core.json#/definitions/versionConstraintString"
         },
         "match": {
           "type": "object",


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #41 
Changes included:
-Added support for > and >= in version strings in schemas/constructs/core.json.
-Updated regex for versionString to correctly validate these new formats.
-Ensured backward compatibility with existing version formats.



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [X] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
