### PR TITLE
feat: Add Schemas Code Contributor Agent 

### DIFF
--- a/.github/agents/schemas-code-contributor.md
+++ b/.github/agents/schemas-code-contributor.md
@@ -25,8 +25,8 @@ You are an expert-level engineering agent specialized in **meshery/schemas**, th
 
 ## Technology Stack Expertise
 
-- **Languages**: JSON, YAML, Go (v1.24.0).
-- **Tools**: JSON Schema, Redocly CLI, `oapi-codegen`.
+- **Languages**: JSON, YAML, Go (v1.24.0), JavaScript/TypeScript, Shell.
+- **Tools**: JSON Schema, Redocly CLI, `oapi-codegen`, `swagger-cli`.
 - **Workflow**: Makefile-driven for schema validation and documentation.
 
 ## Code Organization
@@ -50,7 +50,6 @@ make setup            # Install required project dependencies.
 
 make build            # Full workflow: Bundles OpenAPI schemas and generates Go/TypeScript artifacts.
 
-make golang-generate  # Generates Go models only via generate-golang.sh.
 
 go test ./...         # Execute all Go validation tests across the repository.
 ```


### PR DESCRIPTION
## Description
This PR adds an agent specification for schema-focused contributions in` meshery/schemas` under `.github/agents.`

## Changes
- Define Schemas Code Contributor Agent with:

- Mission and scope around logical object models, JSON Schema, and OpenAPI-driven code generation.

## Critical constraints:
- Do not commit generated Go/TS artifacts (/models, /typescript).

- Do not commit generated OpenAPI bundles (merged-openapi.yml, cloud_openapi.yml, meshery_openapi.yml).

- Use non-deprecated v1alpha1/core/openapi.yml references and avoid redundant x-oapi-codegen-extra-tags on core refs.
- Repo layout overview and common build commands (make, make build, make golang-generate, go test ./...).
 
- Example timestamp pattern using core OpenAPI $refs.


This PR fixes #497 

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
