### PR TITLE
Modify release notes workflow configuration

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -11,7 +11,7 @@ jobs:
         - name: Checkout
           uses: actions/checkout@master
           with:
-            token: ${{ secrets.RELEASEDRAFTER_PAT }}
+            token: ${{ secrets.MESHERY_CI }}
             ref: 'master'
 
 
@@ -32,4 +32,5 @@ jobs:
             commit_author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
             commit_options: '--signoff'
             commit_message: '[Docs] Release Notes for Meshery ${{ steps.release_drafter.outputs.tag_name }}'
+
             branch: master


### PR DESCRIPTION
Updated the release notes workflow to use a different CI token and ensured proper formatting.

**Notes for Reviewers**

This PR fixes #



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
