### PR TITLE
[CI] Replace openapi-generator with swagger-cli and add dep-check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,8 @@ golangci: error dep-check
 .PHONY: redocly-docs-build api-validate schemas-join docs-build
 
 ## Validate Remote provider APIs against OpenAPI spec
-api-validate:
-	openapi-generator validate -i schemas/openapi.yml
+api-validate: dep-check-swagger
+	swagger-cli validate schemas/openapi.yml
 
 
 
@@ -99,11 +99,22 @@ endif
 
 # oapi-codegen
 ifeq (,$(shell command -v oapi-codegen))
-	@echo "Dependency missing: oapi-codegen. Install oapi-codegen cli from
+	@echo "Dependency missing: oapi-codegen. Install oapi-codegen cli"
 	@echo "installing oapi-codegen"
 	# for the binary install
 	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
 endif
+
+
+
+.PHONY: dep-check-swagger
+dep-check-swagger:
+	@if ! command -v swagger-cli >/dev/null 2>&1; then \
+		echo "Dependency missing: swagger-cli."; \
+		echo "Please install it from https://www.npmjs.com/package/@apidevtools/swagger-cli"; \
+		exit 1; \
+	fi
+dep-check: dep-check-swagger
 
 
 


### PR DESCRIPTION
## Description
This PR removes the unused `openapi-generator` dependency from the schemas Makefile and introduces a dep-check flow for `swagger-cli`, which is the tool currently used for bundling and validating OpenAPI specs. 

## Changes
- Remove `openapi-generator` references from the Makefile.
- Add `dep-check-swagger` target for validating the presence of `swagger-cli` and providing an installation URL when missing. 
- Update `api-validate` to use `swagger-cli validate schemas/openapi.yml` instead of `openapi-generator validate`.
- Fix syntax error in the `oapi-codegen` dep-check message.

This PR fixes #505 


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
