### PR TITLE
fix: disable ST1005 for schemas repo

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+version: "2"
+
+linters:
+  settings:
+    staticcheck:
+      checks: ["all", "-ST1005"]


### PR DESCRIPTION
## Description
Disable ST1005 staticcheck lint rule globally to allow capitalized error strings.
## Related Issue
Related to meshery/meshery#16867 
## Changes
- Updated [.golangci.yml](cci:7://file:///home/yash/meshsync/.golangci.yml:0:0-0:0) to disable ST1005 while keeping other staticcheck rules active
## Testing
- Verified ST1005 no longer triggers on capitalized error strings

**[Signed commits](../CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
