### PR TITLE
Stop including 'createdAt' in permission history

### DIFF
--- a/build/lib/permissions.js
+++ b/build/lib/permissions.js
@@ -270,7 +270,7 @@ function buildIndex(permissions) {
   const id = computeIndexId(permissions);
   return {
     id,
-    createdAt: new Date().toISOString(),
+    // createdAt: new Date().toISOString(),
     count: permissions.length,
     items: permissions.map((p) => ({
       name: p.name,


### PR DESCRIPTION
Improper logic is being used to detect changes. Either remove createdAt or exclude it from consideration during hashing.