### PR TITLE
OpenAPI: org team soft-delete via POST action payload

### DIFF
--- a/schemas/constructs/v1beta1/organization/api.yml
+++ b/schemas/constructs/v1beta1/organization/api.yml
@@ -29,6 +29,37 @@ paths:
           description: Internal server error
 
   /api/identity/orgs/{orgID}/teams/{teamId}:
+    post:
+      summary: Add team to organization or soft delete team
+      description: Adds a team to an organization. If request body contains action=delete, tombstones a team by setting its deleted_at timestamp. The team's organization mapping remains intact.
+      operationId: AddTeamToOrg
+      parameters:
+        - $ref: "#/components/parameters/orgID"
+        - $ref: "#/components/parameters/teamId"
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/OrgTeamActionPayload"
+      responses:
+        "200":
+          description: Team added to organization or team tombstoned
+          content:
+            application/json:
+              schema:
+                oneOf:
+                  - $ref: "#/components/schemas/TeamsOrganizationsMappingPage"
+                  - $ref: "#/components/schemas/TeamsPage"
+        "400":
+          description: Bad request
+        "401":
+          description: Unauthorized
+        "404":
+          description: Not found
+        "500":
+          description: Internal server error
+
     delete:
       summary: Remove team from organization
       description: Removes (unassigns) a team from an organization.
@@ -43,30 +74,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/TeamsOrganizationsMappingPage"
-        "400":
-          description: Bad request
-        "401":
-          description: Unauthorized
-        "404":
-          description: Not found
-        "500":
-          description: Internal server error
-
-  /api/identity/orgs/{orgID}/teams/{teamId}/delete:
-    post:
-      summary: Soft delete team
-      description: Tombstones a team by setting its deleted_at timestamp. The team's organization mapping remains intact.
-      operationId: DeleteTeam
-      parameters:
-        - $ref: "#/components/parameters/orgID"
-        - $ref: "#/components/parameters/teamId"
-      responses:
-        "200":
-          description: Team tombstoned
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/TeamsPage"
         "400":
           description: Bad request
         "401":
@@ -107,6 +114,16 @@ components:
 
     MapObject:
       $ref: "../../v1alpha1/core/api.yml#/components/schemas/MapObject"
+
+    OrgTeamActionPayload:
+      type: object
+      description: Optional action payload for POST on /api/identity/orgs/{orgID}/teams/{teamId}.
+      properties:
+        action:
+          type: string
+          description: Internal action to perform on the team resource.
+          enum:
+            - delete
 
     Location:
       type: object
@@ -260,7 +277,7 @@ components:
         updated_at:
           $ref: "#/components/schemas/Time"
         deleted_at:
-          $ref: "#/components/schemas/Time"
+          $ref: "#/components/schemas/NullableTime"
 
     TeamsPage:
       type: object
@@ -290,7 +307,7 @@ components:
         updated_at:
           $ref: "#/components/schemas/Time"
         deleted_at:
-          $ref: "#/components/schemas/Time"
+          $ref: "#/components/schemas/NullableTime"
 
     TeamsOrganizationsMappingPage:
       type: object


### PR DESCRIPTION
Aligns org-team deletion with the Meshery Cloud contract (no `/delete` path segment).

Endpoints:
- `DELETE /api/identity/orgs/{orgID}/teams/{teamId}` → unassign/remove team from org (`RemoveTeamFromOrg`)
- `POST /api/identity/orgs/{orgID}/teams/{teamId}` → add team to org, or soft-delete (tombstone) when body includes `{ "action": "delete" }` (`AddTeamToOrg`)

Also fixes soft-delete typing so `deleted_at` is nullable in the affected schemas.

Notes:
- Soft delete is a tombstone (`deleted_at` set); org mapping remains intact.
- Server-side authorization + org-boundary validation is enforced in meshery-cloud; this PR updates the OpenAPI construct to match the agreed contract.