### PR TITLE
fix: sanitize absolute runner paths in generated schemas

### DIFF
--- a/.github/workflows/generate-artifacts-from-schemas.yml
+++ b/.github/workflows/generate-artifacts-from-schemas.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Sanitize generated files
         shell: bash
         run: |
-          find . -name "*.ts" -type f -exec sed -i "s|$GITHUB_WORKSPACE|.|g" {} +
+          # Sanitize both TypeScript and Go artifacts
+          find ./typescript ./models \( -name "*.ts" -o -name "*.go" \) -type f -exec sed -i "s|$GITHUB_WORKSPACE|.|g" {} +
 
       - name: Pull changes from remote
         run: git pull origin master
@@ -47,7 +48,8 @@ jobs:
       - name: Verify no path leakage
         shell: bash
         run: |
-          if grep -r "/home/runner" ./typescript; then
+          # Check only artifact paths and exclude docs/build directories
+          if grep -r "/home/runner" ./typescript ./models --exclude-dir=docs --exclude-dir=build; then
             echo "::error::1001-CI-PATH-LEAK-ERR: Absolute paths found in generated files. Path leakage detected!"
             exit 1
           fi

--- a/.github/workflows/generate-artifacts-from-schemas.yml
+++ b/.github/workflows/generate-artifacts-from-schemas.yml
@@ -36,8 +36,21 @@ jobs:
         run: |
           make build
 
+      - name: Sanitize generated files
+        shell: bash
+        run: |
+          find . -name "*.ts" -type f -exec sed -i "s|$GITHUB_WORKSPACE|.|g" {} +
+
       - name: Pull changes from remote
         run: git pull origin master
+
+      - name: Verify no path leakage
+        shell: bash
+        run: |
+          if grep -r "/home/runner" ./typescript; then
+            echo "::error::1001-CI-PATH-LEAK-ERR: Absolute paths found in generated files. Path leakage detected!"
+            exit 1
+          fi
 
       - uses: stefanzweifel/git-auto-commit-action@v7
         with:


### PR DESCRIPTION
**Notes for Reviewers**
This PR fixes #526
This PR addresses the issue of absolute environment paths being leaked into the repository during the automated type generation process. Currently, the GitHub Action runner’s local workspace path (e.g., /home/runner/work/...) is being captured by the generation tool and committed directly into the TypeScript schemas, such as SchemasOpenApiSchema.ts.

This causes unnecessary git noise and pollutes the codebase with environment-specific metadata that is irrelevant to other developers and production environments.

**Changes**

•Workflow Sanitization: Updated the generate-types workflow to include a post-generation cleanup step. This step dynamically identifies the $GITHUB_WORKSPACE and replaces it with a relative ./ path across all generated .ts files.

•Verification Gate: Added a validation check before the commit step. The CI will now scan for any remaining /home/runner strings and fail the build if a path leak is detected.

•Standardized Error Logging: Integrated a descriptive error moniker for the verification failure to align with the project's event-tracking framework.
- [✅] Yes, I signed my commits.
