### PR TITLE
fix: resolve all validate-schemas violations

### DIFF
--- a/schemas/constructs/v1beta1/badge/api.yml
+++ b/schemas/constructs/v1beta1/badge/api.yml
@@ -56,7 +56,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Badge"
+              $ref: "#/components/schemas/BadgePayload"
         required: true
       responses:
         "201":
@@ -67,6 +67,64 @@ paths:
 
 components:
   schemas:
+    BadgePayload:
+      type: object
+      description: Payload for creating or updating a badge.
+      required:
+        - label
+        - name
+        - org_id
+        - description
+        - image_url
+      properties:
+        id:
+          $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
+          x-go-name: ID
+          description: Existing badge ID for updates; omit on create.
+          x-oapi-codegen-extra-tags:
+            db: "id"
+            json: "id,omitempty"
+
+        org_id:
+          $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
+          description: The ID of the organization in which this badge is available.
+          x-oapi-codegen-extra-tags:
+            db: "org_id"
+            json: "org_id"
+
+        label:
+          type: string
+          description: unique identifier for the badge ( auto generated )
+          example: Kubernetes-Expert
+          x-oapi-codegen-extra-tags:
+            db: "label"
+            json: "label"
+
+        name:
+          type: string
+          description: Concise descriptor for the badge or certificate.
+          example: Kubernetes Expert
+          x-oapi-codegen-extra-tags:
+            db: "name"
+            json: "name"
+
+        description:
+          type: string
+          description: A description of the milestone achieved, often including criteria for receiving this recognition.
+          example: Awarded for mastering Kubernetes concepts and practices.
+          x-oapi-codegen-extra-tags:
+            db: "description"
+            json: "description"
+
+        image_url:
+          type: string
+          format: uri
+          description: URL to the badge image
+          example: https://raw.githubusercontent.com/layer5io/layer5-academy/refs/heads/master/static/11111111-1111-1111-1111-111111111111/images/meshery-logo-light.webp
+          x-oapi-codegen-extra-tags:
+            db: "image_url"
+            json: "image_url"
+
     Badge:
       type: object
       required:

--- a/schemas/constructs/v1beta1/design/api.yml
+++ b/schemas/constructs/v1beta1/design/api.yml
@@ -66,7 +66,9 @@ paths:
           $ref: "#/components/responses/401"
         "500":
           $ref: "#/components/responses/500"
-    delete:
+
+  /api/content/patterns/delete:
+    post:
       x-internal: ["cloud"]
       tags:
         - designs

--- a/schemas/constructs/v1beta1/design/design.yaml
+++ b/schemas/constructs/v1beta1/design/design.yaml
@@ -2,6 +2,7 @@ $schema: http://json-schema.org/draft-07/schema#
 title: Design Schema
 description: Designs are your primary tool for collaborative authorship of your infrastructure, workflow, and processes.
 type: object
+additionalProperties: false
 properties:
   id:
     $ref: ../../v1alpha1/core/api.yml#/components/schemas/uuid

--- a/schemas/constructs/v1beta1/event/api.yml
+++ b/schemas/constructs/v1beta1/event/api.yml
@@ -73,7 +73,9 @@ paths:
                 $ref: "#/components/schemas/ErrorResponse"
         "500":
           description: Server error
-    delete:
+
+  /events/delete:
+    post:
       tags:
         - events
       summary: Bulk delete events

--- a/schemas/constructs/v1beta1/invitation/api.yml
+++ b/schemas/constructs/v1beta1/invitation/api.yml
@@ -67,7 +67,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Invitation"
+              $ref: "#/components/schemas/InvitationPayload"
         required: true
       responses:
         "200":
@@ -111,7 +111,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/Invitation"
+              $ref: "#/components/schemas/InvitationPayload"
         required: true
       responses:
         "201":
@@ -198,6 +198,97 @@ components:
 
           x-oapi-codegen-extra-tags:
             json: "total"
+
+    InvitationPayload:
+      type: object
+      description: Payload for creating or updating an invitation.
+      required:
+        - name
+        - description
+        - org_id
+        - emails
+        - roles
+        - teams
+        - status
+      properties:
+        id:
+          $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
+          x-go-name: ID
+          description: Existing invitation ID for updates; omit on create.
+          x-oapi-codegen-extra-tags:
+            json: "id,omitempty"
+
+        owner_id:
+          $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
+          description: ID of the user who created the invitation.
+          x-oapi-codegen-extra-tags:
+            db: "owner_id"
+            json: "owner_id,omitempty"
+
+        is_default:
+          type: boolean
+          description: Indicates whether the invitation is a default invitation (open invite).
+          x-oapi-codegen-extra-tags:
+            db: "is_default"
+            json: "is_default,omitempty"
+
+        name:
+          type: string
+          description: Name of the invitation.
+
+        description:
+          type: string
+          description: Description of the invitation.
+
+        emails:
+          type: array
+          x-go-type: "pq.StringArray"
+          x-go-type-import:
+            path: "github.com/lib/pq"
+          items:
+            type: string
+            pattern: "^([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-z]{2,}|@[a-zA-Z0-9.-]+\\.[a-z]{2,})$"
+            x-go-type: "string"
+
+        org_id:
+          type: string
+          description: ID of the organization to which the user is invited.
+          x-oapi-codegen-extra-tags:
+            db: "org_id"
+            json: "org_id"
+
+        expires_at:
+          type: string
+          format: date-time
+          description: Timestamp when the invitation expires, if applicable.
+          x-oapi-codegen-extra-tags:
+            db: "expires_at"
+            json: "expires_at,omitempty"
+
+        quota:
+          type: integer
+          description: Quota for the invitation.
+
+        roles:
+          type: array
+          x-go-type: "pq.StringArray"
+          x-go-type-import:
+            path: "github.com/lib/pq"
+          items:
+            type: string
+
+        teams:
+          type: array
+          x-go-type: "pq.StringArray"
+          x-go-type-import:
+            path: "github.com/lib/pq"
+          items:
+            type: string
+
+        status:
+          type: string
+          $ref: "#/components/schemas/InvitationStatus"
+          x-go-type: "InvitationStatus"
 
     InvitationStatus:
       type: string


### PR DESCRIPTION
## Summary

- **badge/api.yml**: Added `BadgePayload` schema with only client-settable fields; updated `POST /api/organizations/badges` requestBody to reference `BadgePayload` instead of `Badge`
- **design/design.yaml**: Added `additionalProperties: false` at top level to prevent unknown fields in generated structs
- **design/api.yml**: Replaced `DELETE /api/content/patterns` (with requestBody) with `POST /api/content/patterns/delete` per bulk-delete REST convention
- **event/api.yml**: Replaced `DELETE /events` (with requestBody) with `POST /events/delete` per bulk-delete REST convention
- **invitation/api.yml**: Added `InvitationPayload` schema with only client-settable fields; updated `POST` and `PUT` requestBodies to reference `InvitationPayload` instead of `Invitation`

## Test plan

- [ ] Run `make validate-schemas` — should report 0 violations
- [ ] Run `make build` to verify generated Go structs and TypeScript types are valid
- [ ] Run `go test ./...` to verify no Go compilation errors
- [ ] Run `npm run build` to verify TypeScript distribution builds cleanly