### PR TITLE
feat: add selectedK8sContexts to Preference and user prefs API

### DIFF
--- a/models/v1beta1/user/user.go
+++ b/models/v1beta1/user/user.go
@@ -4,8 +4,6 @@
 package user
 
 import (
-	"encoding/json"
-	"fmt"
 	"time"
 
 	"github.com/meshery/schemas/models/core"
@@ -33,25 +31,8 @@ const (
 	Pending   UserStatus = "pending"
 )
 
-// AccountOverview defines model for AccountOverview.
-type AccountOverview map[string]interface{}
-
 // Adapter Placeholder for Adapter struct definition.
 type Adapter = map[string]interface{}
-
-// AvailableNotificationPreference defines model for AvailableNotificationPreference.
-type AvailableNotificationPreference struct {
-	Category             *string                `json:"category,omitempty" yaml:"category,omitempty"`
-	Label                *string                `json:"label,omitempty" yaml:"label,omitempty"`
-	Name                 *string                `json:"name,omitempty" yaml:"name,omitempty"`
-	Subcategory          *string                `json:"subcategory,omitempty" yaml:"subcategory,omitempty"`
-	AdditionalProperties map[string]interface{} `json:"-" yaml:"-"`
-}
-
-// AvailableNotificationPreferences defines model for AvailableNotificationPreferences.
-type AvailableNotificationPreferences struct {
-	NotificationPreferences *map[string]AvailableNotificationPreference `json:"notification_preferences,omitempty" yaml:"notification_preferences,omitempty"`
-}
 
 // Grafana defines model for Grafana.
 type Grafana struct {
@@ -83,14 +64,17 @@ type Panel = map[string]interface{}
 
 // Preference defines model for Preference.
 type Preference struct {
-	AnonymousPerfResults              bool                   `json:"anonymousPerfResults" yaml:"anonymousPerfResults"`
-	AnonymousUsageStats               bool                   `json:"anonymousUsageStats" yaml:"anonymousUsageStats"`
-	DashboardPreferences              map[string]interface{} `json:"dashboardPreferences" yaml:"dashboardPreferences"`
-	Grafana                           *Grafana               `json:"grafana,omitempty" yaml:"grafana,omitempty"`
-	LoadTestPrefs                     *LoadTestPreferences   `json:"loadTestPrefs,omitempty" yaml:"loadTestPrefs,omitempty"`
-	MeshAdapters                      *[]Adapter             `json:"meshAdapters,omitempty" yaml:"meshAdapters,omitempty"`
-	Prometheus                        *Prometheus            `json:"prometheus,omitempty" yaml:"prometheus,omitempty"`
-	RemoteProviderPreferences         map[string]interface{} `json:"remoteProviderPreferences" yaml:"remoteProviderPreferences"`
+	AnonymousPerfResults      bool                   `json:"anonymousPerfResults" yaml:"anonymousPerfResults"`
+	AnonymousUsageStats       bool                   `json:"anonymousUsageStats" yaml:"anonymousUsageStats"`
+	DashboardPreferences      map[string]interface{} `json:"dashboardPreferences" yaml:"dashboardPreferences"`
+	Grafana                   *Grafana               `json:"grafana,omitempty" yaml:"grafana,omitempty"`
+	LoadTestPrefs             *LoadTestPreferences   `json:"loadTestPrefs,omitempty" yaml:"loadTestPrefs,omitempty"`
+	MeshAdapters              *[]Adapter             `json:"meshAdapters,omitempty" yaml:"meshAdapters,omitempty"`
+	Prometheus                *Prometheus            `json:"prometheus,omitempty" yaml:"prometheus,omitempty"`
+	RemoteProviderPreferences map[string]interface{} `json:"remoteProviderPreferences" yaml:"remoteProviderPreferences"`
+
+	// SelectedK8sContexts Persisted selection of active Kubernetes context IDs
+	SelectedK8sContexts               *[]string              `json:"selectedK8sContexts,omitempty" yaml:"selectedK8sContexts,omitempty"`
 	SelectedOrganizationID            string                 `json:"selectedOrganizationID" yaml:"selectedOrganizationID"`
 	SelectedWorkspaceForOrganizations map[string]string      `json:"selectedWorkspaceForOrganizations" yaml:"selectedWorkspaceForOrganizations"`
 	UpdatedAt                         time.Time              `json:"updated_at" yaml:"updated_at"`
@@ -101,17 +85,6 @@ type Preference struct {
 type Prometheus struct {
 	PrometheusURL                   *string                  `json:"prometheusURL,omitempty" yaml:"prometheusURL,omitempty"`
 	SelectedPrometheusBoardsConfigs *[]SelectedGrafanaConfig `json:"selectedPrometheusBoardsConfigs,omitempty" yaml:"selectedPrometheusBoardsConfigs,omitempty"`
-}
-
-// RecentActivity defines model for RecentActivity.
-type RecentActivity map[string]interface{}
-
-// RecentActivityPage defines model for RecentActivityPage.
-type RecentActivityPage struct {
-	Data       *[]RecentActivity `json:"data,omitempty" yaml:"data,omitempty"`
-	Page       *int              `json:"page,omitempty" yaml:"page,omitempty"`
-	PageSize   *int              `json:"page_size,omitempty" yaml:"page_size,omitempty"`
-	TotalCount *int              `json:"total_count,omitempty" yaml:"total_count,omitempty"`
 }
 
 // SelectedGrafanaConfig defines model for SelectedGrafanaConfig.
@@ -235,133 +208,3 @@ type Search = string
 
 // TeamID defines model for teamID.
 type TeamID = corev1alpha1.TeamId
-
-// BulkDeleteUsersPayload defines model for bulkDeleteUsersPayload.
-type BulkDeleteUsersPayload map[string]interface{}
-
-// NotificationPreferencePayload defines model for notificationPreferencePayload.
-type NotificationPreferencePayload map[string]interface{}
-
-// UpdatePasswordPayload defines model for updatePasswordPayload.
-type UpdatePasswordPayload struct {
-	Password *string `json:"password,omitempty" yaml:"password,omitempty"`
-}
-
-// UserFeedbackPayload defines model for userFeedbackPayload.
-type UserFeedbackPayload map[string]interface{}
-
-// UserPreferencePayload defines model for userPreferencePayload.
-type UserPreferencePayload map[string]interface{}
-
-// Getter for additional properties for AvailableNotificationPreference. Returns the specified
-// element and whether it was found
-func (a AvailableNotificationPreference) Get(fieldName string) (value interface{}, found bool) {
-	if a.AdditionalProperties != nil {
-		value, found = a.AdditionalProperties[fieldName]
-	}
-	return
-}
-
-// Setter for additional properties for AvailableNotificationPreference
-func (a *AvailableNotificationPreference) Set(fieldName string, value interface{}) {
-	if a.AdditionalProperties == nil {
-		a.AdditionalProperties = make(map[string]interface{})
-	}
-	a.AdditionalProperties[fieldName] = value
-}
-
-// Override default JSON handling for AvailableNotificationPreference to handle AdditionalProperties
-func (a *AvailableNotificationPreference) UnmarshalJSON(b []byte) error {
-	object := make(map[string]json.RawMessage)
-	err := json.Unmarshal(b, &object)
-	if err != nil {
-		return err
-	}
-
-	if raw, found := object["category"]; found {
-		err = json.Unmarshal(raw, &a.Category)
-		if err != nil {
-			return fmt.Errorf("error reading 'category': %w", err)
-		}
-		delete(object, "category")
-	}
-
-	if raw, found := object["label"]; found {
-		err = json.Unmarshal(raw, &a.Label)
-		if err != nil {
-			return fmt.Errorf("error reading 'label': %w", err)
-		}
-		delete(object, "label")
-	}
-
-	if raw, found := object["name"]; found {
-		err = json.Unmarshal(raw, &a.Name)
-		if err != nil {
-			return fmt.Errorf("error reading 'name': %w", err)
-		}
-		delete(object, "name")
-	}
-
-	if raw, found := object["subcategory"]; found {
-		err = json.Unmarshal(raw, &a.Subcategory)
-		if err != nil {
-			return fmt.Errorf("error reading 'subcategory': %w", err)
-		}
-		delete(object, "subcategory")
-	}
-
-	if len(object) != 0 {
-		a.AdditionalProperties = make(map[string]interface{})
-		for fieldName, fieldBuf := range object {
-			var fieldVal interface{}
-			err := json.Unmarshal(fieldBuf, &fieldVal)
-			if err != nil {
-				return fmt.Errorf("error unmarshaling field %s: %w", fieldName, err)
-			}
-			a.AdditionalProperties[fieldName] = fieldVal
-		}
-	}
-	return nil
-}
-
-// Override default JSON handling for AvailableNotificationPreference to handle AdditionalProperties
-func (a AvailableNotificationPreference) MarshalJSON() ([]byte, error) {
-	var err error
-	object := make(map[string]json.RawMessage)
-
-	if a.Category != nil {
-		object["category"], err = json.Marshal(a.Category)
-		if err != nil {
-			return nil, fmt.Errorf("error marshaling 'category': %w", err)
-		}
-	}
-
-	if a.Label != nil {
-		object["label"], err = json.Marshal(a.Label)
-		if err != nil {
-			return nil, fmt.Errorf("error marshaling 'label': %w", err)
-		}
-	}
-
-	if a.Name != nil {
-		object["name"], err = json.Marshal(a.Name)
-		if err != nil {
-			return nil, fmt.Errorf("error marshaling 'name': %w", err)
-		}
-	}
-
-	if a.Subcategory != nil {
-		object["subcategory"], err = json.Marshal(a.Subcategory)
-		if err != nil {
-			return nil, fmt.Errorf("error marshaling 'subcategory': %w", err)
-		}
-	}
-
-	for fieldName, field := range a.AdditionalProperties {
-		object[fieldName], err = json.Marshal(field)
-		if err != nil {
-			return nil, fmt.Errorf("error marshaling '%s': %w", fieldName, err)
-		}
-	}
-	return json.Marshal(object)
-}

--- a/schemas/constructs/v1beta1/user/api.yml
+++ b/schemas/constructs/v1beta1/user/api.yml
@@ -104,6 +104,53 @@ paths:
           $ref: "#/components/responses/401"
         "500":
           $ref: "#/components/responses/500"
+
+  /api/user/prefs:
+    get:
+      tags:
+        - users
+      operationId: getUserPrefs
+      summary: Get user preferences
+      description: Returns the current user's preferences including selected K8s contexts, load test settings, and other UI preferences.
+      x-internal:
+        - meshery
+      responses:
+        "200":
+          description: User preferences
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Preference"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+    post:
+      tags:
+        - users
+      operationId: updateUserPrefs
+      summary: Update user preferences
+      description: Merges the provided fields into the current user's preferences. Only the fields present in the request body are updated.
+      x-internal:
+        - meshery
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Preference"
+      responses:
+        "200":
+          description: Updated user preferences
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Preference"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
 components:
   responses:
     400:
@@ -482,6 +529,11 @@ components:
         usersExtensionPreferences:
           type: object
           additionalProperties: true
+        selectedK8sContexts:
+          type: array
+          description: Persisted selection of active Kubernetes context IDs
+          items:
+            type: string
         remoteProviderPreferences:
           type: object
           additionalProperties: true

--- a/typescript/generated/v1beta1/user/User.ts
+++ b/typescript/generated/v1beta1/user/User.ts
@@ -18,30 +18,11 @@ export interface paths {
   "/api/identity/users/profile": {
     get: operations["getUser"];
   };
-  "/api/identity/users/preferences": {
-    put: operations["updateUserPreference"];
-  };
-  "/api/identity/users/self": {
-    delete: operations["deleteOwnAccount"];
-  };
-  "/api/identity/orgs/{orgId}/users/bulk": {
-    post: operations["bulkDeleteUsers"];
-  };
-  "/api/identity/users/profile/details": {
-    get: operations["getProfileOverview"];
-  };
-  "/api/identity/users/{userId}/profile/activity": {
-    get: operations["getUserActivity"];
-  };
-  "/api/identity/users/notify/feedback": {
-    post: operations["handleFeedbackFormSubmission"];
-  };
-  "/api/identity/users/password": {
-    post: operations["updateUsersPassword"];
-  };
-  "/api/identity/users/notifications/preferences": {
-    get: operations["getAvailableNotificationPreferences"];
-    put: operations["updateNotificationPreferences"];
+  "/api/user/prefs": {
+    /** Returns the current user's preferences including selected K8s contexts, load test settings, and other UI preferences. */
+    get: operations["getUserPrefs"];
+    /** Merges the provided fields into the current user's preferences. Only the fields present in the request body are updated. */
+    post: operations["updateUserPrefs"];
   };
 }
 
@@ -134,6 +115,8 @@ export interface components {
         selectedOrganizationID: string;
         selectedWorkspaceForOrganizations: { [key: string]: string };
         usersExtensionPreferences: { [key: string]: unknown };
+        /** @description Persisted selection of active Kubernetes context IDs */
+        selectedK8sContexts?: string[];
         remoteProviderPreferences: { [key: string]: unknown };
       };
       /**
@@ -291,6 +274,8 @@ export interface components {
           selectedOrganizationID: string;
           selectedWorkspaceForOrganizations: { [key: string]: string };
           usersExtensionPreferences: { [key: string]: unknown };
+          /** @description Persisted selection of active Kubernetes context IDs */
+          selectedK8sContexts?: string[];
           remoteProviderPreferences: { [key: string]: unknown };
         };
         /**
@@ -449,6 +434,8 @@ export interface components {
           selectedOrganizationID: string;
           selectedWorkspaceForOrganizations: { [key: string]: string };
           usersExtensionPreferences: { [key: string]: unknown };
+          /** @description Persisted selection of active Kubernetes context IDs */
+          selectedK8sContexts?: string[];
           remoteProviderPreferences: { [key: string]: unknown };
         };
         /**
@@ -555,6 +542,8 @@ export interface components {
       selectedOrganizationID: string;
       selectedWorkspaceForOrganizations: { [key: string]: string };
       usersExtensionPreferences: { [key: string]: unknown };
+      /** @description Persisted selection of active Kubernetes context IDs */
+      selectedK8sContexts?: string[];
       remoteProviderPreferences: { [key: string]: unknown };
     };
     /** @description Placeholder for Adapter struct definition. */
@@ -604,30 +593,6 @@ export interface components {
       /** Format: uri */
       link: string;
     };
-    AccountOverview: { [key: string]: unknown };
-    RecentActivity: { [key: string]: unknown };
-    RecentActivityPage: {
-      page?: number;
-      page_size?: number;
-      total_count?: number;
-      data?: { [key: string]: unknown }[];
-    };
-    AvailableNotificationPreference: {
-      category?: string;
-      subcategory?: string;
-      label?: string;
-      name?: string;
-    } & { [key: string]: unknown };
-    AvailableNotificationPreferences: {
-      notification_preferences?: {
-        [key: string]: {
-          category?: string;
-          subcategory?: string;
-          label?: string;
-          name?: string;
-        } & { [key: string]: unknown };
-      };
-    };
   };
   responses: {
     /** Invalid request body or request param */
@@ -672,35 +637,6 @@ export interface components {
     filter: string;
     /** @description Optional team filter when listing organization users */
     teamID: string;
-  };
-  requestBodies: {
-    userPreferencePayload: {
-      content: {
-        "application/json": { [key: string]: unknown };
-      };
-    };
-    bulkDeleteUsersPayload: {
-      content: {
-        "application/json": { [key: string]: unknown };
-      };
-    };
-    userFeedbackPayload: {
-      content: {
-        "application/json": { [key: string]: unknown };
-      };
-    };
-    updatePasswordPayload: {
-      content: {
-        "application/json": {
-          password?: string;
-        };
-      };
-    };
-    notificationPreferencePayload: {
-      content: {
-        "application/json": { [key: string]: unknown };
-      };
-    };
   };
 }
 
@@ -821,6 +757,8 @@ export interface operations {
                 selectedOrganizationID: string;
                 selectedWorkspaceForOrganizations: { [key: string]: string };
                 usersExtensionPreferences: { [key: string]: unknown };
+                /** @description Persisted selection of active Kubernetes context IDs */
+                selectedK8sContexts?: string[];
                 remoteProviderPreferences: { [key: string]: unknown };
               };
               /**
@@ -1020,6 +958,8 @@ export interface operations {
                 selectedOrganizationID: string;
                 selectedWorkspaceForOrganizations: { [key: string]: string };
                 usersExtensionPreferences: { [key: string]: unknown };
+                /** @description Persisted selection of active Kubernetes context IDs */
+                selectedK8sContexts?: string[];
                 remoteProviderPreferences: { [key: string]: unknown };
               };
               /**
@@ -1206,6 +1146,8 @@ export interface operations {
               selectedOrganizationID: string;
               selectedWorkspaceForOrganizations: { [key: string]: string };
               usersExtensionPreferences: { [key: string]: unknown };
+              /** @description Persisted selection of active Kubernetes context IDs */
+              selectedK8sContexts?: string[];
               remoteProviderPreferences: { [key: string]: unknown };
             };
             /**
@@ -1379,6 +1321,8 @@ export interface operations {
               selectedOrganizationID: string;
               selectedWorkspaceForOrganizations: { [key: string]: string };
               usersExtensionPreferences: { [key: string]: unknown };
+              /** @description Persisted selection of active Kubernetes context IDs */
+              selectedK8sContexts?: string[];
               remoteProviderPreferences: { [key: string]: unknown };
             };
             /**
@@ -1461,171 +1405,55 @@ export interface operations {
       };
     };
   };
-  updateUserPreference: {
+  /** Returns the current user's preferences including selected K8s contexts, load test settings, and other UI preferences. */
+  getUserPrefs: {
     responses: {
-      /** Preferences updated */
-      201: {
-        content: {
-          "application/json": { [key: string]: unknown };
-        };
-      };
-      /** Expired JWT token used or insufficient privilege */
-      401: {
-        content: {
-          "text/plain": string;
-        };
-      };
-      /** Internal server error */
-      500: {
-        content: {
-          "text/plain": string;
-        };
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": { [key: string]: unknown };
-      };
-    };
-  };
-  deleteOwnAccount: {
-    responses: {
-      /** Account deleted */
-      201: {
-        content: {
-          "application/json": { [key: string]: unknown };
-        };
-      };
-      /** Invalid request body or request param */
-      400: {
-        content: {
-          "text/plain": string;
-        };
-      };
-      /** Expired JWT token used or insufficient privilege */
-      401: {
-        content: {
-          "text/plain": string;
-        };
-      };
-      /** Internal server error */
-      500: {
-        content: {
-          "text/plain": string;
-        };
-      };
-    };
-  };
-  bulkDeleteUsers: {
-    parameters: {
-      path: {
-        /** Organization ID */
-        orgId: string;
-      };
-    };
-    responses: {
-      /** Users deleted */
-      201: {
-        content: {
-          "application/json": { [key: string]: unknown };
-        };
-      };
-      /** Invalid request body or request param */
-      400: {
-        content: {
-          "text/plain": string;
-        };
-      };
-      /** Expired JWT token used or insufficient privilege */
-      401: {
-        content: {
-          "text/plain": string;
-        };
-      };
-      /** Internal server error */
-      500: {
-        content: {
-          "text/plain": string;
-        };
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": { [key: string]: unknown };
-      };
-    };
-  };
-  getProfileOverview: {
-    responses: {
-      /** User account overview */
-      200: {
-        content: {
-          "application/json": { [key: string]: unknown };
-        };
-      };
-      /** Expired JWT token used or insufficient privilege */
-      401: {
-        content: {
-          "text/plain": string;
-        };
-      };
-      /** Internal server error */
-      500: {
-        content: {
-          "text/plain": string;
-        };
-      };
-    };
-  };
-  getUserActivity: {
-    parameters: {
-      path: {
-        /** User ID */
-        userId: string;
-      };
-      query: {
-        /** Get responses by page */
-        page?: string;
-        /** Get responses by pagesize */
-        pagesize?: string;
-        /** Get ordered responses */
-        order?: string;
-        /** Get filtered reponses */
-        filter?: string;
-      };
-    };
-    responses: {
-      /** User recent activity */
+      /** User preferences */
       200: {
         content: {
           "application/json": {
-            page?: number;
-            page_size?: number;
-            total_count?: number;
-            data?: { [key: string]: unknown }[];
+            meshAdapters?: { [key: string]: unknown }[];
+            grafana?: {
+              grafanaURL?: string;
+              grafanaAPIKey?: string;
+              selectedBoardsConfigs?: {
+                /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
+                board?: { [key: string]: unknown };
+                panels?: { [key: string]: unknown }[];
+                templateVars?: string[];
+              }[];
+            };
+            prometheus?: {
+              prometheusURL?: string;
+              selectedPrometheusBoardsConfigs?: {
+                /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
+                board?: { [key: string]: unknown };
+                panels?: { [key: string]: unknown }[];
+                templateVars?: string[];
+              }[];
+            };
+            loadTestPrefs?: {
+              /** @description Concurrent requests */
+              c?: number;
+              /** @description Queries per second */
+              qps?: number;
+              /** @description Duration */
+              t?: string;
+              /** @description Load generator */
+              gen?: string;
+            };
+            anonymousUsageStats: boolean;
+            anonymousPerfResults: boolean;
+            /** Format: date-time */
+            updated_at: string;
+            dashboardPreferences: { [key: string]: unknown };
+            selectedOrganizationID: string;
+            selectedWorkspaceForOrganizations: { [key: string]: string };
+            usersExtensionPreferences: { [key: string]: unknown };
+            /** @description Persisted selection of active Kubernetes context IDs */
+            selectedK8sContexts?: string[];
+            remoteProviderPreferences: { [key: string]: unknown };
           };
-        };
-      };
-      /** Internal server error */
-      500: {
-        content: {
-          "text/plain": string;
-        };
-      };
-    };
-  };
-  handleFeedbackFormSubmission: {
-    responses: {
-      /** Feedback submitted */
-      201: {
-        content: {
-          "application/json": { [key: string]: unknown };
-        };
-      };
-      /** Invalid request body or request param */
-      400: {
-        content: {
-          "text/plain": string;
         };
       };
       /** Expired JWT token used or insufficient privilege */
@@ -1641,18 +1469,56 @@ export interface operations {
         };
       };
     };
-    requestBody: {
-      content: {
-        "application/json": { [key: string]: unknown };
-      };
-    };
   };
-  updateUsersPassword: {
+  /** Merges the provided fields into the current user's preferences. Only the fields present in the request body are updated. */
+  updateUserPrefs: {
     responses: {
-      /** Password updated */
+      /** Updated user preferences */
       200: {
         content: {
-          "application/json": { [key: string]: unknown };
+          "application/json": {
+            meshAdapters?: { [key: string]: unknown }[];
+            grafana?: {
+              grafanaURL?: string;
+              grafanaAPIKey?: string;
+              selectedBoardsConfigs?: {
+                /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
+                board?: { [key: string]: unknown };
+                panels?: { [key: string]: unknown }[];
+                templateVars?: string[];
+              }[];
+            };
+            prometheus?: {
+              prometheusURL?: string;
+              selectedPrometheusBoardsConfigs?: {
+                /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
+                board?: { [key: string]: unknown };
+                panels?: { [key: string]: unknown }[];
+                templateVars?: string[];
+              }[];
+            };
+            loadTestPrefs?: {
+              /** @description Concurrent requests */
+              c?: number;
+              /** @description Queries per second */
+              qps?: number;
+              /** @description Duration */
+              t?: string;
+              /** @description Load generator */
+              gen?: string;
+            };
+            anonymousUsageStats: boolean;
+            anonymousPerfResults: boolean;
+            /** Format: date-time */
+            updated_at: string;
+            dashboardPreferences: { [key: string]: unknown };
+            selectedOrganizationID: string;
+            selectedWorkspaceForOrganizations: { [key: string]: string };
+            usersExtensionPreferences: { [key: string]: unknown };
+            /** @description Persisted selection of active Kubernetes context IDs */
+            selectedK8sContexts?: string[];
+            remoteProviderPreferences: { [key: string]: unknown };
+          };
         };
       };
       /** Expired JWT token used or insufficient privilege */
@@ -1671,66 +1537,48 @@ export interface operations {
     requestBody: {
       content: {
         "application/json": {
-          password?: string;
-        };
-      };
-    };
-  };
-  getAvailableNotificationPreferences: {
-    responses: {
-      /** Available notification preferences */
-      200: {
-        content: {
-          "application/json": {
-            notification_preferences?: {
-              [key: string]: {
-                category?: string;
-                subcategory?: string;
-                label?: string;
-                name?: string;
-              } & { [key: string]: unknown };
-            };
+          meshAdapters?: { [key: string]: unknown }[];
+          grafana?: {
+            grafanaURL?: string;
+            grafanaAPIKey?: string;
+            selectedBoardsConfigs?: {
+              /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
+              board?: { [key: string]: unknown };
+              panels?: { [key: string]: unknown }[];
+              templateVars?: string[];
+            }[];
           };
+          prometheus?: {
+            prometheusURL?: string;
+            selectedPrometheusBoardsConfigs?: {
+              /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
+              board?: { [key: string]: unknown };
+              panels?: { [key: string]: unknown }[];
+              templateVars?: string[];
+            }[];
+          };
+          loadTestPrefs?: {
+            /** @description Concurrent requests */
+            c?: number;
+            /** @description Queries per second */
+            qps?: number;
+            /** @description Duration */
+            t?: string;
+            /** @description Load generator */
+            gen?: string;
+          };
+          anonymousUsageStats: boolean;
+          anonymousPerfResults: boolean;
+          /** Format: date-time */
+          updated_at: string;
+          dashboardPreferences: { [key: string]: unknown };
+          selectedOrganizationID: string;
+          selectedWorkspaceForOrganizations: { [key: string]: string };
+          usersExtensionPreferences: { [key: string]: unknown };
+          /** @description Persisted selection of active Kubernetes context IDs */
+          selectedK8sContexts?: string[];
+          remoteProviderPreferences: { [key: string]: unknown };
         };
-      };
-      /** Expired JWT token used or insufficient privilege */
-      401: {
-        content: {
-          "text/plain": string;
-        };
-      };
-      /** Internal server error */
-      500: {
-        content: {
-          "text/plain": string;
-        };
-      };
-    };
-  };
-  updateNotificationPreferences: {
-    responses: {
-      /** Notification preferences updated */
-      200: {
-        content: {
-          "application/json": { [key: string]: unknown };
-        };
-      };
-      /** Invalid request body or request param */
-      400: {
-        content: {
-          "text/plain": string;
-        };
-      };
-      /** Internal server error */
-      500: {
-        content: {
-          "text/plain": string;
-        };
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": { [key: string]: unknown };
       };
     };
   };

--- a/typescript/generated/v1beta1/user/UserSchema.ts
+++ b/typescript/generated/v1beta1/user/UserSchema.ts
@@ -287,6 +287,7 @@ const UserSchema: Record<string, unknown> = {
                               "json": "preferences",
                               "yaml": "preferences"
                             },
+                            "x-generate-db-helpers": true,
                             "type": "object",
                             "required": [
                               "anonymousUsageStats",
@@ -426,6 +427,13 @@ const UserSchema: Record<string, unknown> = {
                               "usersExtensionPreferences": {
                                 "type": "object",
                                 "additionalProperties": true
+                              },
+                              "selectedK8sContexts": {
+                                "type": "array",
+                                "description": "Persisted selection of active Kubernetes context IDs",
+                                "items": {
+                                  "type": "string"
+                                }
                               },
                               "remoteProviderPreferences": {
                                 "type": "object",
@@ -884,6 +892,7 @@ const UserSchema: Record<string, unknown> = {
                               "json": "preferences",
                               "yaml": "preferences"
                             },
+                            "x-generate-db-helpers": true,
                             "type": "object",
                             "required": [
                               "anonymousUsageStats",
@@ -1023,6 +1032,13 @@ const UserSchema: Record<string, unknown> = {
                               "usersExtensionPreferences": {
                                 "type": "object",
                                 "additionalProperties": true
+                              },
+                              "selectedK8sContexts": {
+                                "type": "array",
+                                "description": "Persisted selection of active Kubernetes context IDs",
+                                "items": {
+                                  "type": "string"
+                                }
                               },
                               "remoteProviderPreferences": {
                                 "type": "object",
@@ -1440,6 +1456,7 @@ const UserSchema: Record<string, unknown> = {
                         "json": "preferences",
                         "yaml": "preferences"
                       },
+                      "x-generate-db-helpers": true,
                       "type": "object",
                       "required": [
                         "anonymousUsageStats",
@@ -1579,6 +1596,13 @@ const UserSchema: Record<string, unknown> = {
                         "usersExtensionPreferences": {
                           "type": "object",
                           "additionalProperties": true
+                        },
+                        "selectedK8sContexts": {
+                          "type": "array",
+                          "description": "Persisted selection of active Kubernetes context IDs",
+                          "items": {
+                            "type": "string"
+                          }
                         },
                         "remoteProviderPreferences": {
                           "type": "object",
@@ -1966,6 +1990,7 @@ const UserSchema: Record<string, unknown> = {
                         "json": "preferences",
                         "yaml": "preferences"
                       },
+                      "x-generate-db-helpers": true,
                       "type": "object",
                       "required": [
                         "anonymousUsageStats",
@@ -2105,6 +2130,13 @@ const UserSchema: Record<string, unknown> = {
                         "usersExtensionPreferences": {
                           "type": "object",
                           "additionalProperties": true
+                        },
+                        "selectedK8sContexts": {
+                          "type": "array",
+                          "description": "Persisted selection of active Kubernetes context IDs",
+                          "items": {
+                            "type": "string"
+                          }
                         },
                         "remoteProviderPreferences": {
                           "type": "object",
@@ -2323,489 +2355,182 @@ const UserSchema: Record<string, unknown> = {
         }
       }
     },
-    "/api/identity/users/preferences": {
-      "put": {
-        "tags": [
-          "users"
-        ],
-        "operationId": "updateUserPreference",
-        "summary": "Update user preferences",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "additionalProperties": true
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Preferences updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Expired JWT token used or insufficient privilege",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/identity/users/self": {
-      "delete": {
-        "tags": [
-          "users"
-        ],
-        "operationId": "deleteOwnAccount",
-        "summary": "Delete current user account",
-        "responses": {
-          "201": {
-            "description": "Account deleted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request body or request param",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Expired JWT token used or insufficient privilege",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/identity/orgs/{orgId}/users/bulk": {
-      "post": {
-        "tags": [
-          "users"
-        ],
-        "operationId": "bulkDeleteUsers",
-        "summary": "Bulk delete organization users",
-        "parameters": [
-          {
-            "name": "orgId",
-            "in": "path",
-            "required": true,
-            "description": "Organization ID",
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "x-go-type": "uuid.UUID",
-              "x-go-type-import": {
-                "path": "github.com/gofrs/uuid"
-              },
-              "x-oapi-codegen-extra-tags": {
-                "db": "org_id",
-                "json": "org_id"
-              },
-              "x-go-type-name": "OrganizationId",
-              "x-go-type-skip-optional-pointer": true
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "additionalProperties": true
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Users deleted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request body or request param",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Expired JWT token used or insufficient privilege",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/identity/users/profile/details": {
+    "/api/user/prefs": {
       "get": {
         "tags": [
           "users"
         ],
-        "operationId": "getProfileOverview",
-        "summary": "Get current user profile overview",
-        "responses": {
-          "200": {
-            "description": "User account overview",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Expired JWT token used or insufficient privilege",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/identity/users/{userId}/profile/activity": {
-      "get": {
-        "tags": [
-          "users"
-        ],
-        "operationId": "getUserActivity",
-        "summary": "Get user activity",
-        "security": [],
-        "parameters": [
-          {
-            "name": "userId",
-            "in": "path",
-            "required": true,
-            "description": "User ID",
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
-              "x-go-type": "uuid.UUID",
-              "x-go-type-import": {
-                "path": "github.com/gofrs/uuid"
-              }
-            }
-          },
-          {
-            "name": "page",
-            "in": "query",
-            "description": "Get responses by page",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "pagesize",
-            "in": "query",
-            "description": "Get responses by pagesize",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "order",
-            "in": "query",
-            "description": "Get ordered responses",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "name": "filter",
-            "in": "query",
-            "description": "Get filtered reponses",
-            "schema": {
-              "type": "string"
-            }
-          }
+        "operationId": "getUserPrefs",
+        "summary": "Get user preferences",
+        "description": "Returns the current user's preferences including selected K8s contexts, load test settings, and other UI preferences.",
+        "x-internal": [
+          "meshery"
         ],
         "responses": {
           "200": {
-            "description": "User recent activity",
+            "description": "User preferences",
             "content": {
               "application/json": {
                 "schema": {
+                  "x-generate-db-helpers": true,
                   "type": "object",
+                  "required": [
+                    "anonymousUsageStats",
+                    "anonymousPerfResults",
+                    "updated_at",
+                    "dashboardPreferences",
+                    "selectedOrganizationID",
+                    "selectedWorkspaceForOrganizations",
+                    "usersExtensionPreferences",
+                    "remoteProviderPreferences"
+                  ],
                   "properties": {
-                    "page": {
-                      "type": "integer"
-                    },
-                    "page_size": {
-                      "type": "integer"
-                    },
-                    "total_count": {
-                      "type": "integer"
-                    },
-                    "data": {
+                    "meshAdapters": {
                       "type": "array",
                       "items": {
+                        "x-go-type": "Adapter",
                         "type": "object",
-                        "additionalProperties": true
+                        "description": "Placeholder for Adapter struct definition."
                       }
+                    },
+                    "grafana": {
+                      "x-go-type": "Grafana",
+                      "type": "object",
+                      "properties": {
+                        "grafanaURL": {
+                          "type": "string"
+                        },
+                        "grafanaAPIKey": {
+                          "type": "string"
+                        },
+                        "selectedBoardsConfigs": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "board": {
+                                "type": "object",
+                                "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
+                              },
+                              "panels": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
+                                }
+                              },
+                              "templateVars": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "prometheus": {
+                      "x-go-type": "Prometheus",
+                      "type": "object",
+                      "properties": {
+                        "prometheusURL": {
+                          "type": "string"
+                        },
+                        "selectedPrometheusBoardsConfigs": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "board": {
+                                "type": "object",
+                                "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
+                              },
+                              "panels": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
+                                }
+                              },
+                              "templateVars": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "loadTestPrefs": {
+                      "x-go-type": "LoadTestPreferences",
+                      "type": "object",
+                      "properties": {
+                        "c": {
+                          "type": "integer",
+                          "description": "Concurrent requests"
+                        },
+                        "qps": {
+                          "type": "integer",
+                          "description": "Queries per second"
+                        },
+                        "t": {
+                          "type": "string",
+                          "description": "Duration"
+                        },
+                        "gen": {
+                          "type": "string",
+                          "description": "Load generator"
+                        }
+                      }
+                    },
+                    "anonymousUsageStats": {
+                      "type": "boolean"
+                    },
+                    "anonymousPerfResults": {
+                      "type": "boolean"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "dashboardPreferences": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "selectedOrganizationID": {
+                      "type": "string"
+                    },
+                    "selectedWorkspaceForOrganizations": {
+                      "type": "object",
+                      "additionalProperties": {
+                        "type": "string"
+                      }
+                    },
+                    "usersExtensionPreferences": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "selectedK8sContexts": {
+                      "type": "array",
+                      "description": "Persisted selection of active Kubernetes context IDs",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "remoteProviderPreferences": {
+                      "type": "object",
+                      "additionalProperties": true
                     }
                   }
                 }
               }
             }
           },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/identity/users/notify/feedback": {
-      "post": {
-        "tags": [
-          "users"
-        ],
-        "operationId": "handleFeedbackFormSubmission",
-        "summary": "Submit feedback notification",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "additionalProperties": true
-              }
-            }
-          }
-        },
-        "responses": {
-          "201": {
-            "description": "Feedback submitted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request body or request param",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
           "401": {
             "description": "Expired JWT token used or insufficient privilege",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/identity/users/password": {
-      "post": {
-        "tags": [
-          "users"
-        ],
-        "operationId": "updateUsersPassword",
-        "summary": "Update current user password",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "properties": {
-                  "password": {
-                    "type": "string"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Password updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Expired JWT token used or insufficient privilege",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal server error",
-            "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      }
-    },
-    "/api/identity/users/notifications/preferences": {
-      "put": {
-        "tags": [
-          "users"
-        ],
-        "operationId": "updateNotificationPreferences",
-        "summary": "Update notification preferences",
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "type": "object",
-                "additionalProperties": true
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Notification preferences updated",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": true
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request body or request param",
             "content": {
               "text/plain": {
                 "schema": {
@@ -2826,40 +2551,335 @@ const UserSchema: Record<string, unknown> = {
           }
         }
       },
-      "get": {
+      "post": {
         "tags": [
           "users"
         ],
-        "operationId": "getAvailableNotificationPreferences",
-        "summary": "Get available notification preferences",
+        "operationId": "updateUserPrefs",
+        "summary": "Update user preferences",
+        "description": "Merges the provided fields into the current user's preferences. Only the fields present in the request body are updated.",
+        "x-internal": [
+          "meshery"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "x-generate-db-helpers": true,
+                "type": "object",
+                "required": [
+                  "anonymousUsageStats",
+                  "anonymousPerfResults",
+                  "updated_at",
+                  "dashboardPreferences",
+                  "selectedOrganizationID",
+                  "selectedWorkspaceForOrganizations",
+                  "usersExtensionPreferences",
+                  "remoteProviderPreferences"
+                ],
+                "properties": {
+                  "meshAdapters": {
+                    "type": "array",
+                    "items": {
+                      "x-go-type": "Adapter",
+                      "type": "object",
+                      "description": "Placeholder for Adapter struct definition."
+                    }
+                  },
+                  "grafana": {
+                    "x-go-type": "Grafana",
+                    "type": "object",
+                    "properties": {
+                      "grafanaURL": {
+                        "type": "string"
+                      },
+                      "grafanaAPIKey": {
+                        "type": "string"
+                      },
+                      "selectedBoardsConfigs": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "board": {
+                              "type": "object",
+                              "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
+                            },
+                            "panels": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
+                              }
+                            },
+                            "templateVars": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "prometheus": {
+                    "x-go-type": "Prometheus",
+                    "type": "object",
+                    "properties": {
+                      "prometheusURL": {
+                        "type": "string"
+                      },
+                      "selectedPrometheusBoardsConfigs": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "board": {
+                              "type": "object",
+                              "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
+                            },
+                            "panels": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
+                              }
+                            },
+                            "templateVars": {
+                              "type": "array",
+                              "items": {
+                                "type": "string"
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  },
+                  "loadTestPrefs": {
+                    "x-go-type": "LoadTestPreferences",
+                    "type": "object",
+                    "properties": {
+                      "c": {
+                        "type": "integer",
+                        "description": "Concurrent requests"
+                      },
+                      "qps": {
+                        "type": "integer",
+                        "description": "Queries per second"
+                      },
+                      "t": {
+                        "type": "string",
+                        "description": "Duration"
+                      },
+                      "gen": {
+                        "type": "string",
+                        "description": "Load generator"
+                      }
+                    }
+                  },
+                  "anonymousUsageStats": {
+                    "type": "boolean"
+                  },
+                  "anonymousPerfResults": {
+                    "type": "boolean"
+                  },
+                  "updated_at": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "dashboardPreferences": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "selectedOrganizationID": {
+                    "type": "string"
+                  },
+                  "selectedWorkspaceForOrganizations": {
+                    "type": "object",
+                    "additionalProperties": {
+                      "type": "string"
+                    }
+                  },
+                  "usersExtensionPreferences": {
+                    "type": "object",
+                    "additionalProperties": true
+                  },
+                  "selectedK8sContexts": {
+                    "type": "array",
+                    "description": "Persisted selection of active Kubernetes context IDs",
+                    "items": {
+                      "type": "string"
+                    }
+                  },
+                  "remoteProviderPreferences": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        },
         "responses": {
           "200": {
-            "description": "Available notification preferences",
+            "description": "Updated user preferences",
             "content": {
               "application/json": {
                 "schema": {
+                  "x-generate-db-helpers": true,
                   "type": "object",
+                  "required": [
+                    "anonymousUsageStats",
+                    "anonymousPerfResults",
+                    "updated_at",
+                    "dashboardPreferences",
+                    "selectedOrganizationID",
+                    "selectedWorkspaceForOrganizations",
+                    "usersExtensionPreferences",
+                    "remoteProviderPreferences"
+                  ],
                   "properties": {
-                    "notification_preferences": {
+                    "meshAdapters": {
+                      "type": "array",
+                      "items": {
+                        "x-go-type": "Adapter",
+                        "type": "object",
+                        "description": "Placeholder for Adapter struct definition."
+                      }
+                    },
+                    "grafana": {
+                      "x-go-type": "Grafana",
+                      "type": "object",
+                      "properties": {
+                        "grafanaURL": {
+                          "type": "string"
+                        },
+                        "grafanaAPIKey": {
+                          "type": "string"
+                        },
+                        "selectedBoardsConfigs": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "board": {
+                                "type": "object",
+                                "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
+                              },
+                              "panels": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
+                                }
+                              },
+                              "templateVars": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "prometheus": {
+                      "x-go-type": "Prometheus",
+                      "type": "object",
+                      "properties": {
+                        "prometheusURL": {
+                          "type": "string"
+                        },
+                        "selectedPrometheusBoardsConfigs": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "board": {
+                                "type": "object",
+                                "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
+                              },
+                              "panels": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
+                                }
+                              },
+                              "templateVars": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "loadTestPrefs": {
+                      "x-go-type": "LoadTestPreferences",
+                      "type": "object",
+                      "properties": {
+                        "c": {
+                          "type": "integer",
+                          "description": "Concurrent requests"
+                        },
+                        "qps": {
+                          "type": "integer",
+                          "description": "Queries per second"
+                        },
+                        "t": {
+                          "type": "string",
+                          "description": "Duration"
+                        },
+                        "gen": {
+                          "type": "string",
+                          "description": "Load generator"
+                        }
+                      }
+                    },
+                    "anonymousUsageStats": {
+                      "type": "boolean"
+                    },
+                    "anonymousPerfResults": {
+                      "type": "boolean"
+                    },
+                    "updated_at": {
+                      "type": "string",
+                      "format": "date-time"
+                    },
+                    "dashboardPreferences": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "selectedOrganizationID": {
+                      "type": "string"
+                    },
+                    "selectedWorkspaceForOrganizations": {
                       "type": "object",
                       "additionalProperties": {
-                        "type": "object",
-                        "properties": {
-                          "category": {
-                            "type": "string"
-                          },
-                          "subcategory": {
-                            "type": "string"
-                          },
-                          "label": {
-                            "type": "string"
-                          },
-                          "name": {
-                            "type": "string"
-                          }
-                        },
-                        "additionalProperties": true
+                        "type": "string"
                       }
+                    },
+                    "usersExtensionPreferences": {
+                      "type": "object",
+                      "additionalProperties": true
+                    },
+                    "selectedK8sContexts": {
+                      "type": "array",
+                      "description": "Persisted selection of active Kubernetes context IDs",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "remoteProviderPreferences": {
+                      "type": "object",
+                      "additionalProperties": true
                     }
                   }
                 }
@@ -3037,67 +3057,6 @@ const UserSchema: Record<string, unknown> = {
         "bearerFormat": "JWT"
       }
     },
-    "requestBodies": {
-      "userPreferencePayload": {
-        "required": true,
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "additionalProperties": true
-            }
-          }
-        }
-      },
-      "bulkDeleteUsersPayload": {
-        "required": true,
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "additionalProperties": true
-            }
-          }
-        }
-      },
-      "userFeedbackPayload": {
-        "required": true,
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "additionalProperties": true
-            }
-          }
-        }
-      },
-      "updatePasswordPayload": {
-        "required": true,
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "properties": {
-                "password": {
-                  "type": "string"
-                }
-              }
-            }
-          }
-        }
-      },
-      "notificationPreferencePayload": {
-        "required": true,
-        "content": {
-          "application/json": {
-            "schema": {
-              "type": "object",
-              "additionalProperties": true
-            }
-          }
-        }
-      }
-    },
     "schemas": {
       "User": {
         "type": "object",
@@ -3256,6 +3215,7 @@ const UserSchema: Record<string, unknown> = {
               "json": "preferences",
               "yaml": "preferences"
             },
+            "x-generate-db-helpers": true,
             "type": "object",
             "required": [
               "anonymousUsageStats",
@@ -3395,6 +3355,13 @@ const UserSchema: Record<string, unknown> = {
               "usersExtensionPreferences": {
                 "type": "object",
                 "additionalProperties": true
+              },
+              "selectedK8sContexts": {
+                "type": "array",
+                "description": "Persisted selection of active Kubernetes context IDs",
+                "items": {
+                  "type": "string"
+                }
               },
               "remoteProviderPreferences": {
                 "type": "object",
@@ -3759,6 +3726,7 @@ const UserSchema: Record<string, unknown> = {
                     "json": "preferences",
                     "yaml": "preferences"
                   },
+                  "x-generate-db-helpers": true,
                   "type": "object",
                   "required": [
                     "anonymousUsageStats",
@@ -3898,6 +3866,13 @@ const UserSchema: Record<string, unknown> = {
                     "usersExtensionPreferences": {
                       "type": "object",
                       "additionalProperties": true
+                    },
+                    "selectedK8sContexts": {
+                      "type": "array",
+                      "description": "Persisted selection of active Kubernetes context IDs",
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "remoteProviderPreferences": {
                       "type": "object",
@@ -4265,6 +4240,7 @@ const UserSchema: Record<string, unknown> = {
                     "json": "preferences",
                     "yaml": "preferences"
                   },
+                  "x-generate-db-helpers": true,
                   "type": "object",
                   "required": [
                     "anonymousUsageStats",
@@ -4404,6 +4380,13 @@ const UserSchema: Record<string, unknown> = {
                     "usersExtensionPreferences": {
                       "type": "object",
                       "additionalProperties": true
+                    },
+                    "selectedK8sContexts": {
+                      "type": "array",
+                      "description": "Persisted selection of active Kubernetes context IDs",
+                      "items": {
+                        "type": "string"
+                      }
                     },
                     "remoteProviderPreferences": {
                       "type": "object",
@@ -4600,6 +4583,7 @@ const UserSchema: Record<string, unknown> = {
         }
       },
       "Preference": {
+        "x-generate-db-helpers": true,
         "type": "object",
         "required": [
           "anonymousUsageStats",
@@ -4739,6 +4723,13 @@ const UserSchema: Record<string, unknown> = {
           "usersExtensionPreferences": {
             "type": "object",
             "additionalProperties": true
+          },
+          "selectedK8sContexts": {
+            "type": "array",
+            "description": "Persisted selection of active Kubernetes context IDs",
+            "items": {
+              "type": "string"
+            }
           },
           "remoteProviderPreferences": {
             "type": "object",
@@ -4887,79 +4878,6 @@ const UserSchema: Record<string, unknown> = {
           "site",
           "link"
         ]
-      },
-      "AccountOverview": {
-        "type": "object",
-        "additionalProperties": true
-      },
-      "RecentActivity": {
-        "type": "object",
-        "additionalProperties": true
-      },
-      "RecentActivityPage": {
-        "type": "object",
-        "properties": {
-          "page": {
-            "type": "integer"
-          },
-          "page_size": {
-            "type": "integer"
-          },
-          "total_count": {
-            "type": "integer"
-          },
-          "data": {
-            "type": "array",
-            "items": {
-              "type": "object",
-              "additionalProperties": true
-            }
-          }
-        }
-      },
-      "AvailableNotificationPreference": {
-        "type": "object",
-        "properties": {
-          "category": {
-            "type": "string"
-          },
-          "subcategory": {
-            "type": "string"
-          },
-          "label": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "additionalProperties": true
-      },
-      "AvailableNotificationPreferences": {
-        "type": "object",
-        "properties": {
-          "notification_preferences": {
-            "type": "object",
-            "additionalProperties": {
-              "type": "object",
-              "properties": {
-                "category": {
-                  "type": "string"
-                },
-                "subcategory": {
-                  "type": "string"
-                },
-                "label": {
-                  "type": "string"
-                },
-                "name": {
-                  "type": "string"
-                }
-              },
-              "additionalProperties": true
-            }
-          }
-        }
       }
     }
   }

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -352,66 +352,13 @@ const injectedRtkApi = api
         query: () => ({ url: `/api/identity/users/profile` }),
         providesTags: ["User_users"],
       }),
-      updateUserPreference: build.mutation<UpdateUserPreferenceApiResponse, UpdateUserPreferenceApiArg>({
-        query: (queryArg) => ({ url: `/api/identity/users/preferences`, method: "PUT", body: queryArg.body }),
-        invalidatesTags: ["User_users"],
-      }),
-      deleteOwnAccount: build.mutation<DeleteOwnAccountApiResponse, DeleteOwnAccountApiArg>({
-        query: () => ({ url: `/api/identity/users/self`, method: "DELETE" }),
-        invalidatesTags: ["User_users"],
-      }),
-      bulkDeleteUsers: build.mutation<BulkDeleteUsersApiResponse, BulkDeleteUsersApiArg>({
-        query: (queryArg) => ({
-          url: `/api/identity/orgs/${queryArg.orgId}/users/bulk`,
-          method: "POST",
-          body: queryArg.body,
-        }),
-        invalidatesTags: ["User_users"],
-      }),
-      getProfileOverview: build.query<GetProfileOverviewApiResponse, GetProfileOverviewApiArg>({
-        query: () => ({ url: `/api/identity/users/profile/details` }),
+      getUserPrefs: build.query<GetUserPrefsApiResponse, GetUserPrefsApiArg>({
+        query: () => ({ url: `/api/user/prefs` }),
         providesTags: ["User_users"],
       }),
-      getUserActivity: build.query<GetUserActivityApiResponse, GetUserActivityApiArg>({
-        query: (queryArg) => ({
-          url: `/api/identity/users/${queryArg.userId}/profile/activity`,
-          params: {
-            page: queryArg.page,
-            pagesize: queryArg.pagesize,
-            order: queryArg.order,
-            filter: queryArg.filter,
-          },
-        }),
-        providesTags: ["User_users"],
-      }),
-      handleFeedbackFormSubmission: build.mutation<
-        HandleFeedbackFormSubmissionApiResponse,
-        HandleFeedbackFormSubmissionApiArg
-      >({
-        query: (queryArg) => ({ url: `/api/identity/users/notify/feedback`, method: "POST", body: queryArg.body }),
+      updateUserPrefs: build.mutation<UpdateUserPrefsApiResponse, UpdateUserPrefsApiArg>({
+        query: (queryArg) => ({ url: `/api/user/prefs`, method: "POST", body: queryArg.body }),
         invalidatesTags: ["User_users"],
-      }),
-      updateUsersPassword: build.mutation<UpdateUsersPasswordApiResponse, UpdateUsersPasswordApiArg>({
-        query: (queryArg) => ({ url: `/api/identity/users/password`, method: "POST", body: queryArg.body }),
-        invalidatesTags: ["User_users"],
-      }),
-      updateNotificationPreferences: build.mutation<
-        UpdateNotificationPreferencesApiResponse,
-        UpdateNotificationPreferencesApiArg
-      >({
-        query: (queryArg) => ({
-          url: `/api/identity/users/notifications/preferences`,
-          method: "PUT",
-          body: queryArg.body,
-        }),
-        invalidatesTags: ["User_users"],
-      }),
-      getAvailableNotificationPreferences: build.query<
-        GetAvailableNotificationPreferencesApiResponse,
-        GetAvailableNotificationPreferencesApiArg
-      >({
-        query: () => ({ url: `/api/identity/users/notifications/preferences` }),
-        providesTags: ["User_users"],
       }),
     }),
     overrideExisting: false,
@@ -3818,6 +3765,8 @@ export type GetUsersForOrgApiResponse = /** status 200 Paginated list of organiz
       usersExtensionPreferences: {
         [key: string]: any;
       };
+      /** Persisted selection of active Kubernetes context IDs */
+      selectedK8sContexts?: string[];
       remoteProviderPreferences: {
         [key: string]: any;
       };
@@ -3954,6 +3903,8 @@ export type GetUsersApiResponse = /** status 200 Paginated list of public users 
       usersExtensionPreferences: {
         [key: string]: any;
       };
+      /** Persisted selection of active Kubernetes context IDs */
+      selectedK8sContexts?: string[];
       remoteProviderPreferences: {
         [key: string]: any;
       };
@@ -4082,6 +4033,8 @@ export type GetUserProfileByIdApiResponse = /** status 200 User profile for the 
     usersExtensionPreferences: {
       [key: string]: any;
     };
+    /** Persisted selection of active Kubernetes context IDs */
+    selectedK8sContexts?: string[];
     remoteProviderPreferences: {
       [key: string]: any;
     };
@@ -4201,6 +4154,8 @@ export type GetUserApiResponse = /** status 200 Current user profile and role co
     usersExtensionPreferences: {
       [key: string]: any;
     };
+    /** Persisted selection of active Kubernetes context IDs */
+    selectedK8sContexts?: string[];
     remoteProviderPreferences: {
       [key: string]: any;
     };
@@ -4245,88 +4200,159 @@ export type GetUserApiResponse = /** status 200 Current user profile and role co
   };
 };
 export type GetUserApiArg = void;
-export type UpdateUserPreferenceApiResponse = /** status 201 Preferences updated */ {
-  [key: string]: any;
-};
-export type UpdateUserPreferenceApiArg = {
-  body: {
+export type GetUserPrefsApiResponse = /** status 200 User preferences */ {
+  meshAdapters?: object[];
+  grafana?: {
+    grafanaURL?: string;
+    grafanaAPIKey?: string;
+    selectedBoardsConfigs?: {
+      /** Placeholder for GrafanaBoard definition (define fields as needed) */
+      board?: object;
+      panels?: object[];
+      templateVars?: string[];
+    }[];
+  };
+  prometheus?: {
+    prometheusURL?: string;
+    selectedPrometheusBoardsConfigs?: {
+      /** Placeholder for GrafanaBoard definition (define fields as needed) */
+      board?: object;
+      panels?: object[];
+      templateVars?: string[];
+    }[];
+  };
+  loadTestPrefs?: {
+    /** Concurrent requests */
+    c?: number;
+    /** Queries per second */
+    qps?: number;
+    /** Duration */
+    t?: string;
+    /** Load generator */
+    gen?: string;
+  };
+  anonymousUsageStats: boolean;
+  anonymousPerfResults: boolean;
+  updated_at: string;
+  dashboardPreferences: {
+    [key: string]: any;
+  };
+  selectedOrganizationID: string;
+  selectedWorkspaceForOrganizations: {
+    [key: string]: string;
+  };
+  usersExtensionPreferences: {
+    [key: string]: any;
+  };
+  /** Persisted selection of active Kubernetes context IDs */
+  selectedK8sContexts?: string[];
+  remoteProviderPreferences: {
     [key: string]: any;
   };
 };
-export type DeleteOwnAccountApiResponse = /** status 201 Account deleted */ {
-  [key: string]: any;
-};
-export type DeleteOwnAccountApiArg = void;
-export type BulkDeleteUsersApiResponse = /** status 201 Users deleted */ {
-  [key: string]: any;
-};
-export type BulkDeleteUsersApiArg = {
-  /** Organization ID */
-  orgId: string;
-  body: {
+export type GetUserPrefsApiArg = void;
+export type UpdateUserPrefsApiResponse = /** status 200 Updated user preferences */ {
+  meshAdapters?: object[];
+  grafana?: {
+    grafanaURL?: string;
+    grafanaAPIKey?: string;
+    selectedBoardsConfigs?: {
+      /** Placeholder for GrafanaBoard definition (define fields as needed) */
+      board?: object;
+      panels?: object[];
+      templateVars?: string[];
+    }[];
+  };
+  prometheus?: {
+    prometheusURL?: string;
+    selectedPrometheusBoardsConfigs?: {
+      /** Placeholder for GrafanaBoard definition (define fields as needed) */
+      board?: object;
+      panels?: object[];
+      templateVars?: string[];
+    }[];
+  };
+  loadTestPrefs?: {
+    /** Concurrent requests */
+    c?: number;
+    /** Queries per second */
+    qps?: number;
+    /** Duration */
+    t?: string;
+    /** Load generator */
+    gen?: string;
+  };
+  anonymousUsageStats: boolean;
+  anonymousPerfResults: boolean;
+  updated_at: string;
+  dashboardPreferences: {
+    [key: string]: any;
+  };
+  selectedOrganizationID: string;
+  selectedWorkspaceForOrganizations: {
+    [key: string]: string;
+  };
+  usersExtensionPreferences: {
+    [key: string]: any;
+  };
+  /** Persisted selection of active Kubernetes context IDs */
+  selectedK8sContexts?: string[];
+  remoteProviderPreferences: {
     [key: string]: any;
   };
 };
-export type GetProfileOverviewApiResponse = /** status 200 User account overview */ {
-  [key: string]: any;
-};
-export type GetProfileOverviewApiArg = void;
-export type GetUserActivityApiResponse = /** status 200 User recent activity */ {
-  page?: number;
-  page_size?: number;
-  total_count?: number;
-  data?: {
-    [key: string]: any;
-  }[];
-};
-export type GetUserActivityApiArg = {
-  /** User ID */
-  userId: string;
-  /** Get responses by page */
-  page?: string;
-  /** Get responses by pagesize */
-  pagesize?: string;
-  /** Get ordered responses */
-  order?: string;
-  /** Get filtered reponses */
-  filter?: string;
-};
-export type HandleFeedbackFormSubmissionApiResponse = /** status 201 Feedback submitted */ {
-  [key: string]: any;
-};
-export type HandleFeedbackFormSubmissionApiArg = {
+export type UpdateUserPrefsApiArg = {
   body: {
-    [key: string]: any;
-  };
-};
-export type UpdateUsersPasswordApiResponse = /** status 200 Password updated */ {
-  [key: string]: any;
-};
-export type UpdateUsersPasswordApiArg = {
-  body: {
-    password?: string;
-  };
-};
-export type UpdateNotificationPreferencesApiResponse = /** status 200 Notification preferences updated */ {
-  [key: string]: any;
-};
-export type UpdateNotificationPreferencesApiArg = {
-  body: {
-    [key: string]: any;
-  };
-};
-export type GetAvailableNotificationPreferencesApiResponse = /** status 200 Available notification preferences */ {
-  notification_preferences?: {
-    [key: string]: {
-      category?: string;
-      subcategory?: string;
-      label?: string;
-      name?: string;
+    meshAdapters?: object[];
+    grafana?: {
+      grafanaURL?: string;
+      grafanaAPIKey?: string;
+      selectedBoardsConfigs?: {
+        /** Placeholder for GrafanaBoard definition (define fields as needed) */
+        board?: object;
+        panels?: object[];
+        templateVars?: string[];
+      }[];
+    };
+    prometheus?: {
+      prometheusURL?: string;
+      selectedPrometheusBoardsConfigs?: {
+        /** Placeholder for GrafanaBoard definition (define fields as needed) */
+        board?: object;
+        panels?: object[];
+        templateVars?: string[];
+      }[];
+    };
+    loadTestPrefs?: {
+      /** Concurrent requests */
+      c?: number;
+      /** Queries per second */
+      qps?: number;
+      /** Duration */
+      t?: string;
+      /** Load generator */
+      gen?: string;
+    };
+    anonymousUsageStats: boolean;
+    anonymousPerfResults: boolean;
+    updated_at: string;
+    dashboardPreferences: {
+      [key: string]: any;
+    };
+    selectedOrganizationID: string;
+    selectedWorkspaceForOrganizations: {
+      [key: string]: string;
+    };
+    usersExtensionPreferences: {
+      [key: string]: any;
+    };
+    /** Persisted selection of active Kubernetes context IDs */
+    selectedK8sContexts?: string[];
+    remoteProviderPreferences: {
       [key: string]: any;
     };
   };
 };
-export type GetAvailableNotificationPreferencesApiArg = void;
 export const {
   useGetConnectionsQuery,
   useRegisterConnectionMutation,
@@ -4376,13 +4402,6 @@ export const {
   useGetUsersQuery,
   useGetUserProfileByIdQuery,
   useGetUserQuery,
-  useUpdateUserPreferenceMutation,
-  useDeleteOwnAccountMutation,
-  useBulkDeleteUsersMutation,
-  useGetProfileOverviewQuery,
-  useGetUserActivityQuery,
-  useHandleFeedbackFormSubmissionMutation,
-  useUpdateUsersPasswordMutation,
-  useUpdateNotificationPreferencesMutation,
-  useGetAvailableNotificationPreferencesQuery,
+  useGetUserPrefsQuery,
+  useUpdateUserPrefsMutation,
 } = injectedRtkApi;


### PR DESCRIPTION
## Summary
- Adds `selectedK8sContexts` (string array) to the `Preference` schema, enabling persistence of the user's Kubernetes context selection across sessions
- Adds `GET /api/user/prefs` and `POST /api/user/prefs` endpoints (meshery-only via `x-internal`) so RTK Query hooks (`useGetUserPrefsQuery`, `useUpdateUserPrefsMutation`) are auto-generated
- Regenerates Go models, RTK Query clients, and TypeScript types

## Test plan
- [ ] Verify generated Go model includes `SelectedK8sContexts *[]string` field
- [ ] Verify `useGetUserPrefsQuery` and `useUpdateUserPrefsMutation` are exported from `mesheryApi`
- [ ] Integration tested in companion meshery PR for persisting K8s context selection