### PR TITLE
feat: add Rule 42 — validate string format values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ Every element in the API has exactly one correct casing. The table below is the 
 
 ## Per-Property Validation Constraints
 
-The schema validator (`build/validate-schemas.js`) enforces per-property constraints as advisory rules (Rules 37–41). These do not block CI but are reported on `--warn` runs and should be resolved in new schemas.
+The schema validator (`build/validate-schemas.js`) enforces per-property constraints as advisory rules (Rules 37–42). These do not block CI but are reported on `--warn` runs and should be resolved in new schemas.
 
 | Rule | What it checks |
 |---|---|
@@ -172,6 +172,7 @@ The schema validator (`build/validate-schemas.js`) enforces per-property constra
 | 39 | Numeric properties have `minimum`, `maximum`, or `const` |
 | 40 | ID-like properties (`id`, `*_id`, `*Id`) have `format: uuid` or `$ref` to a UUID type |
 | 41 | Page-size properties (`page_size`, `pagesize`, `pageSize`) have `minimum: 1` |
+| 42 | `format` values must be from the known OpenAPI 3.0 / JSON Schema set (e.g., `date-time`, `email`, `uri`, `uuid`) |
 
 ### `x-id-format: external` — exempting non-UUID IDs
 

--- a/build/lib/property-constraint-validation.js
+++ b/build/lib/property-constraint-validation.js
@@ -148,11 +148,12 @@ function validateFormatValues(issues, properties, scope) {
     if (!propDef || typeof propDef !== "object") continue;
     if (propDef.$ref) continue;
     if (propDef.format === undefined) continue;
+    if (typeof propDef.format !== "string") continue;
 
     if (!KNOWN_FORMATS.has(propDef.format)) {
       issues.push(
         `${formatContext(scope)}property "${propName}" uses unknown format "${propDef.format}". ` +
-          `Known formats: ${KNOWN_FORMATS_LIST}.`,
+          `Use a standard OpenAPI 3.0 / JSON Schema format (e.g. date-time, email, uri, uuid, int32).`,
       );
     }
   }

--- a/build/lib/property-constraint-validation.js
+++ b/build/lib/property-constraint-validation.js
@@ -13,6 +13,7 @@ const KNOWN_FORMATS = new Set([
   "idn-email",
   "uri",
   "uri-reference",
+  "uri-template",
   "iri",
   "iri-reference",
   "uuid",
@@ -32,6 +33,7 @@ const KNOWN_FORMATS = new Set([
   "relative-json-pointer",
   "regex",
 ]);
+const KNOWN_FORMATS_LIST = [...KNOWN_FORMATS].join(", ");
 
 function formatContext(scope) {
   return scope ? `Schema "${scope}" — ` : "";
@@ -150,7 +152,7 @@ function validateFormatValues(issues, properties, scope) {
     if (!KNOWN_FORMATS.has(propDef.format)) {
       issues.push(
         `${formatContext(scope)}property "${propName}" uses unknown format "${propDef.format}". ` +
-          `Known formats: ${[...KNOWN_FORMATS].join(", ")}.`,
+          `Known formats: ${KNOWN_FORMATS_LIST}.`,
       );
     }
   }

--- a/build/lib/property-constraint-validation.js
+++ b/build/lib/property-constraint-validation.js
@@ -4,6 +4,35 @@ const ID_PROPERTY_PATTERN = /(?:^id$|_id$|Id$|ID$)/;
 const PAGE_SIZE_NAMES = new Set(["page_size", "pagesize", "pageSize"]);
 const COMBINERS = ["allOf", "oneOf", "anyOf"];
 
+// Known format values from OpenAPI 3.0 / JSON Schema.
+const KNOWN_FORMATS = new Set([
+  "date-time",
+  "date",
+  "time",
+  "email",
+  "idn-email",
+  "uri",
+  "uri-reference",
+  "iri",
+  "iri-reference",
+  "uuid",
+  "ipv4",
+  "ipv6",
+  "hostname",
+  "idn-hostname",
+  "byte",
+  "binary",
+  "password",
+  "int32",
+  "int64",
+  "float",
+  "double",
+  "duration",
+  "json-pointer",
+  "relative-json-pointer",
+  "regex",
+]);
+
 function formatContext(scope) {
   return scope ? `Schema "${scope}" — ` : "";
 }
@@ -110,6 +139,23 @@ function validatePageSizeMinimum(issues, properties, scope) {
   }
 }
 
+function validateFormatValues(issues, properties, scope) {
+  if (!properties || typeof properties !== "object") return;
+
+  for (const [propName, propDef] of Object.entries(properties)) {
+    if (!propDef || typeof propDef !== "object") continue;
+    if (propDef.$ref) continue;
+    if (propDef.format === undefined) continue;
+
+    if (!KNOWN_FORMATS.has(propDef.format)) {
+      issues.push(
+        `${formatContext(scope)}property "${propName}" uses unknown format "${propDef.format}". ` +
+          `Known formats: ${[...KNOWN_FORMATS].join(", ")}.`,
+      );
+    }
+  }
+}
+
 function nextScope(scope, suffix) {
   return scope ? `${scope}.${suffix}` : suffix;
 }
@@ -123,6 +169,7 @@ function walkPropertyConstraintTree(schema, scope, issues) {
     validateNumericBounds(issues, schema.properties, scope);
     validateIdFormat(issues, schema.properties, scope);
     validatePageSizeMinimum(issues, schema.properties, scope);
+    validateFormatValues(issues, schema.properties, scope);
 
     for (const [propName, propDef] of Object.entries(schema.properties)) {
       walkPropertyConstraintTree(propDef, nextScope(scope, propName), issues);

--- a/build/validate-schemas.js
+++ b/build/validate-schemas.js
@@ -55,7 +55,7 @@
  *   Rule 40 — String properties named *id/*Id must have format: uuid or $ref to a UUID schema.
  *              Skips non-string types and properties annotated with `x-id-format: external`.
  *   Rule 41 — Page-size properties (page_size, pagesize) must have minimum: 1.
- *   Rule 42 — String `format` values must be from the known OpenAPI 3.0 / JSON Schema set
+ *   Rule 42 — `format` values must be from the known OpenAPI 3.0 / JSON Schema set
  *              (date-time, date, email, uri, uuid, ipv4, ipv6, hostname, byte, binary, password, etc.).
  *
  * USAGE:

--- a/build/validate-schemas.js
+++ b/build/validate-schemas.js
@@ -55,6 +55,8 @@
  *   Rule 40 — String properties named *id/*Id must have format: uuid or $ref to a UUID schema.
  *              Skips non-string types and properties annotated with `x-id-format: external`.
  *   Rule 41 — Page-size properties (page_size, pagesize) must have minimum: 1.
+ *   Rule 42 — String `format` values must be from the known OpenAPI 3.0 / JSON Schema set
+ *              (date-time, date, email, uri, uuid, ipv4, ipv6, hostname, byte, binary, password, etc.).
  *
  * USAGE:
  *   node build/validate-schemas.js          # exits 0 if no blocking violations found

--- a/build/validate-schemas.js
+++ b/build/validate-schemas.js
@@ -2242,7 +2242,7 @@ function validateResponseText(filePath, doc) {
   }
 }
 
-// ─── Rules 37–41: property-level validation constraints ─────────────────────
+// ─── Rules 37–42: property-level validation constraints ─────────────────────
 
 function validatePropertyConstraints(filePath, doc) {
   for (const issue of collectPropertyConstraintIssues(doc)) {
@@ -2314,7 +2314,7 @@ function walk(dir) {
             if (entityDoc.components?.schemas) {
               validateGoTypeImportConsistency(entityPath, entityDoc);
             }
-            // Rules 37–41: property-level validation constraints
+            // Rules 37–42: property-level validation constraints
             validatePropertyConstraints(entityPath, entityDoc);
           }
         }
@@ -2367,7 +2367,7 @@ function walk(dir) {
           collectSchemaFingerprints(apiYml, doc);
           validateResponseSchemaRefs(apiYml, doc);
           validateResponseText(apiYml, doc);
-          // Rules 37–41: property-level validation constraints
+          // Rules 37–42: property-level validation constraints
           validatePropertyConstraints(apiYml, doc);
         }
       }

--- a/tests/validate-schemas-property-constraints.test.js
+++ b/tests/validate-schemas-property-constraints.test.js
@@ -178,7 +178,7 @@ test("accepts known format values without issues", () => {
     },
   });
 
-  assert.equal(issues.some((issue) => issue.includes("unknown format")), false);
+  assert.equal(issues.length, 0, "expected no issues for known formats, got: " + JSON.stringify(issues));
 });
 
 test("skips format validation for $ref properties", () => {
@@ -198,7 +198,7 @@ test("skips format validation for $ref properties", () => {
     },
   });
 
-  assert.equal(issues.some((issue) => issue.includes("unknown format")), false);
+  assert.equal(issues.length, 0, "expected no issues for $ref properties, got: " + JSON.stringify(issues));
 });
 
 test("does not treat arbitrary lowercase id suffixes as ID fields", () => {

--- a/tests/validate-schemas-property-constraints.test.js
+++ b/tests/validate-schemas-property-constraints.test.js
@@ -129,6 +129,78 @@ test("recursively validates nested object, array item, combiner, and additionalP
 });
 
 
+test("flags unknown format values as issues", () => {
+  const issues = collectPropertyConstraintIssues({
+    components: {
+      schemas: {
+        Example: {
+          type: "object",
+          properties: {
+            createdAt: {
+              type: "string",
+              description: "Creation timestamp.",
+              format: "datetime",
+            },
+          },
+        },
+      },
+    },
+  });
+
+  assert.ok(issues.some((issue) => issue.includes('property "createdAt" uses unknown format "datetime"')));
+});
+
+test("accepts known format values without issues", () => {
+  const issues = collectPropertyConstraintIssues({
+    components: {
+      schemas: {
+        Example: {
+          type: "object",
+          properties: {
+            createdAt: {
+              type: "string",
+              description: "Creation timestamp.",
+              format: "date-time",
+            },
+            email: {
+              type: "string",
+              description: "User email.",
+              format: "email",
+            },
+            homepage: {
+              type: "string",
+              description: "Homepage URL.",
+              format: "uri",
+            },
+          },
+        },
+      },
+    },
+  });
+
+  assert.equal(issues.some((issue) => issue.includes("unknown format")), false);
+});
+
+test("skips format validation for $ref properties", () => {
+  const issues = collectPropertyConstraintIssues({
+    components: {
+      schemas: {
+        Example: {
+          type: "object",
+          properties: {
+            userId: {
+              $ref: "#/components/schemas/Uuid",
+              format: "custom-ref-format",
+            },
+          },
+        },
+      },
+    },
+  });
+
+  assert.equal(issues.some((issue) => issue.includes("unknown format")), false);
+});
+
 test("does not treat arbitrary lowercase id suffixes as ID fields", () => {
   const issues = collectPropertyConstraintIssues({
     components: {


### PR DESCRIPTION
## Summary
- Adds advisory Rule 42 to the schema validator that checks `format` values against the known OpenAPI 3.0 / JSON Schema set (`date-time`, `date`, `email`, `uri`, `uuid`, `ipv4`, `ipv6`, `hostname`, `byte`, `binary`, `password`, etc.)
- Warns on unknown format values which may be typos (e.g., `datetime` instead of `date-time`)
- Skips properties that use `$ref` (format is inherited from the referenced schema)

Closes #722

## Changes
- `build/lib/property-constraint-validation.js` — added `KNOWN_FORMATS` set and `validateFormatValues()` function, wired into the property constraint tree walker
- `build/validate-schemas.js` — added Rule 42 to the header comment
- `AGENTS.md` — updated the advisory rules table to include Rule 42
- `tests/validate-schemas-property-constraints.test.js` — added 3 test cases (unknown format flagged, known formats accepted, `$ref` properties skipped)

## Test plan
- [x] `node --test tests/validate-schemas-property-constraints.test.js` — all 8 tests pass
- [x] `node build/validate-schemas.js` — no blocking violations