### PR TITLE
docs: align rule numbering with CLAUDE.md

### DIFF
--- a/validation/audit.go
+++ b/validation/audit.go
@@ -190,7 +190,7 @@ func auditEntitySchemas(constructDir string, opts AuditOptions,
 			addViolation(result, v, baseline)
 		}
 
-		// Rules 36–41: property-constraint advisories.
+		// Rules 37–41: property-constraint advisories.
 		for _, v := range checkEntityPropertyConstraints(relPath, entity, opts) {
 			addViolation(result, v, baseline)
 		}
@@ -247,7 +247,7 @@ func auditAPISpec(apiYmlPath, constructDir string, opts AuditOptions,
 		checkRule17, checkRule19, checkRule21, checkRule23,
 		checkRule24, checkRule25, checkRule26, checkRule27,
 		checkRule28, checkRule30, checkRule31, checkRule35,
-		checkRule37,
+		checkRule36,
 	}
 
 	for _, check := range ruleChecks {
@@ -276,7 +276,7 @@ func auditAPISpec(apiYmlPath, constructDir string, opts AuditOptions,
 		addViolation(result, v, baseline)
 	}
 
-	// Rules 36-41: property constraints.
+	// Rules 37-41: property constraints.
 	for _, v := range checkPropertyConstraints(relPath, doc, opts) {
 		addViolation(result, v, baseline)
 	}

--- a/validation/rules_design.go
+++ b/validation/rules_design.go
@@ -479,9 +479,9 @@ func checkRule31(filePath string, doc *openapi3.T, opts AuditOptions) []Violatio
 	return out
 }
 
-// --- Rule 37: Operations must have tags ---
+// --- Rule 36: Operations must have tags ---
 
-func checkRule37(filePath string, doc *openapi3.T, opts AuditOptions) []Violation {
+func checkRule36(filePath string, doc *openapi3.T, opts AuditOptions) []Violation {
 	if doc == nil || doc.Paths == nil {
 		return nil
 	}
@@ -500,7 +500,7 @@ func checkRule37(filePath string, doc *openapi3.T, opts AuditOptions) []Violatio
 			}
 			label := fmt.Sprintf("%s %s", strings.ToUpper(method), path)
 			if len(op.Tags) == 0 {
-				out = append(out, Violation{File: filePath, Message: fmt.Sprintf("%s — operation is missing `tags`.", label), Severity: classifyDesignIssue(opts), RuleNumber: 37})
+				out = append(out, Violation{File: filePath, Message: fmt.Sprintf("%s — operation is missing `tags`.", label), Severity: classifyDesignIssue(opts), RuleNumber: 36})
 				continue
 			}
 			if len(declaredTags) > 0 {
@@ -508,7 +508,7 @@ func checkRule37(filePath string, doc *openapi3.T, opts AuditOptions) []Violatio
 					if !declaredTags[tag] {
 						out = append(out, Violation{File: filePath,
 							Message:  fmt.Sprintf(`%s — operation tag %q is not declared in the document-root tags section.`, label, tag),
-							Severity: classifyDesignIssue(opts), RuleNumber: 37})
+							Severity: classifyDesignIssue(opts), RuleNumber: 36})
 					}
 				}
 			}

--- a/validation/rules_entity.go
+++ b/validation/rules_entity.go
@@ -354,12 +354,12 @@ func walkEntityPropertyConstraints(filePath, scope string, properties map[string
 
 		fullScope := scope + "." + propName
 
-		// Rule 36: description.
+		// Rule 37: description.
 		rawDesc, _ := rawMapString(raw, "description")
 		if propDef.Description == "" && rawDesc == "" {
 			*out = append(*out, Violation{File: filePath,
 				Message:  fmt.Sprintf(`Entity property %q is missing a description.`, propName),
-				Severity: classifyDesignIssue(opts), RuleNumber: 36})
+				Severity: classifyDesignIssue(opts), RuleNumber: 37})
 		}
 
 		// Rule 38: string constraints. A `const` value is inherently

--- a/validation/rules_property.go
+++ b/validation/rules_property.go
@@ -131,11 +131,11 @@ func walkSchemaConstraints(filePath, scope string, schema *openapi3.Schema, opts
 			}
 			fullScope += propName
 
-			// Rule 36: description.
+			// Rule 37: description.
 			if propRef.Ref == "" && p.Description == "" {
 				*out = append(*out, Violation{File: filePath,
 					Message:  fmt.Sprintf(`Schema %q — property %q is missing a description.`, scope, propName),
-					Severity: classifyDesignIssue(opts), RuleNumber: 36})
+					Severity: classifyDesignIssue(opts), RuleNumber: 37})
 			}
 
 			// Rule 38: string constraints. A `const` value is inherently

--- a/validation/rules_property_test.go
+++ b/validation/rules_property_test.go
@@ -272,15 +272,15 @@ func TestCheckEntityPropertyConstraints_RecursesIntoNestedProperties(t *testing.
 		},
 	}
 	vs := checkEntityPropertyConstraints("entity.yaml", entity, AuditOptions{})
-	foundR36 := false
+	foundR37 := false
 	for _, v := range vs {
-		if v.RuleNumber == 36 && contains(v.Message, "label") {
-			foundR36 = true
+		if v.RuleNumber == 37 && contains(v.Message, "label") {
+			foundR37 = true
 			break
 		}
 	}
-	if !foundR36 {
-		t.Errorf("expected Rule 36 violation for nested property 'label' without description; got %d violations", len(vs))
+	if !foundR37 {
+		t.Errorf("expected Rule 37 violation for nested property 'label' without description; got %d violations", len(vs))
 		for _, v := range vs {
 			t.Logf("  violation: %s", v.Message)
 		}


### PR DESCRIPTION
This PR aligns the rule numbering in the validator with the canonical definitions in CLAUDE.md.
- Rule 36 (tags) moved to 36 (from 37).
- - Rule 37 (description) moved to 37 (from 36).
This PR fixes #745.