### PR TITLE
feat(schemas): add MeshModel component and relationship summary filter schemas

### DIFF
--- a/schemas/constructs/v1beta2/component/api.yml
+++ b/schemas/constructs/v1beta2/component/api.yml
@@ -108,9 +108,8 @@ components:
           default: "enabled"
           maxLength: 50
         annotations:
-          type: string
+          type: boolean
           description: "Filter by annotations."
-          enum: ["true", "false"]
         registrant:
           type: string
           description: "Filter by registrant name."
@@ -119,5 +118,5 @@ components:
           type: array
           items:
             type: string
-            enum: ["by_model", "by_category", "by_registrant"]
+            enum: ["byModel", "byCategory", "byRegistrant"]
           description: "Criteria for grouping the summary."

--- a/schemas/constructs/v1beta2/component/api.yml
+++ b/schemas/constructs/v1beta2/component/api.yml
@@ -39,3 +39,85 @@ components:
         - version
         - kind
         - schema
+
+    ComponentGroupEntry:
+      type: object
+      description: "A grouping of components by a specific key (e.g., model name)."
+      required:
+        - key
+        - count
+      properties:
+        key:
+          type: string
+          description: "The name of the group."
+          maxLength: 500
+        count:
+          type: integer
+          format: int32
+          description: "The number of components in this group."
+          minimum: 0
+
+    ComponentSummary:
+      type: object
+      description: "Summary of components grouped by various criteria."
+      required:
+        - total
+      additionalProperties: false
+      properties:
+        total:
+          type: integer
+          format: int64
+          description: "Total number of components."
+          minimum: 0
+        byModel:
+          type: array
+          items:
+            $ref: "#/components/schemas/ComponentGroupEntry"
+          description: "Components grouped by model."
+        byCategory:
+          type: array
+          items:
+            $ref: "#/components/schemas/ComponentGroupEntry"
+          description: "Components grouped by category."
+        byRegistrant:
+          type: array
+          items:
+            $ref: "#/components/schemas/ComponentGroupEntry"
+          description: "Components grouped by registrant."
+
+    ComponentSummaryFilter:
+      type: object
+      description: "Filter parameters for component summary."
+      additionalProperties: false
+      properties:
+        modelName:
+          type: string
+          description: "Filter by model name."
+          maxLength: 500
+        categoryName:
+          type: string
+          description: "Filter by category name."
+          maxLength: 500
+        version:
+          type: string
+          description: "Filter by version."
+          maxLength: 100
+        status:
+          type: string
+          description: "Filter by status (e.g., enabled, disabled)."
+          default: "enabled"
+          maxLength: 50
+        annotations:
+          type: string
+          description: "Filter by annotations."
+          enum: ["true", "false"]
+        registrant:
+          type: string
+          description: "Filter by registrant name."
+          maxLength: 500
+        include:
+          type: array
+          items:
+            type: string
+            enum: ["by_model", "by_category", "by_registrant"]
+          description: "Criteria for grouping the summary."

--- a/schemas/constructs/v1beta2/relationship/api.yml
+++ b/schemas/constructs/v1beta2/relationship/api.yml
@@ -645,5 +645,5 @@ components:
           type: array
           items:
             type: string
-            enum: ["by_model", "by_kind", "by_type", "by_subtype"]
+            enum: ["byModel", "byKind", "byType", "bySubType"]
           description: "Criteria for grouping the summary."

--- a/schemas/constructs/v1beta2/relationship/api.yml
+++ b/schemas/constructs/v1beta2/relationship/api.yml
@@ -556,3 +556,94 @@ components:
           description: Indicates whether the relationship should be treated as a logical representation only
           x-oapi-codegen-extra-tags:
             json: "isAnnotation"
+
+    RelationshipGroupEntry:
+      type: object
+      description: "A grouping of relationships by a specific key (e.g., model name)."
+      required:
+        - key
+        - count
+      properties:
+        key:
+          type: string
+          description: "The name of the group."
+          maxLength: 500
+        count:
+          type: integer
+          format: int32
+          description: "The number of relationships in this group."
+          minimum: 0
+
+    RelationshipSummary:
+      type: object
+      description: "Summary of relationships grouped by various criteria."
+      required:
+        - total
+      additionalProperties: false
+      properties:
+        total:
+          type: integer
+          format: int64
+          description: "Total number of relationships."
+          minimum: 0
+        byModel:
+          type: array
+          items:
+            $ref: "#/components/schemas/RelationshipGroupEntry"
+          description: "Relationships grouped by model."
+        byKind:
+          type: array
+          items:
+            $ref: "#/components/schemas/RelationshipGroupEntry"
+          description: "Relationships grouped by kind."
+        byType:
+          type: array
+          items:
+            $ref: "#/components/schemas/RelationshipGroupEntry"
+          description: "Relationships grouped by type."
+        bySubType:
+          type: array
+          items:
+            $ref: "#/components/schemas/RelationshipGroupEntry"
+          description: "Relationships grouped by sub-type."
+
+    RelationshipSummaryFilter:
+      type: object
+      description: "Filter parameters for relationship summary."
+      additionalProperties: false
+      properties:
+        kind:
+          type: string
+          description: "Filter by relationship kind."
+          maxLength: 255
+        greedy:
+          type: boolean
+          description: "Filter by greedy status."
+          default: false
+        subType:
+          type: string
+          description: "Filter by sub-type."
+          maxLength: 255
+        relationshipType:
+          type: string
+          description: "Filter by relationship type."
+          maxLength: 255
+        version:
+          type: string
+          description: "Filter by version."
+          maxLength: 100
+        modelName:
+          type: string
+          description: "Filter by model name."
+          maxLength: 500
+        status:
+          type: string
+          description: "Filter by status (e.g., enabled, disabled)."
+          default: "enabled"
+          maxLength: 50
+        include:
+          type: array
+          items:
+            type: string
+            enum: ["by_model", "by_kind", "by_type", "by_subtype"]
+          description: "Criteria for grouping the summary."


### PR DESCRIPTION
This PR introduces OpenAPI schemas for MeshModel component and relationship summary filters. 
- Added ComponentSummaryFilter, ComponentSummary, and ComponentGroupEntry to v1beta2/component/api.yml.
- Added RelationshipSummaryFilter, RelationshipSummary, and RelationshipGroupEntry to v1beta2/relationship/api.yml.
Fixes #747