### PR TITLE
refactor(validation): replace hardcoded casing list with regex detection

### DIFF
--- a/validation/casing.go
+++ b/validation/casing.go
@@ -37,6 +37,9 @@ var (
 var lowercaseSuffixExemptions = map[string]bool{
 	"grid": true, "uuid": true, "mid": true, "valid": true,
 	"acid": true, "solid": true, "fluid": true,
+	"invalid": true, "hybrid": true, "rapid": true, "liquid": true,
+	"void": true, "paid": true, "said": true, "avoid": true,
+	"rigid": true, "vivid": true, "curl": true,
 }
 
 
@@ -94,7 +97,8 @@ func HasScreamingIDToken(s string) bool {
 // in all-lowercase, which usually indicates it is a compound word that should
 // be camelCased (e.g., "userid" → "userId").
 func HasLowercaseSuffix(s string) bool {
-	if lowercaseSuffixExemptions[strings.ToLower(s)] {
+	lower := strings.ToLower(s)
+	if lowercaseSuffixExemptions[lower] || lowercaseSuffixExemptions[strings.TrimSuffix(lower, "s")] {
 		return false
 	}
 	return lowercaseSuffixPattern.MatchString(s)

--- a/validation/casing.go
+++ b/validation/casing.go
@@ -32,18 +32,13 @@ var (
 	lowercaseSuffixPattern = regexp.MustCompile(`[a-z](id|ids|url|uri)$`)
 )
 
-// knownLowercaseSuffixViolations lists compound property names that end in
-// a known suffix ("id", "url", "uri") but are incorrectly all-lowercase.
-var knownLowercaseSuffixViolations = map[string]bool{
-	"userid": true, "orgid": true, "teamid": true, "workspaceid": true,
-	"modelid": true, "designid": true, "connectionid": true,
-	"environmentid": true, "credentialid": true, "subscriptionid": true,
-	"invitationid": true, "tokenid": true, "eventid": true, "keyid": true,
-	"roleid": true, "badgeid": true, "planid": true, "schemaid": true,
-	"registrantid": true, "componentid": true, "categoryid": true,
-	"pageurl": true, "avatarurl": true, "snapshoturl": true,
-	"callbackurl": true, "redirecturl": true,
+// lowercaseSuffixExemptions lists common words that end with a known suffix
+// but are not casing violations (e.g., "grid", "uuid").
+var lowercaseSuffixExemptions = map[string]bool{
+	"grid": true, "uuid": true, "mid": true, "valid": true,
+	"acid": true, "solid": true, "fluid": true,
 }
+
 
 // dbMirroredFields are known contract-stable snake_case fields that may not
 // carry explicit db tags but are DB-backed.
@@ -95,9 +90,14 @@ func HasScreamingIDToken(s string) bool {
 	return screamingIDRE.MatchString(s)
 }
 
-// HasLowercaseSuffix returns true if s is a known lowercase-suffix violation.
+// HasLowercaseSuffix returns true if s ends with a known suffix ("id", "url", etc.)
+// in all-lowercase, which usually indicates it is a compound word that should
+// be camelCased (e.g., "userid" → "userId").
 func HasLowercaseSuffix(s string) bool {
-	return knownLowercaseSuffixViolations[s]
+	if lowercaseSuffixExemptions[strings.ToLower(s)] {
+		return false
+	}
+	return lowercaseSuffixPattern.MatchString(s)
 }
 
 // ToCamelCase converts a property name to its expected camelCase form.

--- a/validation/casing_test.go
+++ b/validation/casing_test.go
@@ -199,3 +199,30 @@ func TestSuggestPathParam(t *testing.T) {
 		})
 	}
 }
+func TestHasLowercaseSuffix(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"userId", false},      // Valid camelCase
+		{"userid", true},       // Original violation
+		{"teamid", true},       // Original violation
+		{"projectid", true},    // New violation, caught by regex
+		{"avatarurl", true},    // Original violation
+		{"imageurl", true},     // New violation, caught by regex
+		{"grid", false},        // Exemption
+		{"uuid", false},        // Exemption
+		{"valid", false},       // Exemption
+		{"acid", false},        // Not in exemption but would be caught by regex if not carefully handled
+		                        // Actually, my regex is [a-z](id|ids|url|uri)$
+		                        // "acid" has 'i' as the [a-z] before 'd'? No.
+		                        // Regex: [a-z](id)$ -> matches "acid" because 'c' is [a-z] and it ends in "id".
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := HasLowercaseSuffix(tt.input); got != tt.want {
+				t.Errorf("HasLowercaseSuffix(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/validation/casing_test.go
+++ b/validation/casing_test.go
@@ -213,10 +213,9 @@ func TestHasLowercaseSuffix(t *testing.T) {
 		{"grid", false},        // Exemption
 		{"uuid", false},        // Exemption
 		{"valid", false},       // Exemption
-		{"acid", false},        // Not in exemption but would be caught by regex if not carefully handled
-		                        // Actually, my regex is [a-z](id|ids|url|uri)$
-		                        // "acid" has 'i' as the [a-z] before 'd'? No.
-		                        // Regex: [a-z](id)$ -> matches "acid" because 'c' is [a-z] and it ends in "id".
+		{"rapids", false},      // Plural exemption (rapid + s)
+		{"hybrids", false},     // Plural exemption (hybrid + s)
+		{"acid", false},        // Exemption
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {

--- a/validation/rules_design_test.go
+++ b/validation/rules_design_test.go
@@ -281,6 +281,42 @@ func TestCheckRule12_NilDoc(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Rule 13: api.yml must have info.title and info.version
+// ---------------------------------------------------------------------------
+
+func TestCheckRule13(t *testing.T) {
+	tests := []struct {
+		name      string
+		title     string
+		version   string
+		wantCount int
+	}{
+		{"valid", "Meshery", "v1", 0},
+		{"missing title", "", "v1", 1},
+		{"missing version", "Meshery", "", 1},
+		{"missing both", "", "", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			doc := &openapi3.T{Info: &openapi3.Info{Title: tt.title, Version: tt.version}}
+			vs := checkRule13("api.yml", doc, AuditOptions{})
+			if len(vs) != tt.wantCount {
+				t.Errorf("checkRule13(title=%q, version=%q) got %d violations, want %d", tt.title, tt.version, len(vs), tt.wantCount)
+			}
+		})
+	}
+}
+
+func TestCheckRule13_MissingInfo(t *testing.T) {
+	doc := &openapi3.T{}
+	vs := checkRule13("api.yml", doc, AuditOptions{})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation for missing info section, got %d", len(vs))
+	}
+}
+
+
+// ---------------------------------------------------------------------------
 // Rule 19: No unnecessary single-entry allOf
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #725. Migrates from a hardcoded map of lowercase suffix violations to a regex-based system with exemptions.

