### PR TITLE
fix(user): tolerate non-UUID selectedOrganizationId in Preference.Scan

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.25.5
 require (
 	github.com/getkin/kin-openapi v0.133.0
 	github.com/gofrs/uuid v4.4.0+incompatible
+	github.com/google/uuid v1.6.0
 	github.com/lib/pq v1.12.1
 	github.com/meshery/meshkit v0.8.70
 	github.com/oapi-codegen/runtime v1.3.1
@@ -33,7 +34,6 @@ require (
 	github.com/go-openapi/swag/jsonname v0.25.4 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.7 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect

--- a/models/v1beta1/user/helpers.go
+++ b/models/v1beta1/user/helpers.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/google/uuid"
 	core "github.com/meshery/schemas/models/core"
 )
 
@@ -55,6 +56,19 @@ func (p *Preference) Scan(src interface{}) error {
 	mapVal := core.Map{}
 	if err := mapVal.Scan(src); err != nil {
 		return err
+	}
+
+	// Legacy rows may hold an empty string (or other non-UUID content) under
+	// selectedOrganizationId — e.g. the v1.0.1 key rename carried empty values
+	// over verbatim. The current schema types that field as a required UUID,
+	// so leaving bad input in place would fail MapToStruct and block callers
+	// like OAuth sign-in. Drop the key instead; the zero UUID will be written
+	// on the next preference update.
+	if v, ok := mapVal["selectedOrganizationId"]; ok {
+		s, isStr := v.(string)
+		if !isStr || uuid.Validate(s) != nil {
+			delete(mapVal, "selectedOrganizationId")
+		}
 	}
 
 	return core.MapToStruct(mapVal, p)

--- a/models/v1beta1/user/helpers_test.go
+++ b/models/v1beta1/user/helpers_test.go
@@ -1,0 +1,38 @@
+package user
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+)
+
+func TestPreferenceScan_LegacyEmptySelectedOrganizationId(t *testing.T) {
+	p := &Preference{}
+	if err := p.Scan([]byte(`{"selectedOrganizationId":""}`)); err != nil {
+		t.Fatalf("scan with empty selectedOrganizationId should not error, got: %v", err)
+	}
+	if p.SelectedOrganizationId != uuid.Nil {
+		t.Fatalf("expected zero UUID, got %s", p.SelectedOrganizationId)
+	}
+}
+
+func TestPreferenceScan_LegacyNonUUIDSelectedOrganizationId(t *testing.T) {
+	p := &Preference{}
+	if err := p.Scan([]byte(`{"selectedOrganizationId":"not-a-uuid"}`)); err != nil {
+		t.Fatalf("scan with non-UUID selectedOrganizationId should not error, got: %v", err)
+	}
+	if p.SelectedOrganizationId != uuid.Nil {
+		t.Fatalf("expected zero UUID, got %s", p.SelectedOrganizationId)
+	}
+}
+
+func TestPreferenceScan_ValidSelectedOrganizationIdPreserved(t *testing.T) {
+	id := uuid.New()
+	p := &Preference{}
+	if err := p.Scan([]byte(`{"selectedOrganizationId":"` + id.String() + `"}`)); err != nil {
+		t.Fatalf("scan with valid UUID should not error, got: %v", err)
+	}
+	if p.SelectedOrganizationId != id {
+		t.Fatalf("expected %s, got %s", id, p.SelectedOrganizationId)
+	}
+}


### PR DESCRIPTION
## Summary

- Harden `Preference.Scan` (`models/v1beta1/user/helpers.go`) so a legacy or malformed `selectedOrganizationId` in the JSONB source does not fail the entire scan with `invalid UUID length: 0`.
- Drop the key from the intermediate map when `uuid.Validate` rejects it; `SelectedOrganizationId` stays at its zero value and the next preference write repopulates it normally.
- Adds `helpers_test.go` covering empty string, non-UUID string, and the valid-UUID happy path.

## Why

`SelectedOrganizationId` is typed as a required `uuid.UUID` (non-pointer, non-nullable). `Preference.Scan` calls `MapToStruct`, which JSON-unmarshals the map into the struct — any non-UUID string under that key fails unmarshal with `invalid UUID length: 0`, and the whole preference column is unreadable.

Observed impact in layer5io/meshery-cloud: `UsersDao.GetUser` surfaces the scan error during the Hydra login_challenge leg of OAuth and users are redirected to `/error`. The legacy data was created (or carried over) by the v1.0.1 rename (`selectedOrganizationID` → `selectedOrganizationId`, see meshery-cloud migration `20260401000000_rename_selectedOrganizationID_pref_key`), which didn't filter empty/invalid values.

meshery-cloud has a companion data-cleanup migration (layer5io/meshery-cloud#5044); this patch is the durable fix so the same class of bad input cannot re-break sign-in from any other writer or export.

## Test plan

- [x] `go test ./models/v1beta1/user/ -run TestPreferenceScan` — 3 passing
- [ ] CI green
- [ ] Downstream: bump `github.com/meshery/schemas` in layer5io/meshery-cloud `go.mod`, verify OAuth sign-in succeeds against a DB that still contains the bad data (without running the meshery-cloud migration)