### PR TITLE
feat(share): canonical Visibility enum + content share endpoints

### DIFF
--- a/models/core/core.go
+++ b/models/core/core.go
@@ -24,6 +24,13 @@ const (
 	MesheryDesign IaCFileTypes = "meshery-design"
 )
 
+// Defines values for Visibility.
+const (
+	Private   Visibility = "private"
+	Public    Visibility = "public"
+	Published Visibility = "published"
+)
+
 // Defines values for ComponentStylesBorderStyle.
 const (
 	ComponentStylesBorderStyleDashed ComponentStylesBorderStyle = "dashed"
@@ -228,6 +235,12 @@ type Text = string
 
 // Time defines model for Time.
 type Time = time.Time
+
+// Visibility Visibility level of a resource. Controls who can see and access it.
+// - `private`: Only the owner and explicitly shared users can access.
+// - `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.
+// - `published`: Promoted to the catalog for broad discovery beyond the owning organization.
+type Visibility string
 
 // AcceptedTermsAt defines model for accepted_terms_at.
 type AcceptedTermsAt = string
@@ -870,9 +883,6 @@ type Type = string
 
 // Userid defines model for userid.
 type Userid = string
-
-// Visibility defines model for visibility.
-type Visibility = string
 
 // Getter for additional properties for ComponentStyles. Returns the specified
 // element and whether it was found

--- a/models/v1beta1/view/view.go
+++ b/models/v1beta1/view/view.go
@@ -10,22 +10,19 @@ import (
 
 // Defines values for ContentSharePayloadContentType.
 const (
-	Filter  ContentSharePayloadContentType = "filter"
-	Pattern ContentSharePayloadContentType = "pattern"
-	View    ContentSharePayloadContentType = "view"
+	View ContentSharePayloadContentType = "view"
 )
 
 // ContentSharePayload Payload for sharing a view with one or more recipients by email. The
-// wire format is identical to the design share payload (defined in
-// `v1beta2/design`); Go consumers are expected to import the canonical
-// `pattern.ContentSharePayload` type and reuse it for both endpoints.
+// wire format matches the canonical design share payload
+// (`design.ContentSharePayload` in `v1beta2/design`), restricted to the
+// `view` content type since that is all this endpoint accepts.
 type ContentSharePayload struct {
 	// ContentId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
 	ContentId core.Uuid `json:"content_id" yaml:"content_id"`
 
-	// ContentType The kind of content being shared. On this endpoint only `view` is
-	// accepted; the enum is kept open for symmetry with the design share
-	// endpoint so a single client-side type can back both calls.
+	// ContentType The kind of content being shared. Only `view` is accepted on this
+	// endpoint.
 	ContentType ContentSharePayloadContentType `json:"content_type" yaml:"content_type"`
 
 	// Emails Email addresses of the recipients to share this view with.
@@ -36,9 +33,8 @@ type ContentSharePayload struct {
 	Share bool `json:"share" yaml:"share"`
 }
 
-// ContentSharePayloadContentType The kind of content being shared. On this endpoint only `view` is
-// accepted; the enum is kept open for symmetry with the design share
-// endpoint so a single client-side type can back both calls.
+// ContentSharePayloadContentType The kind of content being shared. Only `view` is accepted on this
+// endpoint.
 type ContentSharePayloadContentType string
 
 // MesheryView A saved view with filters and metadata that defines a customized perspective of Meshery resources. Learn more at https://docs.meshery.io/concepts/logical/views

--- a/models/v1beta1/view/view.go
+++ b/models/v1beta1/view/view.go
@@ -5,7 +5,41 @@ package view
 
 import (
 	core "github.com/meshery/schemas/models/core"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
+
+// Defines values for ContentSharePayloadContentType.
+const (
+	Filter  ContentSharePayloadContentType = "filter"
+	Pattern ContentSharePayloadContentType = "pattern"
+	View    ContentSharePayloadContentType = "view"
+)
+
+// ContentSharePayload Payload for sharing a view with one or more recipients by email. The
+// wire format is identical to the design share payload (defined in
+// `v1beta2/design`); Go consumers are expected to import the canonical
+// `pattern.ContentSharePayload` type and reuse it for both endpoints.
+type ContentSharePayload struct {
+	// ContentId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	ContentId core.Uuid `json:"content_id" yaml:"content_id"`
+
+	// ContentType The kind of content being shared. On this endpoint only `view` is
+	// accepted; the enum is kept open for symmetry with the design share
+	// endpoint so a single client-side type can back both calls.
+	ContentType ContentSharePayloadContentType `json:"content_type" yaml:"content_type"`
+
+	// Emails Email addresses of the recipients to share this view with.
+	Emails []openapi_types.Email `json:"emails" yaml:"emails"`
+
+	// Share When true, flip the view's visibility to public and send invitation
+	// emails to the recipients. When false, revert visibility to private.
+	Share bool `json:"share" yaml:"share"`
+}
+
+// ContentSharePayloadContentType The kind of content being shared. On this endpoint only `view` is
+// accepted; the enum is kept open for symmetry with the design share
+// endpoint so a single client-side type can back both calls.
+type ContentSharePayloadContentType string
 
 // MesheryView A saved view with filters and metadata that defines a customized perspective of Meshery resources. Learn more at https://docs.meshery.io/concepts/logical/views
 type MesheryView struct {

--- a/models/v1beta2/design/design.go
+++ b/models/v1beta2/design/design.go
@@ -11,6 +11,14 @@ import (
 	catalogv1alpha2 "github.com/meshery/schemas/models/v1alpha2/catalog"
 	component "github.com/meshery/schemas/models/v1beta2/component"
 	relationship "github.com/meshery/schemas/models/v1beta2/relationship"
+	openapi_types "github.com/oapi-codegen/runtime/types"
+)
+
+// Defines values for ContentSharePayloadContentType.
+const (
+	Filter  ContentSharePayloadContentType = "filter"
+	Pattern ContentSharePayloadContentType = "pattern"
+	View    ContentSharePayloadContentType = "view"
 )
 
 // DesignPreferences Design-level preferences
@@ -73,6 +81,32 @@ type CatalogRequestsPage struct {
 	// TotalCount Total number of items available.
 	TotalCount *int `json:"total_count,omitempty" yaml:"total_count,omitempty"`
 }
+
+// ContentSharePayload Payload for sharing a piece of content (design, filter, or view) with one
+// or more recipients by email. This schema backs both
+// `POST /api/content/design/share` and `POST /api/content/view/share`; the
+// server dispatches on `content_type` to decide which entity to mutate.
+type ContentSharePayload struct {
+	// ContentId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	ContentId core.Uuid `json:"content_id" yaml:"content_id"`
+
+	// ContentType The kind of content being shared. Must match the entity the handler
+	// expects — `pattern` and `filter` are valid on the design share
+	// endpoint; `view` is valid on the view share endpoint.
+	ContentType ContentSharePayloadContentType `json:"content_type" yaml:"content_type"`
+
+	// Emails Email addresses of the recipients to share this content with.
+	Emails []openapi_types.Email `json:"emails" yaml:"emails"`
+
+	// Share When true, flip visibility to public and send invitation emails to
+	// the recipients. When false, revert visibility to private.
+	Share bool `json:"share" yaml:"share"`
+}
+
+// ContentSharePayloadContentType The kind of content being shared. Must match the entity the handler
+// expects — `pattern` and `filter` are valid on the design share
+// endpoint; `view` is valid on the view share endpoint.
+type ContentSharePayloadContentType string
 
 // DeletePatternModel defines model for DeletePatternModel.
 type DeletePatternModel struct {

--- a/schemas/constructs/v1alpha1/core/api.yml
+++ b/schemas/constructs/v1alpha1/core/api.yml
@@ -83,6 +83,19 @@ components:
       type: string
       x-go-type-skip-optional-pointer: true
 
+    Visibility:
+      type: string
+      description: |
+        Visibility level of a resource. Controls who can see and access it.
+        - `private`: Only the owner and explicitly shared users can access.
+        - `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.
+        - `published`: Promoted to the catalog for broad discovery beyond the owning organization.
+      enum:
+        - private
+        - public
+        - published
+      x-go-type-skip-optional-pointer: true
+
     number:
       type: integer
       x-go-type-skip-optional-pointer: true
@@ -894,7 +907,7 @@ components:
       in: query
       description: Get responses based on visibility - private, public or published
       schema:
-        type: string
+        $ref: "#/components/schemas/Visibility"
     populate:
       name: populate
       in: query

--- a/schemas/constructs/v1beta1/core/api.yml
+++ b/schemas/constructs/v1beta1/core/api.yml
@@ -85,6 +85,19 @@ components:
       type: string
       x-go-type-skip-optional-pointer: true
 
+    Visibility:
+      type: string
+      description: |
+        Visibility level of a resource. Controls who can see and access it.
+        - `private`: Only the owner and explicitly shared users can access.
+        - `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.
+        - `published`: Promoted to the catalog for broad discovery beyond the owning organization.
+      enum:
+        - private
+        - public
+        - published
+      x-go-type-skip-optional-pointer: true
+
     number:
       type: integer
       x-go-type-skip-optional-pointer: true
@@ -899,7 +912,7 @@ components:
       in: query
       description: Get responses based on visibility - private, public or published
       schema:
-        type: string
+        $ref: "#/components/schemas/Visibility"
     populate:
       name: populate
       in: query

--- a/schemas/constructs/v1beta1/view/api.yml
+++ b/schemas/constructs/v1beta1/view/api.yml
@@ -211,9 +211,9 @@ components:
       type: object
       description: |
         Payload for sharing a view with one or more recipients by email. The
-        wire format is identical to the design share payload (defined in
-        `v1beta2/design`); Go consumers are expected to import the canonical
-        `pattern.ContentSharePayload` type and reuse it for both endpoints.
+        wire format matches the canonical design share payload
+        (`design.ContentSharePayload` in `v1beta2/design`), restricted to the
+        `view` content type since that is all this endpoint accepts.
       required:
         - content_id
         - content_type
@@ -226,12 +226,9 @@ components:
         content_type:
           type: string
           description: |
-            The kind of content being shared. On this endpoint only `view` is
-            accepted; the enum is kept open for symmetry with the design share
-            endpoint so a single client-side type can back both calls.
+            The kind of content being shared. Only `view` is accepted on this
+            endpoint.
           enum:
-            - pattern
-            - filter
             - view
         emails:
           type: array

--- a/schemas/constructs/v1beta1/view/api.yml
+++ b/schemas/constructs/v1beta1/view/api.yml
@@ -207,6 +207,44 @@ components:
           x-oapi-codegen-extra-tags:
             json: "metadata,omitempty"
 
+    ContentSharePayload:
+      type: object
+      description: |
+        Payload for sharing a view with one or more recipients by email. The
+        wire format is identical to the design share payload (defined in
+        `v1beta2/design`); Go consumers are expected to import the canonical
+        `pattern.ContentSharePayload` type and reuse it for both endpoints.
+      required:
+        - content_id
+        - content_type
+        - emails
+        - share
+      properties:
+        content_id:
+          $ref: "../core/api.yml#/components/schemas/uuid"
+          description: Identifier of the view being shared.
+        content_type:
+          type: string
+          description: |
+            The kind of content being shared. On this endpoint only `view` is
+            accepted; the enum is kept open for symmetry with the design share
+            endpoint so a single client-side type can back both calls.
+          enum:
+            - pattern
+            - filter
+            - view
+        emails:
+          type: array
+          description: Email addresses of the recipients to share this view with.
+          items:
+            type: string
+            format: email
+        share:
+          type: boolean
+          description: |
+            When true, flip the view's visibility to public and send invitation
+            emails to the recipients. When false, revert visibility to private.
+
     MesheryViewPage:
       type: object
       description: Paginated list of views with location enrichment.
@@ -233,6 +271,13 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/ViewPayload"
+    contentSharePayload:
+      description: Body for sharing a view with recipients by email.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ContentSharePayload"
 
 paths:
   /api/content/views:
@@ -304,6 +349,35 @@ paths:
                 $ref: "#/components/schemas/MesheryViewPage"
         "401":
           $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /api/content/view/share:
+    post:
+      x-internal: ["cloud"]
+      tags:
+        - views
+      operationId: shareView
+      summary: Share a view by email
+      description: |
+        Shares a view with a list of email addresses. When `share` is true, the
+        view's visibility is flipped to public and an invitation email is sent
+        to each recipient. When `share` is false, visibility is reverted to
+        private. Only the owner of the view (or a provider admin) may change
+        its sharing mode.
+      requestBody:
+        $ref: "#/components/requestBodies/contentSharePayload"
+      responses:
+        "200":
+          description: View shared.
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          description: Caller is not the owner of the view.
+        "404":
+          $ref: "#/components/responses/404"
         "500":
           $ref: "#/components/responses/500"
 

--- a/schemas/constructs/v1beta2/core/api.yml
+++ b/schemas/constructs/v1beta2/core/api.yml
@@ -83,6 +83,19 @@ components:
       type: string
       x-go-type-skip-optional-pointer: true
 
+    Visibility:
+      type: string
+      description: |
+        Visibility level of a resource. Controls who can see and access it.
+        - `private`: Only the owner and explicitly shared users can access.
+        - `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.
+        - `published`: Promoted to the catalog for broad discovery beyond the owning organization.
+      enum:
+        - private
+        - public
+        - published
+      x-go-type-skip-optional-pointer: true
+
     Number:
       type: integer
       x-go-type-skip-optional-pointer: true
@@ -973,7 +986,7 @@ components:
       in: query
       description: Get responses based on visibility - private, public or published
       schema:
-        type: string
+        $ref: "#/components/schemas/Visibility"
     populate:
       name: populate
       in: query

--- a/schemas/constructs/v1beta2/design/api.yml
+++ b/schemas/constructs/v1beta2/design/api.yml
@@ -698,14 +698,14 @@ paths:
       x-internal: ["cloud"]
       tags:
         - designs
-      summary: Share a design or filter by email
+      summary: Share a design, view, or filter by email
       operationId: shareDesign
       description: |
-        Shares a design (pattern) or filter with a list of email addresses. When
-        `share` is true, the content's visibility is flipped to public and an
-        invitation email is sent to each recipient. When `share` is false,
-        visibility is reverted to private. Only the owner of the content may
-        change its sharing mode.
+        Shares a design (pattern), view, or filter with a list of email
+        addresses. When `share` is true, the content's visibility is flipped to
+        public and an invitation email is sent to each recipient. When `share`
+        is false, visibility is reverted to private. Only the owner of the
+        content may change its sharing mode.
       requestBody:
         $ref: "#/components/requestBodies/contentSharePayload"
       responses:

--- a/schemas/constructs/v1beta2/design/api.yml
+++ b/schemas/constructs/v1beta2/design/api.yml
@@ -693,6 +693,35 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
+  /api/content/design/share:
+    post:
+      x-internal: ["cloud"]
+      tags:
+        - designs
+      summary: Share a design or filter by email
+      operationId: shareDesign
+      description: |
+        Shares a design (pattern) or filter with a list of email addresses. When
+        `share` is true, the content's visibility is flipped to public and an
+        invitation email is sent to each recipient. When `share` is false,
+        visibility is reverted to private. Only the owner of the content may
+        change its sharing mode.
+      requestBody:
+        $ref: "#/components/requestBodies/contentSharePayload"
+      responses:
+        "200":
+          description: Content shared.
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "403":
+          description: Caller is not the owner of the content.
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
   /api/catalog/requests:
     get:
       x-internal: ["cloud"]
@@ -987,6 +1016,44 @@ components:
             additionalProperties: true
           description: The users of the resourceaccessactorsresponse.
 
+    ContentSharePayload:
+      type: object
+      description: |
+        Payload for sharing a piece of content (design, filter, or view) with one
+        or more recipients by email. This schema backs both
+        `POST /api/content/design/share` and `POST /api/content/view/share`; the
+        server dispatches on `content_type` to decide which entity to mutate.
+      required:
+        - content_id
+        - content_type
+        - emails
+        - share
+      properties:
+        content_id:
+          $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: Identifier of the content being shared (design, filter, or view).
+        content_type:
+          type: string
+          description: |
+            The kind of content being shared. Must match the entity the handler
+            expects — `pattern` and `filter` are valid on the design share
+            endpoint; `view` is valid on the view share endpoint.
+          enum:
+            - pattern
+            - filter
+            - view
+        emails:
+          type: array
+          description: Email addresses of the recipients to share this content with.
+          items:
+            type: string
+            format: email
+        share:
+          type: boolean
+          description: |
+            When true, flip visibility to public and send invitation emails to
+            the recipients. When false, revert visibility to private.
+
   requestBodies:
     catalogContentPayload:
       required: true
@@ -1002,3 +1069,10 @@ components:
           schema:
             type: object
             additionalProperties: true
+    contentSharePayload:
+      description: Body for sharing a design, filter, or view with recipients by email.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ContentSharePayload"

--- a/typescript/generated/v1alpha1/core/Core.ts
+++ b/typescript/generated/v1alpha1/core/Core.ts
@@ -43,6 +43,15 @@ export interface components {
      */
     email: string;
     Text: string;
+    /**
+     * @description Visibility level of a resource. Controls who can see and access it.
+     * - `private`: Only the owner and explicitly shared users can access.
+     * - `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.
+     * - `published`: Promoted to the catalog for broad discovery beyond the owning organization.
+     *
+     * @enum {string}
+     */
+    Visibility: "private" | "public" | "published";
     number: number;
     /** @description Link for profile picture */
     avatar_url: string;
@@ -782,7 +791,7 @@ export interface components {
     /** @description Get ordered responses */
     order: string;
     /** @description Get responses based on visibility - private, public or published */
-    visibility: string;
+    visibility: "private" | "public" | "published";
     /** @description Populate the response with additional data like pattern_file */
     populate: string;
     /** @description Get responses that match search param value */

--- a/typescript/generated/v1alpha1/core/CoreSchema.ts
+++ b/typescript/generated/v1alpha1/core/CoreSchema.ts
@@ -100,6 +100,16 @@ const CoreSchema: Record<string, unknown> = {
         "type": "string",
         "x-go-type-skip-optional-pointer": true
       },
+      "Visibility": {
+        "type": "string",
+        "description": "Visibility level of a resource. Controls who can see and access it.\n- `private`: Only the owner and explicitly shared users can access.\n- `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.\n- `published`: Promoted to the catalog for broad discovery beyond the owning organization.\n",
+        "enum": [
+          "private",
+          "public",
+          "published"
+        ],
+        "x-go-type-skip-optional-pointer": true
+      },
       "number": {
         "type": "integer",
         "x-go-type-skip-optional-pointer": true
@@ -1705,7 +1715,14 @@ const CoreSchema: Record<string, unknown> = {
         "in": "query",
         "description": "Get responses based on visibility - private, public or published",
         "schema": {
-          "type": "string"
+          "type": "string",
+          "description": "Visibility level of a resource. Controls who can see and access it.\n- `private`: Only the owner and explicitly shared users can access.\n- `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.\n- `published`: Promoted to the catalog for broad discovery beyond the owning organization.\n",
+          "enum": [
+            "private",
+            "public",
+            "published"
+          ],
+          "x-go-type-skip-optional-pointer": true
         }
       },
       "populate": {

--- a/typescript/generated/v1beta1/core/Core.ts
+++ b/typescript/generated/v1beta1/core/Core.ts
@@ -43,6 +43,15 @@ export interface components {
      */
     email: string;
     Text: string;
+    /**
+     * @description Visibility level of a resource. Controls who can see and access it.
+     * - `private`: Only the owner and explicitly shared users can access.
+     * - `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.
+     * - `published`: Promoted to the catalog for broad discovery beyond the owning organization.
+     *
+     * @enum {string}
+     */
+    Visibility: "private" | "public" | "published";
     number: number;
     /** @description Link for profile picture */
     avatar_url: string;
@@ -782,7 +791,7 @@ export interface components {
     /** @description Get ordered responses */
     order: string;
     /** @description Get responses based on visibility - private, public or published */
-    visibility: string;
+    visibility: "private" | "public" | "published";
     /** @description Populate the response with additional data like pattern_file */
     populate: string;
     /** @description Get responses that match search param value */

--- a/typescript/generated/v1beta1/core/CoreSchema.ts
+++ b/typescript/generated/v1beta1/core/CoreSchema.ts
@@ -102,6 +102,16 @@ const CoreSchema: Record<string, unknown> = {
         "type": "string",
         "x-go-type-skip-optional-pointer": true
       },
+      "Visibility": {
+        "type": "string",
+        "description": "Visibility level of a resource. Controls who can see and access it.\n- `private`: Only the owner and explicitly shared users can access.\n- `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.\n- `published`: Promoted to the catalog for broad discovery beyond the owning organization.\n",
+        "enum": [
+          "private",
+          "public",
+          "published"
+        ],
+        "x-go-type-skip-optional-pointer": true
+      },
       "number": {
         "type": "integer",
         "x-go-type-skip-optional-pointer": true
@@ -1711,7 +1721,14 @@ const CoreSchema: Record<string, unknown> = {
         "in": "query",
         "description": "Get responses based on visibility - private, public or published",
         "schema": {
-          "type": "string"
+          "type": "string",
+          "description": "Visibility level of a resource. Controls who can see and access it.\n- `private`: Only the owner and explicitly shared users can access.\n- `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.\n- `published`: Promoted to the catalog for broad discovery beyond the owning organization.\n",
+          "enum": [
+            "private",
+            "public",
+            "published"
+          ],
+          "x-go-type-skip-optional-pointer": true
         }
       },
       "populate": {

--- a/typescript/generated/v1beta1/view/View.ts
+++ b/typescript/generated/v1beta1/view/View.ts
@@ -142,9 +142,9 @@ export interface components {
     };
     /**
      * @description Payload for sharing a view with one or more recipients by email. The
-     * wire format is identical to the design share payload (defined in
-     * `v1beta2/design`); Go consumers are expected to import the canonical
-     * `pattern.ContentSharePayload` type and reuse it for both endpoints.
+     * wire format matches the canonical design share payload
+     * (`design.ContentSharePayload` in `v1beta2/design`), restricted to the
+     * `view` content type since that is all this endpoint accepts.
      */
     ContentSharePayload: {
       /**
@@ -153,13 +153,12 @@ export interface components {
        */
       content_id: string;
       /**
-       * @description The kind of content being shared. On this endpoint only `view` is
-       * accepted; the enum is kept open for symmetry with the design share
-       * endpoint so a single client-side type can back both calls.
+       * @description The kind of content being shared. Only `view` is accepted on this
+       * endpoint.
        *
        * @enum {string}
        */
-      content_type: "pattern" | "filter" | "view";
+      content_type: "view";
       /** @description Email addresses of the recipients to share this view with. */
       emails: string[];
       /**
@@ -294,13 +293,12 @@ export interface components {
            */
           content_id: string;
           /**
-           * @description The kind of content being shared. On this endpoint only `view` is
-           * accepted; the enum is kept open for symmetry with the design share
-           * endpoint so a single client-side type can back both calls.
+           * @description The kind of content being shared. Only `view` is accepted on this
+           * endpoint.
            *
            * @enum {string}
            */
-          content_type: "pattern" | "filter" | "view";
+          content_type: "view";
           /** @description Email addresses of the recipients to share this view with. */
           emails: string[];
           /**
@@ -537,13 +535,12 @@ export interface operations {
            */
           content_id: string;
           /**
-           * @description The kind of content being shared. On this endpoint only `view` is
-           * accepted; the enum is kept open for symmetry with the design share
-           * endpoint so a single client-side type can back both calls.
+           * @description The kind of content being shared. Only `view` is accepted on this
+           * endpoint.
            *
            * @enum {string}
            */
-          content_type: "pattern" | "filter" | "view";
+          content_type: "view";
           /** @description Email addresses of the recipients to share this view with. */
           emails: string[];
           /**

--- a/typescript/generated/v1beta1/view/View.ts
+++ b/typescript/generated/v1beta1/view/View.ts
@@ -10,6 +10,16 @@ export interface paths {
     /** Creates a new view with the given filters and metadata. */
     post: operations["createView"];
   };
+  "/api/content/view/share": {
+    /**
+     * Shares a view with a list of email addresses. When `share` is true, the
+     * view's visibility is flipped to public and an invitation email is sent
+     * to each recipient. When `share` is false, visibility is reverted to
+     * private. Only the owner of the view (or a provider admin) may change
+     * its sharing mode.
+     */
+    post: operations["shareView"];
+  };
   "/api/content/views/{viewId}": {
     /** Returns a single view by its unique identifier. */
     get: operations["getViewById"];
@@ -130,6 +140,34 @@ export interface components {
       /** @description Metadata associated with the view. */
       metadata?: { [key: string]: unknown };
     };
+    /**
+     * @description Payload for sharing a view with one or more recipients by email. The
+     * wire format is identical to the design share payload (defined in
+     * `v1beta2/design`); Go consumers are expected to import the canonical
+     * `pattern.ContentSharePayload` type and reuse it for both endpoints.
+     */
+    ContentSharePayload: {
+      /**
+       * Format: uuid
+       * @description Identifier of the view being shared.
+       */
+      content_id: string;
+      /**
+       * @description The kind of content being shared. On this endpoint only `view` is
+       * accepted; the enum is kept open for symmetry with the design share
+       * endpoint so a single client-side type can back both calls.
+       *
+       * @enum {string}
+       */
+      content_type: "pattern" | "filter" | "view";
+      /** @description Email addresses of the recipients to share this view with. */
+      emails: string[];
+      /**
+       * @description When true, flip the view's visibility to public and send invitation
+       * emails to the recipients. When false, revert visibility to private.
+       */
+      share: boolean;
+    };
     /** @description Paginated list of views with location enrichment. */
     MesheryViewPage: {
       page?: number;
@@ -243,6 +281,33 @@ export interface components {
           visibility?: string;
           /** @description Metadata associated with the view. */
           metadata?: { [key: string]: unknown };
+        };
+      };
+    };
+    /** Body for sharing a view with recipients by email. */
+    contentSharePayload: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description Identifier of the view being shared.
+           */
+          content_id: string;
+          /**
+           * @description The kind of content being shared. On this endpoint only `view` is
+           * accepted; the enum is kept open for symmetry with the design share
+           * endpoint so a single client-side type can back both calls.
+           *
+           * @enum {string}
+           */
+          content_type: "pattern" | "filter" | "view";
+          /** @description Email addresses of the recipients to share this view with. */
+          emails: string[];
+          /**
+           * @description When true, flip the view's visibility to public and send invitation
+           * emails to the recipients. When false, revert visibility to private.
+           */
+          share: boolean;
         };
       };
     };
@@ -420,6 +485,72 @@ export interface operations {
           visibility?: string;
           /** @description Metadata associated with the view. */
           metadata?: { [key: string]: unknown };
+        };
+      };
+    };
+  };
+  /**
+   * Shares a view with a list of email addresses. When `share` is true, the
+   * view's visibility is flipped to public and an invitation email is sent
+   * to each recipient. When `share` is false, visibility is reverted to
+   * private. Only the owner of the view (or a provider admin) may change
+   * its sharing mode.
+   */
+  shareView: {
+    responses: {
+      /** View shared. */
+      200: unknown;
+      /** Invalid request body or request param */
+      400: {
+        content: {
+          "text/plain": string;
+        };
+      };
+      /** Expired JWT token used or insufficient privilege */
+      401: {
+        content: {
+          "text/plain": string;
+        };
+      };
+      /** Caller is not the owner of the view. */
+      403: unknown;
+      /** Result not found */
+      404: {
+        content: {
+          "text/plain": string;
+        };
+      };
+      /** Internal server error */
+      500: {
+        content: {
+          "text/plain": string;
+        };
+      };
+    };
+    /** Body for sharing a view with recipients by email. */
+    requestBody: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description Identifier of the view being shared.
+           */
+          content_id: string;
+          /**
+           * @description The kind of content being shared. On this endpoint only `view` is
+           * accepted; the enum is kept open for symmetry with the design share
+           * endpoint so a single client-side type can back both calls.
+           *
+           * @enum {string}
+           */
+          content_type: "pattern" | "filter" | "view";
+          /** @description Email addresses of the recipients to share this view with. */
+          emails: string[];
+          /**
+           * @description When true, flip the view's visibility to public and send invitation
+           * emails to the recipients. When false, revert visibility to private.
+           */
+          share: boolean;
         };
       };
     };

--- a/typescript/generated/v1beta1/view/ViewSchema.ts
+++ b/typescript/generated/v1beta1/view/ViewSchema.ts
@@ -546,7 +546,7 @@ const ViewSchema: Record<string, unknown> = {
       },
       "ContentSharePayload": {
         "type": "object",
-        "description": "Payload for sharing a view with one or more recipients by email. The\nwire format is identical to the design share payload (defined in\n`v1beta2/design`); Go consumers are expected to import the canonical\n`pattern.ContentSharePayload` type and reuse it for both endpoints.\n",
+        "description": "Payload for sharing a view with one or more recipients by email. The\nwire format matches the canonical design share payload\n(`design.ContentSharePayload` in `v1beta2/design`), restricted to the\n`view` content type since that is all this endpoint accepts.\n",
         "required": [
           "content_id",
           "content_type",
@@ -565,10 +565,8 @@ const ViewSchema: Record<string, unknown> = {
           },
           "content_type": {
             "type": "string",
-            "description": "The kind of content being shared. On this endpoint only `view` is\naccepted; the enum is kept open for symmetry with the design share\nendpoint so a single client-side type can back both calls.\n",
+            "description": "The kind of content being shared. Only `view` is accepted on this\nendpoint.\n",
             "enum": [
-              "pattern",
-              "filter",
               "view"
             ]
           },
@@ -851,7 +849,7 @@ const ViewSchema: Record<string, unknown> = {
           "application/json": {
             "schema": {
               "type": "object",
-              "description": "Payload for sharing a view with one or more recipients by email. The\nwire format is identical to the design share payload (defined in\n`v1beta2/design`); Go consumers are expected to import the canonical\n`pattern.ContentSharePayload` type and reuse it for both endpoints.\n",
+              "description": "Payload for sharing a view with one or more recipients by email. The\nwire format matches the canonical design share payload\n(`design.ContentSharePayload` in `v1beta2/design`), restricted to the\n`view` content type since that is all this endpoint accepts.\n",
               "required": [
                 "content_id",
                 "content_type",
@@ -870,10 +868,8 @@ const ViewSchema: Record<string, unknown> = {
                 },
                 "content_type": {
                   "type": "string",
-                  "description": "The kind of content being shared. On this endpoint only `view` is\naccepted; the enum is kept open for symmetry with the design share\nendpoint so a single client-side type can back both calls.\n",
+                  "description": "The kind of content being shared. Only `view` is accepted on this\nendpoint.\n",
                   "enum": [
-                    "pattern",
-                    "filter",
                     "view"
                   ]
                 },
@@ -1494,7 +1490,7 @@ const ViewSchema: Record<string, unknown> = {
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "Payload for sharing a view with one or more recipients by email. The\nwire format is identical to the design share payload (defined in\n`v1beta2/design`); Go consumers are expected to import the canonical\n`pattern.ContentSharePayload` type and reuse it for both endpoints.\n",
+                "description": "Payload for sharing a view with one or more recipients by email. The\nwire format matches the canonical design share payload\n(`design.ContentSharePayload` in `v1beta2/design`), restricted to the\n`view` content type since that is all this endpoint accepts.\n",
                 "required": [
                   "content_id",
                   "content_type",
@@ -1513,10 +1509,8 @@ const ViewSchema: Record<string, unknown> = {
                   },
                   "content_type": {
                     "type": "string",
-                    "description": "The kind of content being shared. On this endpoint only `view` is\naccepted; the enum is kept open for symmetry with the design share\nendpoint so a single client-side type can back both calls.\n",
+                    "description": "The kind of content being shared. Only `view` is accepted on this\nendpoint.\n",
                     "enum": [
-                      "pattern",
-                      "filter",
                       "view"
                     ]
                   },

--- a/typescript/generated/v1beta1/view/ViewSchema.ts
+++ b/typescript/generated/v1beta1/view/ViewSchema.ts
@@ -544,6 +544,48 @@ const ViewSchema: Record<string, unknown> = {
           }
         }
       },
+      "ContentSharePayload": {
+        "type": "object",
+        "description": "Payload for sharing a view with one or more recipients by email. The\nwire format is identical to the design share payload (defined in\n`v1beta2/design`); Go consumers are expected to import the canonical\n`pattern.ContentSharePayload` type and reuse it for both endpoints.\n",
+        "required": [
+          "content_id",
+          "content_type",
+          "emails",
+          "share"
+        ],
+        "properties": {
+          "content_id": {
+            "description": "Identifier of the view being shared.",
+            "type": "string",
+            "format": "uuid",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/gofrs/uuid"
+            }
+          },
+          "content_type": {
+            "type": "string",
+            "description": "The kind of content being shared. On this endpoint only `view` is\naccepted; the enum is kept open for symmetry with the design share\nendpoint so a single client-side type can back both calls.\n",
+            "enum": [
+              "pattern",
+              "filter",
+              "view"
+            ]
+          },
+          "emails": {
+            "type": "array",
+            "description": "Email addresses of the recipients to share this view with.",
+            "items": {
+              "type": "string",
+              "format": "email"
+            }
+          },
+          "share": {
+            "type": "boolean",
+            "description": "When true, flip the view's visibility to public and send invitation\nemails to the recipients. When false, revert visibility to private.\n"
+          }
+        }
+      },
       "MesheryViewPage": {
         "type": "object",
         "description": "Paginated list of views with location enrichment.",
@@ -796,6 +838,56 @@ const ViewSchema: Record<string, unknown> = {
                   "x-oapi-codegen-extra-tags": {
                     "json": "metadata,omitempty"
                   }
+                }
+              }
+            }
+          }
+        }
+      },
+      "contentSharePayload": {
+        "description": "Body for sharing a view with recipients by email.",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "description": "Payload for sharing a view with one or more recipients by email. The\nwire format is identical to the design share payload (defined in\n`v1beta2/design`); Go consumers are expected to import the canonical\n`pattern.ContentSharePayload` type and reuse it for both endpoints.\n",
+              "required": [
+                "content_id",
+                "content_type",
+                "emails",
+                "share"
+              ],
+              "properties": {
+                "content_id": {
+                  "description": "Identifier of the view being shared.",
+                  "type": "string",
+                  "format": "uuid",
+                  "x-go-type": "uuid.UUID",
+                  "x-go-type-import": {
+                    "path": "github.com/gofrs/uuid"
+                  }
+                },
+                "content_type": {
+                  "type": "string",
+                  "description": "The kind of content being shared. On this endpoint only `view` is\naccepted; the enum is kept open for symmetry with the design share\nendpoint so a single client-side type can back both calls.\n",
+                  "enum": [
+                    "pattern",
+                    "filter",
+                    "view"
+                  ]
+                },
+                "emails": {
+                  "type": "array",
+                  "description": "Email addresses of the recipients to share this view with.",
+                  "items": {
+                    "type": "string",
+                    "format": "email"
+                  }
+                },
+                "share": {
+                  "type": "boolean",
+                  "description": "When true, flip the view's visibility to public and send invitation\nemails to the recipients. When false, revert visibility to private.\n"
                 }
               }
             }
@@ -1363,6 +1455,117 @@ const ViewSchema: Record<string, unknown> = {
           },
           "401": {
             "description": "Expired JWT token used or insufficient privilege",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/content/view/share": {
+      "post": {
+        "x-internal": [
+          "cloud"
+        ],
+        "tags": [
+          "views"
+        ],
+        "operationId": "shareView",
+        "summary": "Share a view by email",
+        "description": "Shares a view with a list of email addresses. When `share` is true, the\nview's visibility is flipped to public and an invitation email is sent\nto each recipient. When `share` is false, visibility is reverted to\nprivate. Only the owner of the view (or a provider admin) may change\nits sharing mode.\n",
+        "requestBody": {
+          "description": "Body for sharing a view with recipients by email.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Payload for sharing a view with one or more recipients by email. The\nwire format is identical to the design share payload (defined in\n`v1beta2/design`); Go consumers are expected to import the canonical\n`pattern.ContentSharePayload` type and reuse it for both endpoints.\n",
+                "required": [
+                  "content_id",
+                  "content_type",
+                  "emails",
+                  "share"
+                ],
+                "properties": {
+                  "content_id": {
+                    "description": "Identifier of the view being shared.",
+                    "type": "string",
+                    "format": "uuid",
+                    "x-go-type": "uuid.UUID",
+                    "x-go-type-import": {
+                      "path": "github.com/gofrs/uuid"
+                    }
+                  },
+                  "content_type": {
+                    "type": "string",
+                    "description": "The kind of content being shared. On this endpoint only `view` is\naccepted; the enum is kept open for symmetry with the design share\nendpoint so a single client-side type can back both calls.\n",
+                    "enum": [
+                      "pattern",
+                      "filter",
+                      "view"
+                    ]
+                  },
+                  "emails": {
+                    "type": "array",
+                    "description": "Email addresses of the recipients to share this view with.",
+                    "items": {
+                      "type": "string",
+                      "format": "email"
+                    }
+                  },
+                  "share": {
+                    "type": "boolean",
+                    "description": "When true, flip the view's visibility to public and send invitation\nemails to the recipients. When false, revert visibility to private.\n"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "View shared."
+          },
+          "400": {
+            "description": "Invalid request body or request param",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Expired JWT token used or insufficient privilege",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not the owner of the view."
+          },
+          "404": {
+            "description": "Result not found",
             "content": {
               "text/plain": {
                 "schema": {

--- a/typescript/generated/v1beta2/core/Core.ts
+++ b/typescript/generated/v1beta2/core/Core.ts
@@ -43,6 +43,15 @@ export interface components {
      */
     Email: string;
     Text: string;
+    /**
+     * @description Visibility level of a resource. Controls who can see and access it.
+     * - `private`: Only the owner and explicitly shared users can access.
+     * - `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.
+     * - `published`: Promoted to the catalog for broad discovery beyond the owning organization.
+     *
+     * @enum {string}
+     */
+    Visibility: "private" | "public" | "published";
     Number: number;
     /** @description Link for profile picture */
     AvatarUrl: string;
@@ -816,7 +825,7 @@ export interface components {
     /** @description Get ordered responses */
     order: string;
     /** @description Get responses based on visibility - private, public or published */
-    visibility: string;
+    visibility: "private" | "public" | "published";
     /** @description Populate the response with additional data like pattern_file */
     populate: string;
     /** @description Get responses that match search param value */

--- a/typescript/generated/v1beta2/core/CoreSchema.ts
+++ b/typescript/generated/v1beta2/core/CoreSchema.ts
@@ -100,6 +100,16 @@ const CoreSchema: Record<string, unknown> = {
         "type": "string",
         "x-go-type-skip-optional-pointer": true
       },
+      "Visibility": {
+        "type": "string",
+        "description": "Visibility level of a resource. Controls who can see and access it.\n- `private`: Only the owner and explicitly shared users can access.\n- `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.\n- `published`: Promoted to the catalog for broad discovery beyond the owning organization.\n",
+        "enum": [
+          "private",
+          "public",
+          "published"
+        ],
+        "x-go-type-skip-optional-pointer": true
+      },
       "Number": {
         "type": "integer",
         "x-go-type-skip-optional-pointer": true
@@ -1860,7 +1870,14 @@ const CoreSchema: Record<string, unknown> = {
         "in": "query",
         "description": "Get responses based on visibility - private, public or published",
         "schema": {
-          "type": "string"
+          "type": "string",
+          "description": "Visibility level of a resource. Controls who can see and access it.\n- `private`: Only the owner and explicitly shared users can access.\n- `public`: Anyone in the organization (or anonymous, depending on resource) can discover and access.\n- `published`: Promoted to the catalog for broad discovery beyond the owning organization.\n",
+          "enum": [
+            "private",
+            "public",
+            "published"
+          ],
+          "x-go-type-skip-optional-pointer": true
         }
       },
       "populate": {

--- a/typescript/generated/v1beta2/design/Design.ts
+++ b/typescript/generated/v1beta2/design/Design.ts
@@ -71,6 +71,16 @@ export interface paths {
   "/api/resource/{resourceType}/share/{resourceId}/{actorType}": {
     get: operations["getResourceAccessActorsByType"];
   };
+  "/api/content/design/share": {
+    /**
+     * Shares a design (pattern) or filter with a list of email addresses. When
+     * `share` is true, the content's visibility is flipped to public and an
+     * invitation email is sent to each recipient. When `share` is false,
+     * visibility is reverted to private. Only the owner of the content may
+     * change its sharing mode.
+     */
+    post: operations["shareDesign"];
+  };
   "/api/catalog/requests": {
     get: operations["getCatalogRequest"];
   };
@@ -8132,6 +8142,34 @@ export interface components {
       /** @description The users of the resourceaccessactorsresponse. */
       users?: { [key: string]: unknown }[];
     };
+    /**
+     * @description Payload for sharing a piece of content (design, filter, or view) with one
+     * or more recipients by email. This schema backs both
+     * `POST /api/content/design/share` and `POST /api/content/view/share`; the
+     * server dispatches on `content_type` to decide which entity to mutate.
+     */
+    ContentSharePayload: {
+      /**
+       * Format: uuid
+       * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+       */
+      content_id: string;
+      /**
+       * @description The kind of content being shared. Must match the entity the handler
+       * expects — `pattern` and `filter` are valid on the design share
+       * endpoint; `view` is valid on the view share endpoint.
+       *
+       * @enum {string}
+       */
+      content_type: "pattern" | "filter" | "view";
+      /** @description Email addresses of the recipients to share this content with. */
+      emails: string[];
+      /**
+       * @description When true, flip visibility to public and send invitation emails to
+       * the recipients. When false, revert visibility to private.
+       */
+      share: boolean;
+    };
   };
   responses: {
     /** Invalid request body or request param */
@@ -8180,6 +8218,33 @@ export interface components {
     resourceSharePayload: {
       content: {
         "application/json": { [key: string]: unknown };
+      };
+    };
+    /** Body for sharing a design, filter, or view with recipients by email. */
+    contentSharePayload: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+           */
+          content_id: string;
+          /**
+           * @description The kind of content being shared. Must match the entity the handler
+           * expects — `pattern` and `filter` are valid on the design share
+           * endpoint; `view` is valid on the view share endpoint.
+           *
+           * @enum {string}
+           */
+          content_type: "pattern" | "filter" | "view";
+          /** @description Email addresses of the recipients to share this content with. */
+          emails: string[];
+          /**
+           * @description When true, flip visibility to public and send invitation emails to
+           * the recipients. When false, revert visibility to private.
+           */
+          share: boolean;
+        };
       };
     };
   };
@@ -18750,6 +18815,72 @@ export interface operations {
       500: {
         content: {
           "text/plain": string;
+        };
+      };
+    };
+  };
+  /**
+   * Shares a design (pattern) or filter with a list of email addresses. When
+   * `share` is true, the content's visibility is flipped to public and an
+   * invitation email is sent to each recipient. When `share` is false,
+   * visibility is reverted to private. Only the owner of the content may
+   * change its sharing mode.
+   */
+  shareDesign: {
+    responses: {
+      /** Content shared. */
+      200: unknown;
+      /** Invalid request body or request param */
+      400: {
+        content: {
+          "text/plain": string;
+        };
+      };
+      /** Expired JWT token used or insufficient privilege */
+      401: {
+        content: {
+          "text/plain": string;
+        };
+      };
+      /** Caller is not the owner of the content. */
+      403: unknown;
+      /** Result not found */
+      404: {
+        content: {
+          "text/plain": string;
+        };
+      };
+      /** Internal server error */
+      500: {
+        content: {
+          "text/plain": string;
+        };
+      };
+    };
+    /** Body for sharing a design, filter, or view with recipients by email. */
+    requestBody: {
+      content: {
+        "application/json": {
+          /**
+           * Format: uuid
+           * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+           */
+          content_id: string;
+          /**
+           * @description The kind of content being shared. Must match the entity the handler
+           * expects — `pattern` and `filter` are valid on the design share
+           * endpoint; `view` is valid on the view share endpoint.
+           *
+           * @enum {string}
+           */
+          content_type: "pattern" | "filter" | "view";
+          /** @description Email addresses of the recipients to share this content with. */
+          emails: string[];
+          /**
+           * @description When true, flip visibility to public and send invitation emails to
+           * the recipients. When false, revert visibility to private.
+           */
+          share: boolean;
         };
       };
     };

--- a/typescript/generated/v1beta2/design/DesignSchema.ts
+++ b/typescript/generated/v1beta2/design/DesignSchema.ts
@@ -30795,6 +30795,117 @@ const DesignSchema: Record<string, unknown> = {
         }
       }
     },
+    "/api/content/design/share": {
+      "post": {
+        "x-internal": [
+          "cloud"
+        ],
+        "tags": [
+          "designs"
+        ],
+        "summary": "Share a design or filter by email",
+        "operationId": "shareDesign",
+        "description": "Shares a design (pattern) or filter with a list of email addresses. When\n`share` is true, the content's visibility is flipped to public and an\ninvitation email is sent to each recipient. When `share` is false,\nvisibility is reverted to private. Only the owner of the content may\nchange its sharing mode.\n",
+        "requestBody": {
+          "description": "Body for sharing a design, filter, or view with recipients by email.",
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Payload for sharing a piece of content (design, filter, or view) with one\nor more recipients by email. This schema backs both\n`POST /api/content/design/share` and `POST /api/content/view/share`; the\nserver dispatches on `content_type` to decide which entity to mutate.\n",
+                "required": [
+                  "content_id",
+                  "content_type",
+                  "emails",
+                  "share"
+                ],
+                "properties": {
+                  "content_id": {
+                    "type": "string",
+                    "format": "uuid",
+                    "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                    "x-go-type": "uuid.UUID",
+                    "x-go-type-import": {
+                      "path": "github.com/gofrs/uuid"
+                    }
+                  },
+                  "content_type": {
+                    "type": "string",
+                    "description": "The kind of content being shared. Must match the entity the handler\nexpects — `pattern` and `filter` are valid on the design share\nendpoint; `view` is valid on the view share endpoint.\n",
+                    "enum": [
+                      "pattern",
+                      "filter",
+                      "view"
+                    ]
+                  },
+                  "emails": {
+                    "type": "array",
+                    "description": "Email addresses of the recipients to share this content with.",
+                    "items": {
+                      "type": "string",
+                      "format": "email"
+                    }
+                  },
+                  "share": {
+                    "type": "boolean",
+                    "description": "When true, flip visibility to public and send invitation emails to\nthe recipients. When false, revert visibility to private.\n"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Content shared."
+          },
+          "400": {
+            "description": "Invalid request body or request param",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Expired JWT token used or insufficient privilege",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Caller is not the owner of the content."
+          },
+          "404": {
+            "description": "Result not found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/catalog/requests": {
       "get": {
         "x-internal": [
@@ -55100,6 +55211,48 @@ const DesignSchema: Record<string, unknown> = {
             "description": "The users of the resourceaccessactorsresponse."
           }
         }
+      },
+      "ContentSharePayload": {
+        "type": "object",
+        "description": "Payload for sharing a piece of content (design, filter, or view) with one\nor more recipients by email. This schema backs both\n`POST /api/content/design/share` and `POST /api/content/view/share`; the\nserver dispatches on `content_type` to decide which entity to mutate.\n",
+        "required": [
+          "content_id",
+          "content_type",
+          "emails",
+          "share"
+        ],
+        "properties": {
+          "content_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/gofrs/uuid"
+            }
+          },
+          "content_type": {
+            "type": "string",
+            "description": "The kind of content being shared. Must match the entity the handler\nexpects — `pattern` and `filter` are valid on the design share\nendpoint; `view` is valid on the view share endpoint.\n",
+            "enum": [
+              "pattern",
+              "filter",
+              "view"
+            ]
+          },
+          "emails": {
+            "type": "array",
+            "description": "Email addresses of the recipients to share this content with.",
+            "items": {
+              "type": "string",
+              "format": "email"
+            }
+          },
+          "share": {
+            "type": "boolean",
+            "description": "When true, flip visibility to public and send invitation emails to\nthe recipients. When false, revert visibility to private.\n"
+          }
+        }
       }
     },
     "requestBodies": {
@@ -55121,6 +55274,56 @@ const DesignSchema: Record<string, unknown> = {
             "schema": {
               "type": "object",
               "additionalProperties": true
+            }
+          }
+        }
+      },
+      "contentSharePayload": {
+        "description": "Body for sharing a design, filter, or view with recipients by email.",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "description": "Payload for sharing a piece of content (design, filter, or view) with one\nor more recipients by email. This schema backs both\n`POST /api/content/design/share` and `POST /api/content/view/share`; the\nserver dispatches on `content_type` to decide which entity to mutate.\n",
+              "required": [
+                "content_id",
+                "content_type",
+                "emails",
+                "share"
+              ],
+              "properties": {
+                "content_id": {
+                  "type": "string",
+                  "format": "uuid",
+                  "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                  "x-go-type": "uuid.UUID",
+                  "x-go-type-import": {
+                    "path": "github.com/gofrs/uuid"
+                  }
+                },
+                "content_type": {
+                  "type": "string",
+                  "description": "The kind of content being shared. Must match the entity the handler\nexpects — `pattern` and `filter` are valid on the design share\nendpoint; `view` is valid on the view share endpoint.\n",
+                  "enum": [
+                    "pattern",
+                    "filter",
+                    "view"
+                  ]
+                },
+                "emails": {
+                  "type": "array",
+                  "description": "Email addresses of the recipients to share this content with.",
+                  "items": {
+                    "type": "string",
+                    "format": "email"
+                  }
+                },
+                "share": {
+                  "type": "boolean",
+                  "description": "When true, flip visibility to public and send invitation emails to\nthe recipients. When false, revert visibility to private.\n"
+                }
+              }
             }
           }
         }

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -543,6 +543,10 @@ const injectedRtkApi = api
         }),
         providesTags: ["View_views"],
       }),
+      shareView: build.mutation<ShareViewApiResponse, ShareViewApiArg>({
+        query: (queryArg) => ({ url: `/api/content/view/share`, method: "POST", body: queryArg.body }),
+        invalidatesTags: ["View_views"],
+      }),
       getViewById: build.query<GetViewByIdApiResponse, GetViewByIdApiArg>({
         query: (queryArg) => ({ url: `/api/content/views/${queryArg.viewId}` }),
         providesTags: ["View_views"],
@@ -1081,6 +1085,10 @@ const injectedRtkApi = api
           url: `/api/resource/${queryArg.resourceType}/share/${queryArg.resourceId}/${queryArg.actorType}`,
         }),
         providesTags: ["Design_designs"],
+      }),
+      shareDesign: build.mutation<ShareDesignApiResponse, ShareDesignApiArg>({
+        query: (queryArg) => ({ url: `/api/content/design/share`, method: "POST", body: queryArg.body }),
+        invalidatesTags: ["Design_designs"],
       }),
       getCatalogRequest: build.query<GetCatalogRequestApiResponse, GetCatalogRequestApiArg>({
         query: (queryArg) => ({
@@ -3895,6 +3903,25 @@ export type GetViewsApiArg = {
   orgId?: string;
   /** UUID of the user whose views to retrieve. */
   userId?: string;
+};
+export type ShareViewApiResponse = unknown;
+export type ShareViewApiArg = {
+  /** Body for sharing a view with recipients by email. */
+  body: {
+    /** Identifier of the view being shared. */
+    content_id: string;
+    /** The kind of content being shared. On this endpoint only `view` is
+        accepted; the enum is kept open for symmetry with the design share
+        endpoint so a single client-side type can back both calls.
+         */
+    content_type: "pattern" | "filter" | "view";
+    /** Email addresses of the recipients to share this view with. */
+    emails: string[];
+    /** When true, flip the view's visibility to public and send invitation
+        emails to the recipients. When false, revert visibility to private.
+         */
+    share: boolean;
+  };
 };
 export type GetViewByIdApiResponse = /** status 200 View */ {
   /** Unique identifier for the view. */
@@ -13924,6 +13951,25 @@ export type GetResourceAccessActorsByTypeApiArg = {
   resourceId: string;
   actorType: string;
 };
+export type ShareDesignApiResponse = unknown;
+export type ShareDesignApiArg = {
+  /** Body for sharing a design, filter, or view with recipients by email. */
+  body: {
+    /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
+    content_id: string;
+    /** The kind of content being shared. Must match the entity the handler
+        expects — `pattern` and `filter` are valid on the design share
+        endpoint; `view` is valid on the view share endpoint.
+         */
+    content_type: "pattern" | "filter" | "view";
+    /** Email addresses of the recipients to share this content with. */
+    emails: string[];
+    /** When true, flip visibility to public and send invitation emails to
+        the recipients. When false, revert visibility to private.
+         */
+    share: boolean;
+  };
+};
 export type GetCatalogRequestApiResponse = /** status 200 Catalog requests page */ {
   /** Current page number of the result set. */
   page?: number;
@@ -14858,6 +14904,7 @@ export const {
   useGetUserQuery,
   useCreateViewMutation,
   useGetViewsQuery,
+  useShareViewMutation,
   useGetViewByIdQuery,
   useUpdateViewMutation,
   useDeleteViewMutation,
@@ -14928,6 +14975,7 @@ export const {
   useCloneFilterMutation,
   useHandleResourceShareMutation,
   useGetResourceAccessActorsByTypeQuery,
+  useShareDesignMutation,
   useGetCatalogRequestQuery,
   useDeleteEventsByIdMutation,
   usePostEventsMutation,

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -3910,11 +3910,10 @@ export type ShareViewApiArg = {
   body: {
     /** Identifier of the view being shared. */
     content_id: string;
-    /** The kind of content being shared. On this endpoint only `view` is
-        accepted; the enum is kept open for symmetry with the design share
-        endpoint so a single client-side type can back both calls.
+    /** The kind of content being shared. Only `view` is accepted on this
+        endpoint.
          */
-    content_type: "pattern" | "filter" | "view";
+    content_type: "view";
     /** Email addresses of the recipients to share this view with. */
     emails: string[];
     /** When true, flip the view's visibility to public and send invitation


### PR DESCRIPTION
## Summary

Publishes two endpoints that meshery-cloud has implemented for a long time but
that were never surfaced from `@meshery/schemas`, forcing every consumer to
re-declare them locally. Introduces a reusable `Visibility` enum along the way
so downstream Go + TS consumers stop treating it as a bare string.

### New shared schema

- `components.schemas.Visibility` (enum: `private` | `public` | `published`)
  added to **all three** core variants (`v1alpha1`, `v1beta1`, `v1beta2`).
  Only `v1alpha1/core` generates Go; the others are added so cross-construct
  `$ref` resolution stays consistent. The existing `visibility` query parameter
  in each core variant now `$ref`s the new schema, promoting the
  `type Visibility = string` alias to a proper named type with constants
  (`core.Private`, `core.Public`, `core.Published`).
- `ContentSharePayload` in `v1beta2/design` (canonical) and inlined in
  `v1beta1/view` (identical wire format). Fields:
  - `content_id` — uuid of the resource being shared
  - `content_type` — enum: `pattern` | `filter` | `view`
  - `emails` — recipient email addresses
  - `share` — flip visibility to public + send invitations, or revert to private

The field is `content_id` rather than `id` to make the client-provided
semantic explicit and to satisfy the Dual-Schema Pattern rule (payloads must
not require server-generated fields).

### New endpoints

- `POST /api/content/design/share` (operationId `shareDesign`) in `v1beta2/design`
- `POST /api/content/view/share` (operationId `shareView`) in `v1beta1/view`

Both use the `ContentSharePayload` schema. The cloud RTK client now exposes
`useShareDesignMutation` and `useShareViewMutation` — meshery-cloud and
meshery-extensions (Kanvas) can replace their locally-defined share mutations
with the generated imports in a follow-up PR.

### Why `ContentSharePayload` is duplicated in `v1beta1/view`

There's no existing precedent in this repo for a `$ref` that crosses major
schema versions (v1beta1 → v1beta2). Rather than introducing a new pattern
in this PR, the view payload is inlined — the wire format matches the
canonical `v1beta2/design` payload exactly. Go consumers are encouraged to
import `designv1beta2.ContentSharePayload` and reuse it for both endpoints.

### Breaking change note

`core.Visibility` changes from a `string` type alias to a named type. Callers
doing `var v core.Visibility = someStringVar` now need an explicit conversion
(`core.Visibility(someStringVar)`). String literals (`"private"`, etc.) still
assign cleanly.

## Test plan

- [x] `make validate-schemas` — no blocking violations
- [x] `make audit-schemas` — no new advisory violations for the added endpoints/schemas
- [x] `make bundle-openapi` — all constructs bundled
- [x] `make generate-golang` — clean regeneration with pinned `oapi-codegen@v2.5.1`
- [x] `make generate-rtk` — `shareDesign` + `shareView` mutations present in `typescript/rtk/cloud.ts`
- [x] `make generate-ts` — TS type artifacts refreshed
- [x] `go build ./...` — all packages compile
- [x] `go test ./...` — all test packages pass (`models/core`, `models/permissions`, `models/v1beta1/connection`, `models/v1beta1/user`, `validation`)

## Follow-ups (separate PRs)

- meshery-cloud: remove `ShareRequestBody` struct + dead `handleShare`/`handleShareView` mutations in `ui/api/api.ts`; switch handlers and frontend to the generated types and hooks.
- meshery-extensions (Kanvas): remove locally-injected `shareView` / `shareResource` RTK endpoints; use the imported `useShareDesignMutation` / `useShareViewMutation` from `@meshery/schemas/cloudApi`.
