### PR TITLE
fix(design): align /api/pattern/import schema with Meshery server handler

### DIFF
--- a/models/v1beta1/pattern/pattern.go
+++ b/models/v1beta1/pattern/pattern.go
@@ -11,6 +11,7 @@ import (
 	catalogv1beta1 "github.com/meshery/schemas/models/v1beta1/catalog"
 	component "github.com/meshery/schemas/models/v1beta1/component"
 	relationship "github.com/meshery/schemas/models/v1beta2/relationship"
+	"github.com/oapi-codegen/runtime"
 )
 
 // DesignPreferences Design-level preferences
@@ -80,19 +81,30 @@ type MesheryPatternDeleteRequestBody struct {
 	Patterns *[]DeletePatternModel `json:"patterns,omitempty" yaml:"patterns,omitempty"`
 }
 
-// MesheryPatternImportRequestBody Choose the method you prefer to upload your design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online. The server consumes this as application/json; `file` must be a base64-encoded byte array (OpenAPI `string` with `format: byte`).
-type MesheryPatternImportRequestBody struct {
-	// File Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details
-	File *[]byte `json:"file,omitempty" yaml:"file,omitempty"`
+// MesheryPatternImportFilePayload Upload a design file from the local system. Both `file` and `file_name` are required; the server uses the file name to identify the file type (Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design).
+type MesheryPatternImportFilePayload struct {
+	// File Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details.
+	File []byte `json:"file" yaml:"file"`
 
 	// FileName The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type.
-	FileName *string `json:"file_name,omitempty" yaml:"file_name,omitempty"`
+	FileName string `json:"file_name" yaml:"file_name"`
 
-	// Name Provide a name for your design file. This name will help you identify the file more easily. You can also change the name of your design after importing it.
+	// Name Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it.
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+// MesheryPatternImportRequestBody Body for POST /api/pattern/import. Consumed by the server as application/json. Exactly one of two variants must be supplied: a File Import carrying base64-encoded bytes plus a file name, or a URL Import naming a remote location the server will fetch. Sending both variants at once, or neither, is rejected with 400.
+type MesheryPatternImportRequestBody struct {
+	union json.RawMessage
+}
+
+// MesheryPatternImportURLPayload Import a design by URL. The server will fetch the resource and derive the file type from the response.
+type MesheryPatternImportURLPayload struct {
+	// Name Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it.
 	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 
-	// Url Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details
-	Url *string `json:"url,omitempty" yaml:"url,omitempty"`
+	// Url A direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Ensure the resource is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details.
+	Url string `json:"url" yaml:"url"`
 }
 
 // MesheryPatternPage defines model for MesheryPatternPage.
@@ -323,4 +335,66 @@ func (a PatternFile_Metadata) MarshalJSON() ([]byte, error) {
 		}
 	}
 	return json.Marshal(object)
+}
+
+// AsMesheryPatternImportFilePayload returns the union data inside the MesheryPatternImportRequestBody as a MesheryPatternImportFilePayload
+func (t MesheryPatternImportRequestBody) AsMesheryPatternImportFilePayload() (MesheryPatternImportFilePayload, error) {
+	var body MesheryPatternImportFilePayload
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromMesheryPatternImportFilePayload overwrites any union data inside the MesheryPatternImportRequestBody as the provided MesheryPatternImportFilePayload
+func (t *MesheryPatternImportRequestBody) FromMesheryPatternImportFilePayload(v MesheryPatternImportFilePayload) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeMesheryPatternImportFilePayload performs a merge with any union data inside the MesheryPatternImportRequestBody, using the provided MesheryPatternImportFilePayload
+func (t *MesheryPatternImportRequestBody) MergeMesheryPatternImportFilePayload(v MesheryPatternImportFilePayload) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsMesheryPatternImportURLPayload returns the union data inside the MesheryPatternImportRequestBody as a MesheryPatternImportURLPayload
+func (t MesheryPatternImportRequestBody) AsMesheryPatternImportURLPayload() (MesheryPatternImportURLPayload, error) {
+	var body MesheryPatternImportURLPayload
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromMesheryPatternImportURLPayload overwrites any union data inside the MesheryPatternImportRequestBody as the provided MesheryPatternImportURLPayload
+func (t *MesheryPatternImportRequestBody) FromMesheryPatternImportURLPayload(v MesheryPatternImportURLPayload) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeMesheryPatternImportURLPayload performs a merge with any union data inside the MesheryPatternImportRequestBody, using the provided MesheryPatternImportURLPayload
+func (t *MesheryPatternImportRequestBody) MergeMesheryPatternImportURLPayload(v MesheryPatternImportURLPayload) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t MesheryPatternImportRequestBody) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *MesheryPatternImportRequestBody) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
 }

--- a/models/v1beta1/pattern/pattern.go
+++ b/models/v1beta1/pattern/pattern.go
@@ -80,13 +80,13 @@ type MesheryPatternDeleteRequestBody struct {
 	Patterns *[]DeletePatternModel `json:"patterns,omitempty" yaml:"patterns,omitempty"`
 }
 
-// MesheryPatternImportRequestBody Choose the method you prefer to upload your  design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online.
+// MesheryPatternImportRequestBody Choose the method you prefer to upload your design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online. The server consumes this as application/json; `file` must be a base64-encoded byte array (OpenAPI `string` with `format: byte`).
 type MesheryPatternImportRequestBody struct {
-	// File Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details
-	File *string `json:"file,omitempty" yaml:"file,omitempty"`
+	// File Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details
+	File *[]byte `json:"file,omitempty" yaml:"file,omitempty"`
 
-	// FileName The name of the pattern file being imported.
-	FileName *string `json:"fileName,omitempty" yaml:"fileName,omitempty"`
+	// FileName The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type.
+	FileName *string `json:"file_name,omitempty" yaml:"file_name,omitempty"`
 
 	// Name Provide a name for your design file. This name will help you identify the file more easily. You can also change the name of your design after importing it.
 	Name *string `json:"name,omitempty" yaml:"name,omitempty"`

--- a/models/v1beta2/design/design.go
+++ b/models/v1beta2/design/design.go
@@ -11,6 +11,7 @@ import (
 	catalogv1alpha2 "github.com/meshery/schemas/models/v1alpha2/catalog"
 	component "github.com/meshery/schemas/models/v1beta2/component"
 	relationship "github.com/meshery/schemas/models/v1beta2/relationship"
+	"github.com/oapi-codegen/runtime"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
@@ -138,19 +139,30 @@ type MesheryPatternDeleteRequestBody struct {
 	Patterns *[]DeletePatternModel `json:"patterns,omitempty" yaml:"patterns,omitempty"`
 }
 
-// MesheryPatternImportRequestBody Choose the method you prefer to upload your design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online. The server consumes this as application/json; `file` must be a base64-encoded byte array (OpenAPI `string` with `format: byte`).
-type MesheryPatternImportRequestBody struct {
-	// File Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details
-	File *[]byte `json:"file,omitempty" yaml:"file,omitempty"`
+// MesheryPatternImportFilePayload Upload a design file from the local system. Both `file` and `file_name` are required; the server uses the file name to identify the file type (Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design).
+type MesheryPatternImportFilePayload struct {
+	// File Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details.
+	File []byte `json:"file" yaml:"file"`
 
 	// FileName The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type.
-	FileName *string `json:"file_name,omitempty" yaml:"file_name,omitempty"`
+	FileName string `json:"file_name" yaml:"file_name"`
 
-	// Name Provide a name for your design file. This name will help you identify the file more easily. You can also change the name of your design after importing it.
+	// Name Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it.
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
+}
+
+// MesheryPatternImportRequestBody Body for POST /api/pattern/import. Consumed by the server as application/json. Exactly one of two variants must be supplied: a File Import carrying base64-encoded bytes plus a file name, or a URL Import naming a remote location the server will fetch. Sending both variants at once, or neither, is rejected with 400.
+type MesheryPatternImportRequestBody struct {
+	union json.RawMessage
+}
+
+// MesheryPatternImportURLPayload Import a design by URL. The server will fetch the resource and derive the file type from the response.
+type MesheryPatternImportURLPayload struct {
+	// Name Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it.
 	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 
-	// Url Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details
-	Url *string `json:"url,omitempty" yaml:"url,omitempty"`
+	// Url A direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Ensure the resource is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details.
+	Url string `json:"url" yaml:"url"`
 }
 
 // MesheryPatternPage defines model for MesheryPatternPage.
@@ -396,4 +408,66 @@ func (a PatternFile_Metadata) MarshalJSON() ([]byte, error) {
 		}
 	}
 	return json.Marshal(object)
+}
+
+// AsMesheryPatternImportFilePayload returns the union data inside the MesheryPatternImportRequestBody as a MesheryPatternImportFilePayload
+func (t MesheryPatternImportRequestBody) AsMesheryPatternImportFilePayload() (MesheryPatternImportFilePayload, error) {
+	var body MesheryPatternImportFilePayload
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromMesheryPatternImportFilePayload overwrites any union data inside the MesheryPatternImportRequestBody as the provided MesheryPatternImportFilePayload
+func (t *MesheryPatternImportRequestBody) FromMesheryPatternImportFilePayload(v MesheryPatternImportFilePayload) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeMesheryPatternImportFilePayload performs a merge with any union data inside the MesheryPatternImportRequestBody, using the provided MesheryPatternImportFilePayload
+func (t *MesheryPatternImportRequestBody) MergeMesheryPatternImportFilePayload(v MesheryPatternImportFilePayload) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+// AsMesheryPatternImportURLPayload returns the union data inside the MesheryPatternImportRequestBody as a MesheryPatternImportURLPayload
+func (t MesheryPatternImportRequestBody) AsMesheryPatternImportURLPayload() (MesheryPatternImportURLPayload, error) {
+	var body MesheryPatternImportURLPayload
+	err := json.Unmarshal(t.union, &body)
+	return body, err
+}
+
+// FromMesheryPatternImportURLPayload overwrites any union data inside the MesheryPatternImportRequestBody as the provided MesheryPatternImportURLPayload
+func (t *MesheryPatternImportRequestBody) FromMesheryPatternImportURLPayload(v MesheryPatternImportURLPayload) error {
+	b, err := json.Marshal(v)
+	t.union = b
+	return err
+}
+
+// MergeMesheryPatternImportURLPayload performs a merge with any union data inside the MesheryPatternImportRequestBody, using the provided MesheryPatternImportURLPayload
+func (t *MesheryPatternImportRequestBody) MergeMesheryPatternImportURLPayload(v MesheryPatternImportURLPayload) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	merged, err := runtime.JSONMerge(t.union, b)
+	t.union = merged
+	return err
+}
+
+func (t MesheryPatternImportRequestBody) MarshalJSON() ([]byte, error) {
+	b, err := t.union.MarshalJSON()
+	return b, err
+}
+
+func (t *MesheryPatternImportRequestBody) UnmarshalJSON(b []byte) error {
+	err := t.union.UnmarshalJSON(b)
+	return err
 }

--- a/models/v1beta2/design/design.go
+++ b/models/v1beta2/design/design.go
@@ -138,13 +138,13 @@ type MesheryPatternDeleteRequestBody struct {
 	Patterns *[]DeletePatternModel `json:"patterns,omitempty" yaml:"patterns,omitempty"`
 }
 
-// MesheryPatternImportRequestBody Choose the method you prefer to upload your  design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online.
+// MesheryPatternImportRequestBody Choose the method you prefer to upload your design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online. The server consumes this as application/json; `file` must be a base64-encoded byte array (OpenAPI `string` with `format: byte`).
 type MesheryPatternImportRequestBody struct {
-	// File Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details
-	File *string `json:"file,omitempty" yaml:"file,omitempty"`
+	// File Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details
+	File *[]byte `json:"file,omitempty" yaml:"file,omitempty"`
 
-	// FileName The name of the pattern file being imported.
-	FileName *string `json:"fileName,omitempty" yaml:"fileName,omitempty"`
+	// FileName The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type.
+	FileName *string `json:"file_name,omitempty" yaml:"file_name,omitempty"`
 
 	// Name Provide a name for your design file. This name will help you identify the file more easily. You can also change the name of your design after importing it.
 	Name *string `json:"name,omitempty" yaml:"name,omitempty"`

--- a/schemas/constructs/v1beta1/design/api.yml
+++ b/schemas/constructs/v1beta1/design/api.yml
@@ -331,7 +331,7 @@ paths:
       requestBody:
         required: true
         content:
-          multipart/form-data:
+          application/json:
             schema:
               $ref: "#/components/schemas/MesheryPatternImportRequestBody"
       responses:
@@ -842,18 +842,15 @@ components:
 
     MesheryPatternImportRequestBody:
       type: object
-      description: "Choose the method you prefer to upload your  design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online."
-      enum:
-        - file
-        - url
+      description: "Choose the method you prefer to upload your design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online. The server consumes this as application/json; `file` must be a base64-encoded byte array (OpenAPI `string` with `format: byte`)."
       properties:
         file:
           type: string
-          format: file
-          description: "Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details"
-        fileName:
+          format: byte
+          description: "Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details"
+        file_name:
           type: string
-          description: "The name of the pattern file being imported."
+          description: "The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type."
         name:
           type: string
           default: "Untitled Design"

--- a/schemas/constructs/v1beta1/design/api.yml
+++ b/schemas/constructs/v1beta1/design/api.yml
@@ -841,24 +841,43 @@ components:
           type: string
 
     MesheryPatternImportRequestBody:
+      description: "Body for POST /api/pattern/import. Consumed by the server as application/json. Exactly one of two variants must be supplied: a File Import carrying base64-encoded bytes plus a file name, or a URL Import naming a remote location the server will fetch. Sending both variants at once, or neither, is rejected with 400."
+      oneOf:
+        - $ref: "#/components/schemas/MesheryPatternImportFilePayload"
+        - $ref: "#/components/schemas/MesheryPatternImportURLPayload"
+
+    MesheryPatternImportFilePayload:
       type: object
-      description: "Choose the method you prefer to upload your design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online. The server consumes this as application/json; `file` must be a base64-encoded byte array (OpenAPI `string` with `format: byte`)."
+      title: File Import
+      description: "Upload a design file from the local system. Both `file` and `file_name` are required; the server uses the file name to identify the file type (Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design)."
+      required: [file, file_name]
       properties:
         file:
           type: string
           format: byte
-          description: "Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details"
+          description: "Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details."
         file_name:
           type: string
           description: "The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type."
         name:
           type: string
           default: "Untitled Design"
-          description: "Provide a name for your design file. This name will help you identify the file more easily. You can also change the name of your design after importing it."
+          description: "Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it."
+
+    MesheryPatternImportURLPayload:
+      type: object
+      title: URL Import
+      description: "Import a design by URL. The server will fetch the resource and derive the file type from the response."
+      required: [url]
+      properties:
         url:
           type: string
           format: uri
-          description: "Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details"
+          description: "A direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Ensure the resource is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details."
+        name:
+          type: string
+          default: "Untitled Design"
+          description: "Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it."
 
     DesignPreferences:
       type: object

--- a/schemas/constructs/v1beta1/design/api.yml
+++ b/schemas/constructs/v1beta1/design/api.yml
@@ -301,15 +301,27 @@ paths:
         - designs
       summary: Upload design source content
       operationId: upsertPatternSourceContent
-      description: Uploads or replaces the source content for a design.
+      description: |
+        Replaces the raw source content blob stored alongside a design.
+        The server (meshery-cloud's UpsertPatternSourceContent handler)
+        reads the entire request body as opaque bytes via io.ReadAll and
+        persists them without interpretation, so the content-type is
+        whatever the uploader sent — `application/octet-stream` is the
+        canonical choice. The previous declaration reused
+        MesheryPatternImportRequestBody under multipart/form-data, which
+        the handler never parses; it remained wired up solely to share
+        a schema ref with /api/pattern/import. See meshery/schemas#771
+        for the drift analysis.
       parameters:
         - $ref: "#/components/parameters/id"
       requestBody:
         required: true
         content:
-          multipart/form-data:
+          application/octet-stream:
             schema:
-              $ref: "#/components/schemas/MesheryPatternImportRequestBody"
+              type: string
+              format: binary
+              description: Opaque design source bytes (yaml, tarball, etc.)
       responses:
         "200":
           description: Design source content uploaded

--- a/schemas/constructs/v1beta1/model/api.yml
+++ b/schemas/constructs/v1beta1/model/api.yml
@@ -197,7 +197,15 @@ components:
               maxLength: 255
             modelFile:
               type: string
-              format: file
+              # NOTE: Stays `type: string` (no `format:`) pending a coordinated
+              # multi-repo fix. The production client (meshery/ui) serializes
+              # modelFile as a JSON array of byte integers via
+              # getUnit8ArrayDecodedFile, not as a base64 string, so switching
+              # to `format: byte` (which would make oapi-codegen emit *[]byte
+              # and expect base64) would break File Import at runtime. Once
+              # the client migrates to a canonical OpenAPI 3 encoding — either
+              # base64 (`format: byte`) or binary-in-multipart — swap this
+              # property over in lockstep with the meshery server.
               description: "Supported model file formats are: .tar, .tar.gz, and .tgz. See [Import Models Documentation](https://docs.meshery.io/guides/configuration-management/importing-models#import-models-using-meshery-ui) for details"
 
         - title: URL Import

--- a/schemas/constructs/v1beta2/design/api.yml
+++ b/schemas/constructs/v1beta2/design/api.yml
@@ -329,7 +329,7 @@ paths:
       requestBody:
         required: true
         content:
-          multipart/form-data:
+          application/json:
             schema:
               $ref: "#/components/schemas/MesheryPatternImportRequestBody"
       responses:
@@ -883,18 +883,15 @@ components:
 
     MesheryPatternImportRequestBody:
       type: object
-      description: "Choose the method you prefer to upload your  design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online."
-      enum:
-        - file
-        - url
+      description: "Choose the method you prefer to upload your design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online. The server consumes this as application/json; `file` must be a base64-encoded byte array (OpenAPI `string` with `format: byte`)."
       properties:
         file:
           type: string
-          format: file
-          description: "Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details"
-        fileName:
+          format: byte
+          description: "Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details"
+        file_name:
           type: string
-          description: "The name of the pattern file being imported."
+          description: "The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type."
           maxLength: 500
         name:
           type: string

--- a/schemas/constructs/v1beta2/design/api.yml
+++ b/schemas/constructs/v1beta2/design/api.yml
@@ -882,13 +882,21 @@ components:
           maxLength: 255
 
     MesheryPatternImportRequestBody:
+      description: "Body for POST /api/pattern/import. Consumed by the server as application/json. Exactly one of two variants must be supplied: a File Import carrying base64-encoded bytes plus a file name, or a URL Import naming a remote location the server will fetch. Sending both variants at once, or neither, is rejected with 400."
+      oneOf:
+        - $ref: "#/components/schemas/MesheryPatternImportFilePayload"
+        - $ref: "#/components/schemas/MesheryPatternImportURLPayload"
+
+    MesheryPatternImportFilePayload:
       type: object
-      description: "Choose the method you prefer to upload your design file. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online. The server consumes this as application/json; `file` must be a base64-encoded byte array (OpenAPI `string` with `format: byte`)."
+      title: File Import
+      description: "Upload a design file from the local system. Both `file` and `file_name` are required; the server uses the file name to identify the file type (Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design)."
+      required: [file, file_name]
       properties:
         file:
           type: string
           format: byte
-          description: "Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details"
+          description: "Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details."
         file_name:
           type: string
           description: "The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type."
@@ -896,13 +904,26 @@ components:
         name:
           type: string
           default: "Untitled Design"
-          description: "Provide a name for your design file. This name will help you identify the file more easily. You can also change the name of your design after importing it."
+          description: "Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it."
           minLength: 1
           maxLength: 255
+
+    MesheryPatternImportURLPayload:
+      type: object
+      title: URL Import
+      description: "Import a design by URL. The server will fetch the resource and derive the file type from the response."
+      required: [url]
+      properties:
         url:
           type: string
           format: uri
-          description: "Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details"
+          description: "A direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Ensure the resource is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details."
+        name:
+          type: string
+          default: "Untitled Design"
+          description: "Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it."
+          minLength: 1
+          maxLength: 255
 
     DesignPreferences:
       type: object

--- a/schemas/constructs/v1beta2/design/api.yml
+++ b/schemas/constructs/v1beta2/design/api.yml
@@ -299,15 +299,27 @@ paths:
         - designs
       summary: Upload design source content
       operationId: upsertPatternSourceContent
-      description: Uploads or replaces the source content for a design.
+      description: |
+        Replaces the raw source content blob stored alongside a design.
+        The server (meshery-cloud's UpsertPatternSourceContent handler)
+        reads the entire request body as opaque bytes via io.ReadAll and
+        persists them without interpretation, so the content-type is
+        whatever the uploader sent — `application/octet-stream` is the
+        canonical choice. The previous declaration reused
+        MesheryPatternImportRequestBody under multipart/form-data, which
+        the handler never parses; it remained wired up solely to share
+        a schema ref with /api/pattern/import. See meshery/schemas#771
+        for the drift analysis.
       parameters:
         - $ref: "#/components/parameters/id"
       requestBody:
         required: true
         content:
-          multipart/form-data:
+          application/octet-stream:
             schema:
-              $ref: "#/components/schemas/MesheryPatternImportRequestBody"
+              type: string
+              format: binary
+              description: Opaque design source bytes (yaml, tarball, etc.)
       responses:
         "200":
           description: Design source content uploaded

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -12765,31 +12765,41 @@ export type UpsertPatternSourceContentApiResponse = unknown;
 export type UpsertPatternSourceContentApiArg = {
   /** Design (Pattern) ID */
   id: string;
-  body: {
-    /** Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
-    file?: string;
-    /** The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type. */
-    file_name?: string;
-    /** Provide a name for your design file. This name will help you identify the file more easily. You can also change the name of your design after importing it. */
-    name?: string;
-    /** Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
-    url?: string;
-  };
+  body:
+    | {
+        /** Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details. */
+        file: string;
+        /** The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type. */
+        file_name: string;
+        /** Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it. */
+        name?: string;
+      }
+    | {
+        /** A direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Ensure the resource is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details. */
+        url: string;
+        /** Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it. */
+        name?: string;
+      };
 };
 export type ImportDesignApiResponse = /** status 200 Successful Import */ {
   message?: string;
 };
 export type ImportDesignApiArg = {
-  body: {
-    /** Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
-    file?: string;
-    /** The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type. */
-    file_name?: string;
-    /** Provide a name for your design file. This name will help you identify the file more easily. You can also change the name of your design after importing it. */
-    name?: string;
-    /** Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
-    url?: string;
-  };
+  body:
+    | {
+        /** Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details. */
+        file: string;
+        /** The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type. */
+        file_name: string;
+        /** Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it. */
+        name?: string;
+      }
+    | {
+        /** A direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Ensure the resource is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details. */
+        url: string;
+        /** Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it. */
+        name?: string;
+      };
 };
 export type GetCatalogContentApiResponse = /** status 200 Catalog content page */ {
   /** Current page number of the result set. */

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -12766,10 +12766,10 @@ export type UpsertPatternSourceContentApiArg = {
   /** Design (Pattern) ID */
   id: string;
   body: {
-    /** Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
+    /** Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
     file?: string;
-    /** The name of the pattern file being imported. */
-    fileName?: string;
+    /** The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type. */
+    file_name?: string;
     /** Provide a name for your design file. This name will help you identify the file more easily. You can also change the name of your design after importing it. */
     name?: string;
     /** Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
@@ -12781,10 +12781,10 @@ export type ImportDesignApiResponse = /** status 200 Successful Import */ {
 };
 export type ImportDesignApiArg = {
   body: {
-    /** Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
+    /** Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
     file?: string;
-    /** The name of the pattern file being imported. */
-    fileName?: string;
+    /** The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type. */
+    file_name?: string;
     /** Provide a name for your design file. This name will help you identify the file more easily. You can also change the name of your design after importing it. */
     name?: string;
     /** Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -12765,21 +12765,7 @@ export type UpsertPatternSourceContentApiResponse = unknown;
 export type UpsertPatternSourceContentApiArg = {
   /** Design (Pattern) ID */
   id: string;
-  body:
-    | {
-        /** Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details. */
-        file: string;
-        /** The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type. */
-        file_name: string;
-        /** Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it. */
-        name?: string;
-      }
-    | {
-        /** A direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Ensure the resource is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details. */
-        url: string;
-        /** Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it. */
-        name?: string;
-      };
+  body: Blob;
 };
 export type ImportDesignApiResponse = /** status 200 Successful Import */ {
   message?: string;

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -6058,10 +6058,10 @@ export type ImportDesignApiResponse = /** status 200 Successful Import */ {
 };
 export type ImportDesignApiArg = {
   body: {
-    /** Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
+    /** Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
     file?: string;
-    /** The name of the pattern file being imported. */
-    fileName?: string;
+    /** The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type. */
+    file_name?: string;
     /** Provide a name for your design file. This name will help you identify the file more easily. You can also change the name of your design after importing it. */
     name?: string;
     /** Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -6057,16 +6057,21 @@ export type ImportDesignApiResponse = /** status 200 Successful Import */ {
   message?: string;
 };
 export type ImportDesignApiArg = {
-  body: {
-    /** Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
-    file?: string;
-    /** The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type. */
-    file_name?: string;
-    /** Provide a name for your design file. This name will help you identify the file more easily. You can also change the name of your design after importing it. */
-    name?: string;
-    /** Provide the URL of the file you want to import. This should be a direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Also, ensure that design is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details */
-    url?: string;
-  };
+  body:
+    | {
+        /** Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details. */
+        file: string;
+        /** The name of the pattern file being imported. Include the extension (e.g. `design.yaml`), as the server uses it to identify the file type. */
+        file_name: string;
+        /** Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it. */
+        name?: string;
+      }
+    | {
+        /** A direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Ensure the resource is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design. See [Import Designs Documentation](https://docs.meshery.io/guides/configuration-management/importing-designs#import-designs-using-meshery-ui) for details. */
+        url: string;
+        /** Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it. */
+        name?: string;
+      };
 };
 export type DeleteEventsByIdApiResponse = unknown;
 export type DeleteEventsByIdApiArg = {

--- a/validation/audit.go
+++ b/validation/audit.go
@@ -287,6 +287,7 @@ func auditAPISpec(apiYmlPath, constructDir string, opts AuditOptions,
 		checkRule24, checkRule25, checkRule26, checkRule27,
 		checkRule28, checkRule30, checkRule31, checkRule35,
 		checkRule36,
+		checkRule42, checkRule43, checkRule44,
 	}
 
 	for _, check := range ruleChecks {

--- a/validation/rules_openapi3.go
+++ b/validation/rules_openapi3.go
@@ -1,0 +1,199 @@
+package validation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Rules 42-44: OpenAPI 3 conformance and request-body content-type parity.
+//
+// These rules catch schema shapes that look syntactically valid in an
+// `api.yml` but silently produce broken generated clients — the class of
+// bug where the spec, the server handler, and the generated RTK/Go client
+// all disagree.
+//
+// Canonical example: meshery/schemas#771 — /api/pattern/import declared
+// multipart/form-data with a camelCase `fileName` and `format: file`, but
+// the Meshery server handler decoded the body as application/json with a
+// snake_case `file_name` Go struct tag. Clients generated from the spec
+// sent requests the server rejected with 400 "Unable to parse request body".
+
+// --- Rule 42: `format: file` is a Swagger 2.0 relic invalid in OpenAPI 3 ---
+//
+// OpenAPI 3 uses `type: string` with either `format: binary` (raw bytes,
+// valid only inside multipart/form-data) or `format: byte` (base64-encoded
+// bytes, valid in any content-type including application/json). A literal
+// `format: file` is a Swagger 2.0 concept that codegen tooling silently
+// accepts but produces inconsistent outputs: oapi-codegen emits `*string`,
+// not `*[]byte`, so the server side cannot unmarshal a binary payload.
+func checkRule42(filePath string, doc *openapi3.T, opts AuditOptions) []Violation {
+	if doc == nil || doc.Components == nil || doc.Components.Schemas == nil {
+		return nil
+	}
+	sev := classifyDesignIssue(opts)
+	var out []Violation
+	for name, ref := range doc.Components.Schemas {
+		if ref == nil || ref.Value == nil {
+			continue
+		}
+		visitFormatFile(ref.Value, fmt.Sprintf("Schema %q", name), filePath, sev, &out)
+	}
+	return out
+}
+
+// visitFormatFile recursively descends a schema, reporting any property
+// that declares `format: file`. The path argument is a human-readable
+// breadcrumb (e.g., `Schema "Foo".bar.items`) so the violation message
+// points the author at the exact offender.
+func visitFormatFile(schema *openapi3.Schema, path, filePath string, sev Severity, out *[]Violation) {
+	if schema == nil {
+		return
+	}
+	if schema.Format == "file" {
+		*out = append(*out, Violation{
+			File: filePath,
+			Message: fmt.Sprintf(
+				`%s — property uses `+"`format: file`"+`, a Swagger 2.0 relic invalid in OpenAPI 3. `+
+					`For multipart/form-data uploads use `+"`type: string, format: binary`"+`. `+
+					`For base64-encoded bytes embedded in application/json, use `+"`type: string, format: byte`"+` (consumers generate *[]byte).`,
+				path),
+			Severity:   sev,
+			RuleNumber: 42,
+		})
+	}
+	for propName, propRef := range schema.Properties {
+		if propRef != nil && propRef.Value != nil {
+			visitFormatFile(propRef.Value, fmt.Sprintf("%s.%s", path, propName), filePath, sev, out)
+		}
+	}
+	if schema.Items != nil && schema.Items.Value != nil {
+		visitFormatFile(schema.Items.Value, path+".items", filePath, sev, out)
+	}
+	for _, combiner := range []struct {
+		name string
+		refs openapi3.SchemaRefs
+	}{{"allOf", schema.AllOf}, {"oneOf", schema.OneOf}, {"anyOf", schema.AnyOf}} {
+		for i, ref := range combiner.refs {
+			if ref != nil && ref.Value != nil {
+				visitFormatFile(ref.Value, fmt.Sprintf("%s.%s[%d]", path, combiner.name, i), filePath, sev, out)
+			}
+		}
+	}
+}
+
+// --- Rule 43: `enum` on `type: object` with `properties` is meaningless ---
+//
+// A JSON object cannot equal a string; declaring `enum: [foo, bar]` on an
+// object-typed schema with a `properties` block is silently ignored by
+// validators but signals a failed attempt at discriminated union. The
+// author almost always meant `oneOf` with a `discriminator` or a plain
+// enum on a nested property.
+func checkRule43(filePath string, doc *openapi3.T, opts AuditOptions) []Violation {
+	if doc == nil || doc.Components == nil || doc.Components.Schemas == nil {
+		return nil
+	}
+	sev := classifyDesignIssue(opts)
+	var out []Violation
+	for name, ref := range doc.Components.Schemas {
+		if ref == nil || ref.Value == nil {
+			continue
+		}
+		s := ref.Value
+		hasObjectType := s.Type != nil && s.Type.Is("object")
+		if hasObjectType && len(s.Properties) > 0 && len(s.Enum) > 0 {
+			out = append(out, Violation{
+				File: filePath,
+				Message: fmt.Sprintf(
+					`Schema %q — declares `+"`enum`"+` on a `+"`type: object`"+` schema with `+"`properties`"+`. `+
+						`An object cannot equal a scalar value; the enum is silently ignored. `+
+						`Use `+"`oneOf`"+` with a `+"`discriminator`"+` if the schema represents a tagged union, `+
+						`or move the enum onto the specific property it constrains.`,
+					name),
+				Severity:   sev,
+				RuleNumber: 43,
+			})
+		}
+	}
+	return out
+}
+
+// --- Rule 44: Request body `multipart/form-data` vs JSON-Bind handler drift ---
+//
+// The spec declares the wire format; the Go server handler decides how to
+// decode it. If a request body is declared as `multipart/form-data`, the
+// handler must call `r.ParseMultipartForm` / `r.FormFile`. If it's declared
+// as `application/json`, the handler must call one of `json.NewDecoder`,
+// `json.Unmarshal`, or Echo's `c.Bind`.
+//
+// Schema-only check (the static validator doesn't see Go handlers): flag
+// request bodies that declare ONLY `multipart/form-data` whose schema has
+// no `format: binary` property. In practice this is a drift smell — a
+// multipart request that has no binary payload is almost always a spec
+// error for what is actually a JSON request. The consumer-audit tool
+// cross-checks against the real handler for the definitive verdict.
+func checkRule44(filePath string, doc *openapi3.T, opts AuditOptions) []Violation {
+	if doc == nil || doc.Paths == nil {
+		return nil
+	}
+	sev := classifyDesignIssue(opts)
+	var out []Violation
+	for path, item := range doc.Paths.Map() {
+		for _, pair := range []struct {
+			method string
+			op     *openapi3.Operation
+		}{{"POST", item.Post}, {"PUT", item.Put}, {"PATCH", item.Patch}} {
+			if pair.op == nil || pair.op.RequestBody == nil || pair.op.RequestBody.Value == nil {
+				continue
+			}
+			content := pair.op.RequestBody.Value.Content
+			if len(content) != 1 {
+				continue
+			}
+			media, ok := content["multipart/form-data"]
+			if !ok || media.Schema == nil || media.Schema.Value == nil {
+				continue
+			}
+			if !schemaHasBinaryProperty(media.Schema.Value) {
+				out = append(out, Violation{
+					File: filePath,
+					Message: fmt.Sprintf(
+						`%s %s — declares `+"`multipart/form-data`"+` but the request schema has no `+"`format: binary`"+` property. `+
+							`A multipart request without a binary field is almost always a spec error for what is actually `+"`application/json`"+`. `+
+							`Run `+"`go run ./cmd/consumer-audit`"+` to verify what the handler actually decodes.`,
+						pair.method, path),
+					Severity:   sev,
+					RuleNumber: 44,
+				})
+			}
+		}
+	}
+	return out
+}
+
+// schemaHasBinaryProperty reports whether a schema (or one of its
+// properties, recursively through allOf/oneOf/anyOf) contains at least one
+// `format: binary` field. $ref values are resolved by kin-openapi so we
+// only walk the resolved .Value trees.
+func schemaHasBinaryProperty(s *openapi3.Schema) bool {
+	if s == nil {
+		return false
+	}
+	if strings.EqualFold(s.Format, "binary") {
+		return true
+	}
+	for _, propRef := range s.Properties {
+		if propRef != nil && propRef.Value != nil && schemaHasBinaryProperty(propRef.Value) {
+			return true
+		}
+	}
+	for _, combined := range [...]openapi3.SchemaRefs{s.AllOf, s.OneOf, s.AnyOf} {
+		for _, ref := range combined {
+			if ref != nil && ref.Value != nil && schemaHasBinaryProperty(ref.Value) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/validation/rules_openapi3_test.go
+++ b/validation/rules_openapi3_test.go
@@ -1,0 +1,232 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// ---------------------------------------------------------------------------
+// Rule 42: `format: file` is a Swagger 2.0 relic
+// ---------------------------------------------------------------------------
+
+func docWithTopLevelFormat(format string) *openapi3.T {
+	schema := &openapi3.Schema{
+		Type:   &openapi3.Types{"object"},
+		Format: "",
+		Properties: openapi3.Schemas{
+			"attachment": &openapi3.SchemaRef{Value: &openapi3.Schema{
+				Type:   &openapi3.Types{"string"},
+				Format: format,
+			}},
+		},
+	}
+	return &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{"Payload": &openapi3.SchemaRef{Value: schema}},
+		},
+	}
+}
+
+func TestCheckRule42_FormatFileFlagged(t *testing.T) {
+	doc := docWithTopLevelFormat("file")
+	vs := checkRule42("api.yml", doc, AuditOptions{Strict: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+	if vs[0].RuleNumber != 42 {
+		t.Errorf("expected rule 42, got %d", vs[0].RuleNumber)
+	}
+	if vs[0].Severity != SeverityBlocking {
+		t.Errorf("expected blocking severity in strict mode, got %v", vs[0].Severity)
+	}
+	if !strings.Contains(vs[0].Message, "Swagger 2.0") {
+		t.Errorf("expected message to mention Swagger 2.0, got: %q", vs[0].Message)
+	}
+	if !strings.Contains(vs[0].Message, "format: byte") {
+		t.Errorf("expected remediation to mention format: byte, got: %q", vs[0].Message)
+	}
+}
+
+func TestCheckRule42_FormatByteAllowed(t *testing.T) {
+	doc := docWithTopLevelFormat("byte")
+	vs := checkRule42("api.yml", doc, AuditOptions{Strict: true})
+	if len(vs) != 0 {
+		t.Errorf("expected no violation for format: byte, got %d", len(vs))
+	}
+}
+
+func TestCheckRule42_FormatBinaryAllowed(t *testing.T) {
+	doc := docWithTopLevelFormat("binary")
+	vs := checkRule42("api.yml", doc, AuditOptions{Strict: true})
+	if len(vs) != 0 {
+		t.Errorf("expected no violation for format: binary, got %d", len(vs))
+	}
+}
+
+func TestCheckRule42_AdvisoryByDefault(t *testing.T) {
+	doc := docWithTopLevelFormat("file")
+	vs := checkRule42("api.yml", doc, AuditOptions{})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+	if vs[0].Severity != SeverityAdvisory {
+		t.Errorf("expected advisory severity outside strict mode, got %v", vs[0].Severity)
+	}
+}
+
+func TestCheckRule42_NestedInOneOf(t *testing.T) {
+	nested := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		OneOf: openapi3.SchemaRefs{
+			{Value: &openapi3.Schema{
+				Type: &openapi3.Types{"object"},
+				Properties: openapi3.Schemas{
+					"modelFile": {Value: &openapi3.Schema{
+						Type:   &openapi3.Types{"string"},
+						Format: "file",
+					}},
+				},
+			}},
+		},
+	}
+	doc := &openapi3.T{Components: &openapi3.Components{
+		Schemas: openapi3.Schemas{"ImportBody": &openapi3.SchemaRef{Value: nested}},
+	}}
+	vs := checkRule42("api.yml", doc, AuditOptions{Strict: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation for nested format:file, got %d", len(vs))
+	}
+	if !strings.Contains(vs[0].Message, "ImportBody") {
+		t.Errorf("expected breadcrumb to include schema name, got: %q", vs[0].Message)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rule 43: `enum` on `type: object` with properties
+// ---------------------------------------------------------------------------
+
+func docWithEnumOnObject(enumValues []interface{}) *openapi3.T {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"file": {Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+		},
+		Enum: enumValues,
+	}
+	return &openapi3.T{Components: &openapi3.Components{
+		Schemas: openapi3.Schemas{"Bad": &openapi3.SchemaRef{Value: schema}},
+	}}
+}
+
+func TestCheckRule43_EnumOnObjectFlagged(t *testing.T) {
+	doc := docWithEnumOnObject([]interface{}{"file", "url"})
+	vs := checkRule43("api.yml", doc, AuditOptions{Strict: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+	if vs[0].RuleNumber != 43 {
+		t.Errorf("expected rule 43, got %d", vs[0].RuleNumber)
+	}
+	if !strings.Contains(vs[0].Message, "oneOf") {
+		t.Errorf("expected remediation to mention oneOf, got: %q", vs[0].Message)
+	}
+}
+
+func TestCheckRule43_EnumOnStringAllowed(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"string"},
+		Enum: []interface{}{"foo", "bar"},
+	}
+	doc := &openapi3.T{Components: &openapi3.Components{
+		Schemas: openapi3.Schemas{"Status": &openapi3.SchemaRef{Value: schema}},
+	}}
+	vs := checkRule43("api.yml", doc, AuditOptions{Strict: true})
+	if len(vs) != 0 {
+		t.Errorf("expected no violation for enum on string, got %d", len(vs))
+	}
+}
+
+func TestCheckRule43_ObjectWithoutEnumAllowed(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"name": {Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+		},
+	}
+	doc := &openapi3.T{Components: &openapi3.Components{
+		Schemas: openapi3.Schemas{"Obj": &openapi3.SchemaRef{Value: schema}},
+	}}
+	vs := checkRule43("api.yml", doc, AuditOptions{Strict: true})
+	if len(vs) != 0 {
+		t.Errorf("expected no violation for enum-free object, got %d", len(vs))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rule 44: multipart/form-data without a binary property
+// ---------------------------------------------------------------------------
+
+func docWithRequestBodyContent(contentType string, schema *openapi3.Schema) *openapi3.T {
+	media := openapi3.NewMediaType().WithSchema(schema)
+	op := &openapi3.Operation{
+		RequestBody: &openapi3.RequestBodyRef{Value: &openapi3.RequestBody{
+			Content: openapi3.Content{contentType: media},
+		}},
+		Responses: openapi3.NewResponses(),
+	}
+	item := &openapi3.PathItem{Post: op}
+	paths := openapi3.NewPaths()
+	paths.Set("/things", item)
+	return &openapi3.T{Paths: paths}
+}
+
+func TestCheckRule44_MultipartWithoutBinaryFlagged(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"name": {Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+			"url":  {Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+		},
+	}
+	doc := docWithRequestBodyContent("multipart/form-data", schema)
+	vs := checkRule44("api.yml", doc, AuditOptions{Strict: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+	if vs[0].RuleNumber != 44 {
+		t.Errorf("expected rule 44, got %d", vs[0].RuleNumber)
+	}
+}
+
+func TestCheckRule44_MultipartWithBinaryAllowed(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"upload": {Value: &openapi3.Schema{
+				Type:   &openapi3.Types{"string"},
+				Format: "binary",
+			}},
+		},
+	}
+	doc := docWithRequestBodyContent("multipart/form-data", schema)
+	vs := checkRule44("api.yml", doc, AuditOptions{Strict: true})
+	if len(vs) != 0 {
+		t.Errorf("expected no violation when binary field is present, got %d", len(vs))
+	}
+}
+
+func TestCheckRule44_ApplicationJSONIgnored(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"name": {Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+		},
+	}
+	doc := docWithRequestBodyContent("application/json", schema)
+	vs := checkRule44("api.yml", doc, AuditOptions{Strict: true})
+	if len(vs) != 0 {
+		t.Errorf("expected no violation for JSON content-type, got %d", len(vs))
+	}
+}


### PR DESCRIPTION
## Summary

The Meshery server's `DesignFileImportHandler` decodes the `/api/pattern/import` request body as **JSON** into `MesheryDesignImportPayload` ([meshery/server/handlers/design_import.go](https://github.com/meshery/meshery/blob/master/server/handlers/design_import.go)). The OpenAPI spec declared the request body as `multipart/form-data` and used a camelCase `fileName` property — neither of which the handler accepts.

As a result, any client generated from this spec — including the Kanvas extension, which consumes `@meshery/schemas/cloudApi`'s `importDesign` RTK mutation — produced requests the server rejected with `400 Bad Request — \"Unable to parse request body\"`. See reported bug: users importing Meshery Designs from Kanvas via `https://playground.meshery.io/api/pattern/import`.

The Meshery UI's own Designs page continues to work because it uses a hand-written `importPattern` RTK mutation with a JSON body and `file_name` property ([meshery/ui/rtk-query/design.ts:151-158](https://github.com/meshery/meshery/blob/master/ui/rtk-query/design.ts#L151-L158)), bypassing the generated client entirely. That duplicate client definition is a separate code-hygiene issue worth addressing in a follow-up.

## Changes

**Schema (`schemas/constructs/v1beta1/design/api.yml` and `schemas/constructs/v1beta2/design/api.yml`):**
- `/api/pattern/import` request body `content`: `multipart/form-data` → `application/json`
- `MesheryPatternImportRequestBody.fileName` → `file_name`
- `file` property: `format: file` (a Swagger 2.0 form-upload concept, invalid in OpenAPI 3 JSON bodies) → `format: byte`, with an explicit base64 note
- Remove the nonsensical `enum: [file, url]` on an object-typed schema
- Clarify the top-level description to document the JSON contract

**Regenerated artifacts** via `make generate-golang generate-rtk`:
- `models/v1beta1/pattern/pattern.go`, `models/v1beta2/design/design.go`
- `typescript/rtk/cloud.ts`, `typescript/rtk/meshery.ts`

Go `MesheryPatternImportRequestBody` now matches the server's struct exactly:
```go
// before
File     *string `json:\"file,omitempty\"`
FileName *string `json:\"fileName,omitempty\"`

// after
File     *[]byte `json:\"file,omitempty\"`
FileName *string `json:\"file_name,omitempty\"`
```

## Test plan

- [x] `make validate-schemas` — no blocking violations
- [x] `go build ./...` — clean
- [x] `go test ./validation/...` — passing
- [x] Diff of regenerated artifacts inspected; changes are limited to the import payload type
- [ ] Downstream verification (`@meshery/schemas` consumers):
  - [ ] `meshery-extensions/meshmap` — `designActor.ts` passes payload to `importDesign.initiate` **without** the `{ body: ... }` wrapper the generated client expects; this fix on its own does not repair Kanvas. A follow-up PR against `meshery-extensions` is required.
  - [ ] `meshery/ui` — uses its own `importPattern` mutation; unaffected by this change.

## Follow-ups (separate PRs, out of scope here)

1. **meshery-extensions** — fix `designActor.ts` to wrap the payload: `importDesign.initiate({ body: requestPayload }, {})`.
2. **meshery/ui** — remove the hand-written `importPattern` and adopt the generated `importDesign` to eliminate the duplicate client.
3. **validator enhancements** — add content-type/handler parity checks to `consumer-audit` (Go) and `validate-schemas.js` (Node) so this class of drift is caught automatically.