### PR TITLE
docs(governance): Option B identifier-naming migration plan

### DIFF
--- a/docs/identifier-naming-option-b-migration.md
+++ b/docs/identifier-naming-option-b-migration.md
@@ -1,0 +1,1074 @@
+# Identifier Naming Standardization — Option B Migration Plan
+
+**Canonical plan — fully executable by an orchestrated system of agents.**
+
+| Field | Value |
+|---|---|
+| Status | Active |
+| Authority | `meshery/schemas/AGENTS.md` after Phase 1.A |
+| Scope | `meshery/schemas`, `meshery/meshery`, `layer5io/meshery-cloud`, `layer5labs/meshery-extensions` |
+| Governance decision | Option B — camelCase on wire, snake_case only at the DB/ORM boundary |
+| Supersedes | Earlier three-layer audit report (the conditional "DB-backed → snake_case JSON tag" rule is retired) |
+| Effective | On merge of Phase 1.A |
+| Sunset | Old wire forms retired per resource over one release cycle after Phase 3 |
+
+---
+
+## 1. The Contract
+
+One contract, one rule per layer. The ORM boundary is the only translation layer.
+
+| Layer | Convention | Canonical examples | Counter-examples (forbidden) |
+|---|---|---|---|
+| DB column / `db:` tag | **snake_case** | `user_id`, `org_id`, `workspace_id`, `created_at`, `pattern_file` | `userId`, `orgID` |
+| Go struct field | **PascalCase with Go-idiomatic initialisms** | `UserID`, `OrgID`, `WorkspaceID`, `CreatedAt` | `User_id`, `userId` (unexported), `UserIdentifier` |
+| JSON tag / wire property | **camelCase** | `json:"userId"`, `json:"orgId"`, `json:"patternFile"`, `json:"createdAt"` | `json:"user_id"`, `json:"orgID"`, `json:"UserId"` |
+| URL query / path param | **camelCase, `Id` suffix** (lowercase `d`) | `{orgId}`, `?userId=...`, `?workspaceId=...` | `{orgID}`, `{org_id}`, `?organizationId=...` |
+| TypeScript property / RTK arg | **camelCase** | `response.userId`, `queryArg.orgId` | `response.user_id`, `queryArg.orgID` |
+| OpenAPI schema property | **camelCase** | `userId:`, `patternFile:`, `createdAt:` | `user_id:`, `patternFile` with snake sibling |
+| OpenAPI `operationId` | **lower camelCase verbNoun** | `getWorkspaces`, `createEnvironment` | `GetWorkspaces`, `get_workspaces`, `getByID` |
+| `components/schemas` type name | **PascalCase** | `WorkspacePayload`, `MesheryPattern` | `workspacePayload` |
+| Go generated type name | PascalCase (from `oapi-codegen`) | `Workspace`, `MesheryPattern` | — |
+| TypeScript generated type name | PascalCase (from RTK codegen) | `Workspace`, `MesheryPattern` | — |
+
+**The one-sentence rule:** *Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.*
+
+The earlier conditional "JSON tag matches `db:` tag when the field is DB-backed" is **retired**. All JSON tags on all fields — DB-backed or not — are camelCase. The `db:` tag in `x-oapi-codegen-extra-tags` remains snake_case and is the only place snake_case persists above the DB layer.
+
+---
+
+## 2. Objectives (measurable)
+
+1. **Single conditional eliminated.** `validation/casing.go` retires the DB-backed exception path; every wire property is checked against one camelCase rule, not a case-by-case DB lookup.
+2. **Zero in-repo drift-masking workarounds.** `utils.QueryParam(q, "orgId", "orgID")`-style fallbacks are removed after one deprecation release.
+3. **Zero locally-declared types that duplicate schemas.** `MesheryPattern`, `MesheryPatternRequestBody`, `MesheryFilter`, `MesheryApplication`, and the named locally-declared RTK endpoints are displaced by schemas-generated equivalents (or the schemas equivalent is added).
+4. **Consumer auditor in CI.** `make consumer-audit` runs on every PR in `meshery/schemas` with advisory output; promoted to blocking after Phase 3.
+5. **TypeScript consumer auditor exists.** `validation/consumer_ts.go` parses `ui/rtk-query/*.ts` across all four repos and diffs against the schemas endpoint index.
+6. **Repo-level governance pinned.** Every repo's `AGENTS.md` and `CLAUDE.md` mandates adherence to this plan and links to `schemas/AGENTS.md § Casing rules at a glance` as the authoritative reference.
+7. **Before/after metrics published.** Count of validator rules, drift-masking sites, locally-declared duplicates, CI gates; measured before and after.
+
+---
+
+## 3. Repo Scope Matrix
+
+| Repo | Role | In-scope work |
+|---|---|---|
+| `meshery/schemas` | Source of truth | `AGENTS.md` amendment; `validation/` rule authoring; `consumer_ts.go` authoring; CI wiring; per-resource API-version authoring in Phase 3; version-bump + publish |
+| `meshery/meshery` | Server (Go) + UI (TypeScript) + `mesheryctl` (CLI) | Query-param extraction alignment; outbound URL alignment; local-model displacement (`MesheryPattern`, `MesheryFilter`, `MesheryApplication`); RTK hook unification; CLI flag casing audit |
+| `layer5io/meshery-cloud` | Remote provider (Go) + UI (TypeScript) | Handler query-param constants; `utils.QueryParam` dual-accept removal; 9 mapping-model JSON tag fixes; `ContentID` JSON tag fix; `users.go MesheryPatternRequestBody` displacement; UI `api.ts` endpoint dedup vs. `@meshery/schemas/cloudApi` |
+| `layer5labs/meshery-extensions` | Kanvas (React/TS) + GraphQL plugin (Go) | Kanvas RTK catalog/designs case-flip removal; `SaveDesign` wrapper alignment (`pattern_data` → `patternData`); `mesherySdk` event-type casing; `collab/config` user-ID duality resolution; any GraphQL schema adjustments |
+
+---
+
+## 4. Phase Structure
+
+| Phase | Goal | Dependency | Duration estimate |
+|---|---|---|---|
+| **0** | Plan authored + baseline metrics collected | none | 1–2 days |
+| **1** | `schemas` governance doc + validator rules + CI wiring + package republish | Phase 0 complete | 1–2 weeks |
+| **2** | Non-breaking alignment across downstream repos (no API-version bump needed) | Phase 1 complete, new `@meshery/schemas` version available | 2–3 weeks (parallel) |
+| **3** | Per-resource versioned wire migration (one new API version per resource) | Phase 2 landed | 6–10 weeks (parallel per resource) |
+| **4** | Deprecation sunset + consumer-audit promoted to blocking + final AGENTS.md/CLAUDE.md updates | Phase 3 complete per resource, one release cycle elapsed | 2 weeks |
+
+Total: ~12–17 weeks. Phases 2 and 3 are heavily parallel.
+
+---
+
+## 5. Common Agent Protocol
+
+Every agent in this plan, regardless of phase, follows the Common Agent Protocol. Each agent specification in sections 6–10 references this protocol; do not re-state these steps per-agent.
+
+### 5.1 Preconditions (every agent verifies before starting)
+1. Clean working tree on a fresh branch cut from the target repo's default branch (typically `master` or `main`).
+2. The `gh` CLI authenticated for the repo.
+3. Required toolchain installed: Go 1.25+, Node 20+, the repo's Makefile targets runnable.
+4. `TaskList` checked to confirm no blocking task is pending.
+
+### 5.2 Execution loop (ordered)
+1. **Plan** — post a `TaskUpdate` with the plan summary, affected files, and acceptance criteria. Set task `in_progress`.
+2. **Implement** — make the changes described in the agent's charter.
+3. **Build locally** — run the repo's default build target (`make build` / `make server` / `npm run build` / `go build ./...`). Must succeed before committing. If it does not, diagnose, fix, re-run. Do not commit broken state.
+4. **Test locally** — run the repo's full test suite for the packages touched (`go test ./...` for Go; `npm test` for TypeScript). New behavior must have new tests; modified behavior must have updated tests.
+5. **Update documentation** — every code change updates the relevant docs in the same PR (§12 for the mandate).
+6. **Lint + format** — repo-required linters and formatters must pass (`make kanvas-lint`, `make graphql-lint`, `gofmt -l`, `golangci-lint run`, ESLint+Prettier). Hooks must pass; never pass `--no-verify`.
+7. **Commit** — signoff required (`git commit -s`). Descriptive commit messages in imperative mood; body explains *why*, not *what*.
+8. **Push + PR** — push branch to upstream (not a fork), open PR via `gh pr create` with the standard PR body template (§5.6).
+9. **Wait for automated review** — `copilot-pull-request-reviewer` and `gemini-code-assist` post automatically. Do not proceed to merge before both have reviewed or reviews have timed out (30 min).
+10. **Iterate on review** — address or refute each review comment:
+    - If valid: fix in new commit; reply to thread explaining the fix.
+    - If false positive: reply to thread explaining why, citing file:line evidence.
+    - Never silently ignore bot review feedback.
+11. **Re-run CI** — on each push, watch CI until green. Use `uv run ~/.claude/skills/iterate-pr/scripts/fetch_pr_checks.py` to poll.
+12. **Merge when criteria met** (§5.5). Arm auto-merge (`gh pr merge --auto`) as early as safe.
+13. **Task close** — `TaskUpdate status=completed` with the merge-commit SHA in the task comment.
+
+### 5.3 Review & iteration protocol (detailed)
+Automated reviewers on every PR:
+- **`copilot-pull-request-reviewer`** — focuses on correctness, edge cases, test gaps.
+- **`gemini-code-assist`** — focuses on structure, idiom, consistency with repo conventions.
+
+The agent must:
+- Reply to every inline thread with a `thread_id` using `~/.claude/skills/iterate-pr/scripts/reply_to_thread.py`.
+- Treat review-bot comments at medium or higher priority the same as human review: verify, then fix or refute with evidence.
+- Never add signatures, attribution, or tool-identity lines to replies.
+- Re-run the local test suite after every push that results from a review fix.
+
+Human reviewer required before merge for:
+- Any change to `meshery/schemas/AGENTS.md`
+- Any change to `schemas/validation/` that adds or inverts a blocking rule
+- Any Phase 3 per-resource API-version authoring PR
+- Any deprecation-sunset PR that removes an API version
+
+For non-governance changes, human reviewer optional; auto-merge can fire as soon as CI + bot review are green.
+
+### 5.4 Build + validation requirements
+Every PR must include:
+- **Compilation** — `go build ./...` clean (Go) or `npm run build` clean (TS); no warnings escalated.
+- **Unit tests** — touched packages pass; new behavior has new tests (§13).
+- **Linter** — `make <repo>-lint` / `golangci-lint run` / `eslint --max-warnings=0` all green.
+- **Format** — `gofmt`, `prettier --check` green.
+- **Integration smoke** — for handler or endpoint changes: verify against the schemas `consumer-audit` output (advisory) and verify the route-level change with a curl or unit test.
+- **Documentation** — touched feature's docs updated in the same PR (§12).
+
+### 5.5 Merge criteria (auto-merge armed when all met)
+- All required CI checks passing.
+- Every review-bot thread replied to (fix or refutation).
+- Human-review gate satisfied for governance changes.
+- Doc + test updates included in the PR.
+- No `[WIP]`, `[DO NOT MERGE]`, `Draft:` markers remain.
+- Branch rebase-current against target (or auto-rebase enabled).
+
+### 5.6 Standard PR body template
+
+```markdown
+## Summary
+- 1–3 bullets describing the change.
+
+## Why
+- The governance rationale, linked to §<section> of identifier-naming-option-b-migration.md
+
+## Changes
+- File-level diff summary.
+
+## Tests
+- [ ] Unit tests added/updated (list)
+- [ ] Local build clean: `<build command>`
+- [ ] Local test suite clean: `<test command>`
+- [ ] Lint clean: `<lint command>`
+
+## Docs
+- [ ] Touched feature's docs updated (list paths)
+- [ ] AGENTS.md / CLAUDE.md updated if the change establishes a new convention
+
+## Migration impact
+- Breaking / non-breaking
+- API-version bump required: yes/no
+- Consumer repos that must be updated: list
+
+## Rollback
+- How to revert safely.
+```
+
+### 5.7 Failure escalation
+An agent stops and escalates (posts to the parent task with `status=in_progress` preserved and a blocking comment) when:
+- Same failure recurs across 3 push attempts.
+- Review feedback requires a design decision outside the charter.
+- Build or test infrastructure is broken (not repaired by the agent's own work).
+- A dependency agent's prerequisite output is missing.
+
+Escalation comment format: `BLOCKED: <one-line reason>. <What I tried>. <What I need>.`
+
+---
+
+## 6. Phase 0 Agents
+
+Baseline metrics collection. Read-only. Output drives Phase 1 rule authoring and Phase 3 sequencing.
+
+### Agent 0.A — Field-count baseline (@meshery/schemas)
+**Charter:** Enumerate every JSON tag across `meshery/schemas` OpenAPI files (`schemas/constructs/v*/*/api.yml` and `*.yaml`), classify by current form (snake / camel / mixed), and produce a per-resource migration-surface count.
+
+**Outputs (committed to `meshery/schemas/validation/baseline/field-count.json`):**
+- Total JSON tags in scope
+- Count by form: snake_case, camelCase, PascalCase, other
+- Count DB-backed vs non-DB-backed (from `x-oapi-codegen-extra-tags.db`)
+- Per-resource row: `{resource, version, total_tags, snake_tags_to_migrate, camel_tags_stable}`
+
+**Acceptance:** JSON report commits; numbers match manual spot-check of three resources (workspace, environment, design).
+
+### Agent 0.B — Tag-divergence baseline (meshery + meshery-cloud Go)
+**Charter:** Scan every Go struct in `meshery/server/models/` and `meshery-cloud/server/models/` with `json:` and `db:` tags. Report every struct where: (i) JSON tag differs from `db:` tag (either form), (ii) multiple JSON-tag conventions appear on one struct, (iii) the `json:` tag is ALL CAPS.
+
+**Outputs (`meshery/schemas/validation/baseline/tag-divergence.json`):**
+- Array of `{repo, file, line, type, field, json_tag, db_tag, classification}`
+- Summary counts by classification
+
+**Acceptance:** Every struct flagged in the original audit is present; summary aligns with §15 impact report numbers.
+
+### Agent 0.C — Route-parity baseline (consumer-audit dry run)
+**Charter:** Run `cd /Users/l/code/schemas && make consumer-audit MESHERY_REPO=../meshery CLOUD_REPO=../meshery-cloud` (extend `Makefile` to accept `EXTENSIONS_REPO=` if not already there) against current-state repos. Capture output verbatim.
+
+**Outputs:** `meshery/schemas/validation/baseline/consumer-audit.txt` (verbatim) plus a summary of divergence classes.
+
+**Acceptance:** Output captured; known divergences (workspaces `orgID`, environments `orgId`, 9 mapping-model `json:"ID"`, etc.) present.
+
+### Agent 0.D — Consumer dependency graph
+**Charter:** For each downstream repo, identify which `@meshery/schemas` import sites use which schema resources. Build a DAG of `resource → consuming files` so Phase 3 sequencing can prioritize resources whose consumers are simple.
+
+**Outputs:** `meshery/schemas/validation/baseline/consumer-graph.json` — `{resource: {consuming_files: [], complexity_score: int}}`
+
+**Acceptance:** Graph covers all 22 resources in §9's inventory; complexity score uses a documented heuristic.
+
+---
+
+## 7. Phase 1 Agents — Schemas governance & validator hardening
+
+Serial execution; each depends on the prior landing. All work in `meshery/schemas`.
+
+### Agent 1.A — `AGENTS.md` Option B amendment
+**Charter:** Replace `§ Casing rules at a glance`, `§ Intentional Design Decisions (Do Not Flag)`, and related paragraphs with the Option B contract from §1 of this plan.
+
+**Files:** `meshery/schemas/AGENTS.md` (symlinked as `CLAUDE.md`).
+
+**Specific changes:**
+1. In `§ Casing rules at a glance`, replace the "DB-backed / DB-mirrored fields | exact snake_case db column name" row with: "JSON tag on DB-backed fields | **camelCase**; `db:` tag in `x-oapi-codegen-extra-tags` carries the snake_case DB column name separately".
+2. In `§ Intentional Design Decisions (Do Not Flag)`, convert `page_size`/`total_count` from a perpetual exception to a **deprecation list** — current forms accepted; migrates to `pageSize`/`totalCount` at the next API-version bump per resource.
+3. Add a new `§ Option B migration` section linking to this plan at `docs/identifier-naming-option-b-migration.md` within the same repo as the operative execution document.
+4. Add to `§ Common Mistakes to Avoid`: "❌ Introducing a `json:` tag that matches the `db:` tag on a new field — wire is camel, DB is snake; they differ by design on DB-backed fields."
+5. Update `§ Checklist for Schema Changes` to reflect the inverted rule.
+
+**Testing:** No code change; manual sanity check that examples in the amendment match the new table. Run `make validate-schemas` to confirm the doc-only change does not trip any rule.
+
+**Docs:** Self-documenting; this IS the doc.
+
+**Review:** Human governance review required (maintainer). Auto-merge disabled on this PR.
+
+**Acceptance:** Amendment merged; validator rules not yet changed but run green.
+
+### Agent 1.B — `validation/rules_naming.go` Rule 6 inversion
+**Charter:** Rewrite Rule 6 (schema property-name casing) to require camelCase unconditionally. Remove the DB-backing exception. Keep `knownLowercaseSuffixViolations` (detects `userid` → should be `userId`) and `screamingIDRE` (detects `orgID` → should be `orgId`).
+
+**Files:**
+- `meshery/schemas/validation/rules_naming.go` — `checkRule6ForAPI`, `checkRule6ForEntity` (and sibling in `rules_entity.go`).
+- `meshery/schemas/validation/casing.go` — the `dbMirroredFields` set stays but is repurposed: fields present here are now **legacy debt tracked via `--style-debt` flag**, not exceptions to Rule 6.
+- New test cases in `meshery/schemas/validation/casing_test.go` and `rules_property_test.go`: (i) a DB-backed field with snake JSON tag now fails Rule 6, (ii) a DB-backed field with camel JSON tag passes, (iii) non-DB-backed snake still fails.
+
+**Testing:** `cd /Users/l/code/schemas && go test ./validation/ -run "TestCasing|TestRule6"` — green. `make validate-schemas` — current schemas will now surface a large number of violations; these get baselined in Agent 1.G.
+
+**Docs:** In the Go file, the docstring for `checkRule6ForAPI` documents the Option B inversion and links to `AGENTS.md § Option B migration`.
+
+**Acceptance:** Tests pass; Rule 6 now flags the pre-Option-B schemas; baseline pending (1.G).
+
+### Agent 1.C — "Partial casing migrations forbidden" rule
+**Charter:** Author a new rule (call it Rule 45) that walks every `components/schemas/<Entity>` object and flags structs that mix JSON-tag conventions (some camel, some snake, some ALL CAPS) on their properties.
+
+**Files:**
+- `meshery/schemas/validation/rules_naming.go` (new `checkRule45`).
+- `meshery/schemas/validation/rules_naming_test.go` (new test file if not present, else extend).
+
+**Testing:** Test fixtures: (i) all-camel struct → pass, (ii) all-snake struct → pass (legacy, caught by Rule 6 but not Rule 45), (iii) mixed camel+snake on one struct → fail Rule 45 with a message citing each non-matching field.
+
+**Docs:** Rule description in the Go docstring references `AGENTS.md § Casing rules at a glance` and notes this rule catches the `MesheryPattern.OrgID json:"orgId"` + `WorkspaceID json:"workspace_id"` + `UserID json:"user_id"` class of drift.
+
+**Acceptance:** Rule 45 fires on fixtures; runs green against the post-Option-B schemas once Phase 3 completes.
+
+### Agent 1.D — "Sibling-endpoint parameter parity" rule
+**Charter:** Author Rule 46 — when two sibling paths in the same API version follow the pattern `GET /api/<entity-plural>`, and one declares `$ref: "#/components/parameters/orgIdQuery"`, the sibling should too. Covers the workspaces-missing-`orgIdQuery` class of omission.
+
+**Files:** `meshery/schemas/validation/rules_naming.go` or new `rules_parity.go`; matching test file.
+
+**Testing:** Fixtures: (i) all siblings declare `orgIdQuery` → pass, (ii) one sibling omits → fail with message identifying the missing sibling.
+
+**Docs:** Rule docstring explains the class of production bug this catches (workspaces 400 from dropped `orgId`).
+
+**Acceptance:** Rule fires on a crafted fixture; `v1beta1/workspace/api.yml` is flagged in the baseline output (will be fixed in Phase 3.Workspace).
+
+### Agent 1.E — Query-parameter casing rule (extend Rule 4)
+**Charter:** Rule 4 currently checks path parameters. Extend it to `parameters: [{in: query, name: ...}]` — query parameter names must be camelCase with `Id` suffix. Flags `user_id` (v1beta1/token), `organizationId` (v1beta1/feature + v1beta2/invitation:322), any `orgID` that slips through.
+
+**Files:** `meshery/schemas/validation/rules_naming.go` `checkRule4`.
+
+**Testing:** Fixtures covering path param, query param, header param (last one untouched).
+
+**Acceptance:** Rule flags the known outliers; they're baselined in 1.G.
+
+### Agent 1.F — `validation/consumer_ts.go` authoring
+**Charter:** Parse TypeScript RTK endpoint definitions from the downstream repos and diff against the schemas endpoint index. The TS parser reads `ui/rtk-query/*.ts` (and equivalents in Cloud UI and Kanvas) to find `builder.query({url, params})` and `builder.mutation({url, params, body})` sites.
+
+**Files:**
+- `meshery/schemas/validation/consumer_ts.go` (new).
+- `meshery/schemas/validation/consumer_ts_test.go` (new).
+- `meshery/schemas/validation/consumer.go` (update) — register the TS consumer alongside echo/gorilla.
+- `meshery/schemas/cmd/consumer-audit/main.go` (update) — accept `--extensions-repo` / `--meshery-repo-ui` flags.
+- `meshery/schemas/Makefile` (update) — `consumer-audit` target accepts `EXTENSIONS_REPO=`, `MESHERY_REPO=`, `CLOUD_REPO=` and iterates all registered consumers.
+
+**Testing:**
+- Unit tests with inline TS fixtures (no external repos).
+- Integration test that runs against `../meshery-extensions` fixture directories and produces deterministic output.
+
+**Docs:** `meshery/schemas/validation/doc.go` extended with a paragraph on TS consumer auditing. `meshery/schemas/AGENTS.md § Consumer audit` added describing the new target.
+
+**Acceptance:** Running `make consumer-audit EXTENSIONS_REPO=../meshery-extensions` produces output naming the `catalog.ts:110` case-flip, the `designs.ts:308` wrapper mismatch, and the `user.ts` hook inconsistencies.
+
+### Agent 1.G — Advisory baseline refresh
+**Charter:** Run `make audit-schemas-full` and the new `make consumer-audit` against the current state of all four repos. Write every violation that fires under the new rules to the advisory baseline file so CI stays green while Phases 2–3 proceed. New violations introduced after this baseline block CI.
+
+**Files:**
+- `meshery/schemas/validation/baseline/advisory.yaml` (or whatever format `baseline.go` uses — follow its convention).
+- `meshery/schemas/validation/baseline/consumer-advisory.yaml` (new for consumer findings).
+
+**Testing:** `make validate-schemas` runs green; `make audit-schemas-full` reports 0 "new" advisory issues (backlog captured in the baseline); introducing a test violation (e.g., edit one test schema to add `json:"orgID"`) makes CI fail.
+
+**Docs:** `meshery/schemas/AGENTS.md § Advisory baseline` — add paragraph explaining the baseline workflow: new violations block; baselined violations require intentional resolution via Phase 3 migrations.
+
+**Acceptance:** `make validate-schemas` and `make audit-schemas-full` both exit 0 on the current repo state; adding a fresh violation fails CI.
+
+### Agent 1.H — CI workflow wiring (consumer-audit advisory)
+**Charter:** Add a `consumer-audit` job to `.github/workflows/schema-audit.yml` that checks out the three downstream repos (using `actions/checkout` with `repository:` and a PAT secret for private-repo access if needed) and runs `make consumer-audit`. Exit 0 regardless — advisory only. Output posted as a PR comment summarizing divergence counts.
+
+**Files:** `meshery/schemas/.github/workflows/schema-audit.yml`.
+
+**Testing:** Trigger a throwaway PR; verify the new job runs and the comment posts. Repro locally with `act` if available.
+
+**Docs:** `meshery/schemas/AGENTS.md § Consumer audit` — document the CI behavior.
+
+**Acceptance:** On PR open, all three jobs (`blocking-validation`, `advisory-audit`, `consumer-audit`) run; `consumer-audit` posts a comment with the divergence counts per downstream repo.
+
+### Agent 1.I — Package version bump + publish
+**Charter:** Bump `@meshery/schemas` npm package minor version to mark Phase 1 complete; bump the Go module version; publish to npm; cut a GitHub release with notes linking this plan.
+
+**Files:** `meshery/schemas/package.json`, `CHANGELOG.md`, git tag.
+
+**Testing:** `npm pack` locally; inspect package contents; `go mod tidy` in a consumer repo against the new version.
+
+**Docs:** Release notes cover the Option B contract, link to this plan, note that Phase 2 downstream fixes depend on this version.
+
+**Acceptance:** Version published; downstream repos can `npm install @meshery/schemas@<new-version>` and `go mod edit -require github.com/meshery/schemas@<new-tag>`.
+
+---
+
+## 8. Phase 2 Agents — Non-breaking alignment fixes
+
+All agents in this phase pin their target repo's `@meshery/schemas` dependency to the Phase 1.I version. Agents 2.A–2.J run in parallel (no inter-dependencies), each producing one PR.
+
+### Agent 2.A — Meshery server query-param extraction alignment
+**Repo:** `meshery/meshery`  
+**Branch:** `fix/handler-orgid-casing-alignment`  
+**Charter:** Change `q.Get("orgID")` to `q.Get("orgId")` in every handler that reads the org-ID query parameter. Ensure the change is consistent across sibling endpoints.
+
+**Files:**
+- `server/handlers/workspace_handlers.go` (lines 24, 46) — `orgID` → `orgId`.
+- `server/handlers/meshery_pattern_handler.go:557` — `q["orgID"]` → `q["orgId"]`.
+- Any other `q.Get("orgID")` or `q["orgID"]` sites turned up by `grep -rn 'Get("orgID")\|\["orgID"\]' server/`.
+- `environments_handlers.go` already uses `orgId` — leave unchanged.
+- Corresponding error messages (`"WorkspaceID or OrgID cannot be empty"`) updated to reflect the canonical `orgId` form.
+
+**Testing:**
+- `cd server && go test ./handlers/...` — green.
+- New handler test: `TestGetWorkspacesHandler_RequiresOrgIdCaseSensitive` — asserts that `?orgID=abc` (legacy case) now fails the new extraction, and `?orgId=abc` succeeds.
+- `go build ./...` — green.
+
+**Docs:**
+- `docs/` in-repo (if any mention) updated.
+- OpenAPI spec at `server/helpers/swagger.yaml` (if present) aligned.
+
+**Acceptance:** PR merged; `make consumer-audit` from schemas repo no longer flags these handlers for wrong casing.
+
+### Agent 2.B — Meshery server outbound URL alignment
+**Repo:** `meshery/meshery`  
+**Branch:** `fix/remote-provider-outbound-orgid-casing`  
+**Charter:** Change every outbound `q.Set("orgID", ...)` in `server/models/remote_provider.go` to `q.Set("orgId", ...)`. Confirm receiving (meshery-cloud) side accepts `orgId` (it does — Cloud middleware already uses `utils.QueryParam(..., "orgId", "orgID")`).
+
+**Files:**
+- `server/models/remote_provider.go` — lines 5174, 5215, 5607, 5671 (confirm via `grep -n 'q.Set("orgID"' server/models/remote_provider.go`).
+- Any other `q.Set("org`-flavored sites.
+
+**Testing:**
+- `go build ./...` — green.
+- Existing tests for `GetEnvironments`, `GetWorkspaces`, `GetCatalogMesheryPatterns`, `GetUsersKeys` remain green.
+- New test: verify the outbound URL contains `?orgId=` (not `?orgID=`) using `httptest.NewServer` that asserts the request URL.
+
+**Acceptance:** PR merged; outbound URLs from meshery to cloud now use `orgId`.
+
+### Agent 2.C — Meshery-cloud `QueryParamOrganizationID` constant + dual-accept retirement (two PRs)
+**Repo:** `layer5io/meshery-cloud`  
+**Branches:** `fix/query-param-org-id-constant` then `chore/retire-org-id-dual-accept`  
+**Charter, PR 1:** `server/utils/constants.go:138` `QueryParamOrganizationID = "orgID"` → `"orgId"`. Cascade: update all callers.  
+**Charter, PR 2 (one release later):** Remove `utils.QueryParam(q, "orgId", "orgID")` fallback; keep only `"orgId"`.
+
+**Files PR 1:**
+- `server/utils/constants.go:138`.
+- Every consumer of the constant — find with `grep -rn QueryParamOrganizationID server/`.
+- Middleware `server/handlers/middlewares_authz_scope.go:241` — verify behavior unchanged.
+
+**Files PR 2:**
+- Every `utils.QueryParam(q, "orgId", "orgID")` — simplify to `q.Get("orgId")` or equivalent.
+- Sites found: `server/handlers/meshery_patterns.go:542`, `meshery_views.go:123`, `flow_emails.go:245`, `middlewares_authz_scope.go:241`, plus any others turned up by `grep -rn 'QueryParam.*"orgId".*"orgID"' server/`.
+
+**Testing:**
+- `go build ./...` — green.
+- `go test ./server/...` — green.
+- Integration test against a live staging Cloud: `curl -H "Cookie: ..." "https://<host>/api/workspaces?orgId=<uuid>"` returns 200 (or the existing business-logic response) and `orgID` returns 400/400 (legacy form no longer accepted in PR 2).
+
+**Docs:** `server/docs/` (if present) or README API examples updated to use `orgId`.
+
+**Acceptance:** PR 1 merged with no behavior change on happy path; PR 2 merged one release later after downstream clients (meshery-server Agents 2.A+2.B, Cloud UI Agent 2.E, Kanvas Agent 2.G) all emit `orgId`.
+
+### Agent 2.D — Meshery-cloud mapping-model JSON tags (`json:"ID"` → `json:"id"`)
+**Repo:** `layer5io/meshery-cloud`  
+**Branch:** `fix/mapping-model-id-json-tag-lowercase`  
+**Charter:** All 9 mapping models use `json:"ID"` (ALL CAPS) on their `ID` primary-key field. AGENTS.md mandates lowercase `json:"id"`. Apply uniformly.
+
+**Files (all in `server/models/`):**
+- `model_environment_connection_mapping.go`
+- `model_workspaces_teams_mapping.go`
+- `model_users_organizations_mapping.go`
+- `model_workspaces_designs_mapping.go`
+- `model_resource_access_mapping.go`
+- `model_workspaces_environments_mapping.go`
+- `model_users_teams_mapping.go`
+- `model_workspaces_views_mapping.go`
+- `model_keychain_filter.go` (`roleID` — check JSON tag, align to `id`)
+
+**Testing:**
+- `go build ./...` — green.
+- `go test ./...` — green.
+- **API-breaking potential.** Survey consumers: is any API response body consumer reading `.ID` field via JSON? If yes, a one-release deprecation notice is required; emit both `ID` and `id` fields via a custom `MarshalJSON` for one release, then drop `ID`.
+  - Consumer survey method: grep the three downstream repos for `.ID` property access on these types' API-returned JSON. Record findings in the PR description.
+
+**Docs:** `meshery-cloud/CHANGELOG.md` entry; if any `server/docs/` exists, update the sample response bodies.
+
+**Acceptance:** PR merged; Agent 2.D's consumer survey documented; deprecation shim in place if any consumer reads `ID`.
+
+### Agent 2.E — Meshery-cloud `ContentID` JSON tag alignment
+**Repo:** `layer5io/meshery-cloud`  
+**Branch:** `fix/content-id-json-tag-option-b`  
+**Charter:** `CatalogRequest.ContentID` at `server/models/users.go:246` currently declares `json:"contentId" db:"content_id"`. Under Option B: `ContentID` Go field + `json:"contentId"` + `db:"content_id"` — this is actually **already correct** under Option B. Agent's task is to verify, and if correct, mark the previously-flagged finding as resolved.
+
+**Testing:** `go test ./...` green; search schemas consumer-audit output for `CatalogRequest`/`ContentID` — no findings.
+
+**Docs:** PR description explains that the original audit misclassified this as a violation; under Option B it is canonical.
+
+**Acceptance:** Confirmed correct; no code change; baseline updated to retire the stale finding.
+
+### Agent 2.F — Cloud UI `ui/api/api.ts` endpoint dedup vs. `@meshery/schemas/cloudApi`
+**Repo:** `layer5io/meshery-cloud`  
+**Branch:** `refactor/cloud-ui-api-dedup`  
+**Charter:** Audit each of the 30+ hand-rolled endpoints in `meshery-cloud/ui/api/api.ts`. For each:
+1. Check if `@meshery/schemas/cloudApi` exposes an equivalent endpoint (same URL + method + params, under Option B).
+2. If yes: displace — import and re-export the generated hook; remove the hand-rolled definition.
+3. If no (legitimate customization): document the reason inline (`// LOCAL: <reason>`) and open a follow-up issue in `meshery/schemas` to consider exporting.
+
+**Additional:** Remove the input-`orgId` → URL-`orgID` case-flip transformation at lines 1264, 1272, 1201, ~96. Under Option B both sides of the wire are `orgId`.
+
+**Testing:** `npm run build`, `npm test`, `eslint --max-warnings=0` all green. Integration-test one representative flow (workspaces list) in a dev environment to confirm no regression.
+
+**Docs:** `ui/api/README.md` (or similar) — document the displacement pattern; `ui/CONTRIBUTING.md` — note that new endpoints should use generated `cloudApi`, not hand-rolled.
+
+**Acceptance:** PR merged; `consumer_ts.go` reports ≥N fewer hand-rolled TS endpoints than before; the specific case-flip sites are gone.
+
+### Agent 2.G — Kanvas `catalog.ts` RTK case-flip removal + `designs.ts` wrapper alignment
+**Repo:** `layer5labs/meshery-extensions`  
+**Branch:** `fix/kanvas-rtk-option-b-alignment`  
+**Charter:** Two related Kanvas fixes that go together:
+1. `meshmap/src/rtk-query/catalog.ts:110` `getWorkspaceForCatalog` — remove the `orgID: queryArg.orgId` transform; emit `orgId` in the URL directly.
+2. `meshmap/src/rtk-query/catalog.ts:58-59` `getPatternsPerUser` — unify to Option B canonical names.
+3. `meshmap/src/rtk-query/designs.ts:308` `uploadPatternBySourceType` body wrapper — change `{ pattern_data: {...} }` to `{ patternData: {...} }` to match the `SaveMesheryPattern` wire contract already established by PR #18856.
+4. `meshmap/src/rtk-query/designs.ts:336-342` `patternFiletoCytoJson` body — align to camelCase throughout.
+5. `meshmap/src/rtk-query/designs.ts:188` `k8sYamlToPattern` body — `{ k8s_manifest: ... }` → `{ k8sManifest: ... }`.
+
+**Coordination:** Changes 3–5 require the receiving side (meshery server's `meshery_pattern_handler.go` etc.) to accept the new wrapper key. Verify acceptance before merge — either the handler already accepts camelCase (check by reading the handler's unmarshal target struct's JSON tags) or a companion PR in meshery server adds a dual-accept during the deprecation window.
+
+**Testing:**
+- `cd meshmap && npm run build && npm test` — green.
+- Manual smoke: in a dev Meshery instance, save a design from Kanvas. Verify success at the server level (PR #18856's existing test can be re-run).
+- E2E test under `tests/` (playwright) — the save-design flow.
+
+**Docs:** Kanvas Developer Guide updated where it references wrapper keys; `AGENTS.md`/`CLAUDE.md` updated (see §14).
+
+**Acceptance:** PR merged; design save works; `consumer_ts.go` no longer flags the catalog case-flip or the `pattern_data` wrapper inconsistency.
+
+### Agent 2.H — Meshery UI RTK hook unification (`ui/rtk-query/`)
+**Repo:** `meshery/meshery`  
+**Branch:** `refactor/ui-rtk-query-orgid-alignment`  
+**Charter:** In `ui/rtk-query/user.ts`, `ui/rtk-query/design.ts`, and any sibling hook files, unify every `orgID` → `orgId`. Remove wrapper hooks that exist only to alias `orgId` through.
+
+**Specific sites:**
+- `ui/rtk-query/user.ts:87` — `orgID: selectedOrganization?.id` → `orgId: ...`.
+- `ui/rtk-query/design.ts:49` — same.
+- `ui/rtk-query/environments.ts:11-21` — thin wrapper; eliminate; have callers use `useSchemasGetEnvironmentsQuery` directly.
+- `ui/rtk-query/workspace.ts:19-80` — custom `queryFn` stays until Phase 3.Workspace (the schemas-generated client gains `orgIdQuery` there); in the meantime, ensure the custom queryFn passes `orgId` (not `orgID`) in its URL construction.
+
+**Testing:** `cd ui && npm run build && npm test` — green. The `environments` wrapper removal touches many call sites; every import of `useGetEnvironmentsQuery` from the local wrapper must be updated to import from `@meshery/schemas/mesheryApi`. Compile-error-driven; TypeScript's type system catches misses.
+
+**Docs:** `ui/CONTRIBUTING.md` adds a paragraph: "Do not wrap schemas-generated hooks solely to alias parameter names; propagate the canonical Option B name."
+
+**Acceptance:** PR merged; no same-file `orgID`/`orgId` mix remains; thin wrappers eliminated.
+
+### Agent 2.I — Kanvas `mesherySdk` event-type casing alignment
+**Repo:** `layer5labs/meshery-extensions`  
+**Branch:** `fix/mesherysdk-event-type-camelcase`  
+**Charter:** In `meshmap/src/globals/mesherySdk.ts`, convert event-payload field names from snake_case to camelCase to match dispatcher signatures on the same file.
+
+**Specific sites:**
+- Event types at lines 30, 38, 46: `design_id` → `designId`, `view_id` → `viewId`.
+- All event publishers in `meshmap/src/` that construct these events (grep for `design_id:` and `view_id:` in `*.ts`/`*.tsx`).
+- The backend-response mapping at `meshmap/src/modules/editor/modes/designer/designActor.ts:308-311` reads `event.output.workspace_id` and `event.output.org_id` — these are from an HTTP response (snake_case preserved by the wire until Phase 3.Design). Keep the snake→camel mapping at the boundary; refactor to a helper function that documents the intentional boundary crossing.
+
+**Testing:** `cd meshmap && npm run build && npm test` — green. TS type checks enforce correctness of the field renames across event-consumer code.
+
+**Docs:** Kanvas Developer Guide event-bus section updated; the boundary-mapping helper has a one-line `// why:` comment pointing at this plan's §1.
+
+**Acceptance:** PR merged; same-file casing split in `mesherySdk.ts` resolved.
+
+### Agent 2.J — Kanvas `collab/config.ts` user-ID duality resolution
+**Repo:** `layer5labs/meshery-extensions`  
+**Branch:** `fix/kanvas-collab-user-id-canonical`  
+**Charter:** `meshmap/src/modules/editor/collab/config.ts:32-40` currently declares both `user_id` and `id` on the user interface — ambiguous canonical key. Pick one (`id`, matching `AGENTS.md` property-default casing for short-form identifiers) and remove the other. Update all consumers.
+
+**Testing:** `cd meshmap && npm run build && npm test` — green. Manual smoke: two-user collaboration session; verify presence indicators render correctly.
+
+**Docs:** Collaboration section of Kanvas Developer Guide updated.
+
+**Acceptance:** PR merged; interface declares one canonical field; no grep hits for `user_id` on the collab type.
+
+---
+
+## 9. Phase 3 Agents — Per-resource versioned wire migration
+
+One agent per resource. Agents may run in parallel across resources. Each agent publishes a new API version for its resource in `meshery/schemas`, regenerates clients, and migrates downstream consumers onto the new version.
+
+### 9.1 Resource inventory (22 resources)
+
+Sequenced by Agent 0.D's complexity score (lowest first). Resource names match `schemas/constructs/v1beta*/<resource>/api.yml` directories.
+
+| Priority | Resource | Current version | New version | Est. consumer count |
+|---|---|---|---|---|
+| 1 | workspace | v1beta1 | v1beta3 | medium |
+| 2 | environment | v1beta1 | v1beta3 | medium |
+| 3 | organization | v1beta1 | v1beta2 (first bump) | high |
+| 4 | user | v1beta1 | v1beta2 (first bump) | high |
+| 5 | design / pattern | v1beta1, v1beta2 | v1beta3 | very high |
+| 6 | connection | v1beta1, v1beta2 | v1beta3 | high |
+| 7 | team | v1beta1 | v1beta2 (first bump) | medium |
+| 8 | role | v1beta1 | v1beta2 (first bump) | low |
+| 9 | credential | v1beta1 | v1beta2 (first bump) | medium |
+| 10 | event | v1beta1, v1beta2 | v1beta3 | medium |
+| 11 | view | v1beta1 | v1beta2 (first bump) | medium |
+| 12 | key | v1beta1 | v1beta2 (first bump) | low |
+| 13 | keychain | v1beta1 | v1beta2 (first bump) | low |
+| 14 | invitation | v1beta1, v1beta2 | v1beta3 | low |
+| 15 | plan | v1beta2 | v1beta3 | low |
+| 16 | subscription | v1beta1, v1beta2 | v1beta3 | low |
+| 17 | token | v1beta1, v1beta2 | v1beta3 | low |
+| 18 | badge | v1beta1 | v1beta2 (first bump) | low |
+| 19 | schedule | v1beta1 | v1beta2 (first bump) | low |
+| 20 | model | v1beta1 | v1beta2 (first bump) | high |
+| 21 | component | v1beta2 | v1beta3 | very high |
+| 22 | relationship | v1beta1, v1beta2, v1alpha3 | v1beta3 | high |
+
+### 9.2 Per-resource agent template (Agent 3.<Resource>)
+
+Every Phase 3 resource agent follows this template. Variable substitutions in `{braces}`.
+
+**Charter:** Author a new API version `{new-version}` for `{resource}` in `meshery/schemas` with 100% camelCase JSON tags on all schema properties, canonical query/path parameter names, and sibling-endpoint parameter parity. Regenerate the Go and TypeScript clients. Migrate every downstream consumer (identified by Agent 0.D's graph) onto the new version. Mark the previous version deprecated with a sunset target of one release cycle after 100% consumer migration.
+
+**Repos touched (one PR per repo, chained):**
+1. `meshery/schemas` — author new version, regenerate clients, publish.
+2. `meshery/meshery` — consume new version in server handlers and UI hooks.
+3. `layer5io/meshery-cloud` — same.
+4. `layer5labs/meshery-extensions` — same.
+
+**Schemas PR:**
+- Files: `schemas/constructs/{new-version}/{resource}/` (new directory), copied from previous version and updated.
+- **Every JSON tag** in schemas properties: camelCase. DB-backed primitives retain their snake `db:` tag via `x-oapi-codegen-extra-tags`.
+- **Every query/path parameter**: camelCase with `Id` suffix.
+- **Every operationId**: lower camelCase verbNoun.
+- If applicable, add the missing parameter references (e.g., `orgIdQuery` for workspace GET).
+- Regenerate: `make generate-golang && make generate-rtk && make build-ts && make publish-ts` (published as a new semver minor).
+- Run validators: `make validate-schemas` green; `make audit-schemas-full` shows the new version as clean.
+
+**Downstream PRs (one per repo):**
+- Repoint imports from `github.com/meshery/schemas/models/{old-version}/{resource}` to `.../{new-version}/...` (Go).
+- Repoint imports from `@meshery/schemas/models/{old-version}/{resource}` to `.../{new-version}/...` (TS), or adjust the RTK hook names if the client generation renames them.
+- Update handler query-param extraction to read the new canonical names (no-op if Phase 2 already aligned).
+- Update outbound URL construction similarly.
+- Update UI hook calls and prop types.
+- Update tests and fixtures.
+- Update sample API request/response docs under `docs/` or `README.md`.
+
+**Test plan per repo:**
+- Full build + test suite green.
+- Integration test hitting the new URL/params + body shape.
+- Backward-compat smoke: old client version still works against its old endpoints (which are still served until sunset).
+
+**Documentation:**
+- `AGENTS.md`/`CLAUDE.md` in each repo — note the migration done.
+- API docs that show response bodies updated for the new version.
+- `CHANGELOG.md` entry with migration notes for external clients.
+
+**Deprecation:**
+- Old version's `api.yml` annotated with `deprecated: true` on every operation.
+- OpenAPI `x-sunset-date` header annotation set to one release cycle out.
+
+**Acceptance per resource:**
+- New version green in validators.
+- All downstream consumers on new version.
+- Old version deprecated but still functional.
+- `consumer-audit` reports no wire-casing divergence on this resource.
+
+### 9.3 Specific priority-1 resource: Agent 3.Workspace
+
+This is the smallest worked example, and it closes the production-hot workspaces-`orgId` bug.
+
+**Schemas changes (`schemas/constructs/v1beta3/workspace/api.yml`):**
+- Copy `v1beta1/workspace/api.yml`.
+- Add `- $ref: "#/components/parameters/orgIdQuery"` to GET `/api/workspaces` parameters (the fix that was missing in v1beta1).
+- Flip any snake_case JSON tags on `Workspace` / `WorkspacePayload` properties to camelCase.
+- Verify `db:` tags in `x-oapi-codegen-extra-tags` remain snake (unchanged).
+
+**Schemas regeneration:**
+- `make generate-golang && make generate-rtk && make build-ts`.
+- The new generated `getWorkspaces` includes `orgId` as an optional URL param, closing the prior omission.
+
+**Meshery server consumer PR:**
+- `server/models/meshery_pattern.go` and any other struct that has a `Workspace` association — import from `v1beta3` if the struct is shared; otherwise retain local struct until Phase 3.Design also lands.
+- Handler updates if any.
+
+**Meshery UI consumer PR:**
+- `ui/rtk-query/workspace.ts` — if the schemas-generated client now covers the orgId case with the correct shape, retire the custom `queryFn` in favor of the generated hook.
+- Component updates where types have changed (compile-error-driven).
+
+**Meshery-cloud server:**
+- Handlers at `server/handlers/workspaces.go` updated to consume the new models package.
+- Middleware `middlewares_authz_scope.go:241` — can now drop the `orgID` fallback once all consumers are on v1beta3.
+
+**Meshery-cloud UI:**
+- `ui/api/api.ts:1255-1272` — displace with the generated hook from `cloudApi`.
+
+**Kanvas:**
+- No direct workspace endpoint usage in Kanvas (workspace modal is provided by Meshery UI). Indirect exposure via `mesherySdk.ts` message shapes — update snake-cased fields.
+
+**Testing:**
+- New handler test: `GET /api/workspaces?orgId=<uuid>` returns 200 (was 400 in v1beta1 due to the schema omission).
+- Integration test against live staging — design save + workspace list flow.
+
+**Docs:**
+- Kanvas Developer Guide — any section mentioning workspace URL shape.
+- Meshery docs — API reference.
+
+**Acceptance:**
+- Workspaces 400 bug observed in PR #18858's context no longer reproduces.
+- `consumer-audit` clean on workspace.
+
+### 9.4 Priority-1 through priority-22 agents
+
+The remaining 21 agents follow the template in §9.2 with per-resource file paths. Authoring each agent's full prompt inline would bloat this doc without adding execution signal; the orchestrator spawns each using the template + resource name as the substitution. The per-resource complexity score from Agent 0.D determines the order.
+
+**Invariant across all Phase 3 agents:** no single PR modifies more than one resource's API version. Multi-resource changes are forbidden — they make review and rollback harder.
+
+---
+
+## 10. Phase 4 Agents — Deprecation & finalization
+
+### Agent 4.A — Deprecated-version sunset
+**Charter (per resource, chained after Phase 3.{Resource} + one release cycle):** Remove deprecated API version files from `meshery/schemas` once every consumer repo has migrated to the new version. Regenerate clients. Publish.
+
+**Files:** `schemas/constructs/{deprecated-version}/{resource}/` directory deleted. Regeneration updates `dist/` and `models/`.
+
+**Testing:** `make validate-schemas`, `make audit-schemas-full`, `make consumer-audit` all green. Running a consumer repo's test suite against the new schemas version must stay green — if not, that repo still has references to the deprecated version; fix before sunset proceeds.
+
+**Docs:** `CHANGELOG.md` entry noting the removal.
+
+**Acceptance:** Deprecated-version directory gone; no consumer imports break.
+
+### Agent 4.B — Consumer-audit promoted to blocking
+**Charter:** In `meshery/schemas/.github/workflows/schema-audit.yml`, change the `consumer-audit` job to exit non-zero on divergence. This permanently closes the drift door.
+
+**Files:** `.github/workflows/schema-audit.yml`.
+
+**Testing:** Introduce a deliberate drift (e.g., add an `orgID` param to a test schema) on a throwaway PR; verify CI now fails. Revert.
+
+**Docs:** `AGENTS.md § Consumer audit` updated to reflect blocking status.
+
+**Acceptance:** Drift introduced in a test PR fails CI; reverted, green.
+
+### Agent 4.C — Universal `AGENTS.md` + `CLAUDE.md` updates across every repo
+**Charter:** In each of the four repos (`meshery/schemas`, `meshery/meshery`, `layer5io/meshery-cloud`, `layer5labs/meshery-extensions`), ensure `AGENTS.md` and `CLAUDE.md` (symlinked or duplicated) contain the Option B mandate with a strong "MUST" / "MUST NOT" section referencing `schemas/AGENTS.md § Casing rules at a glance` as the authority. Boilerplate text in §14 of this plan.
+
+**Files (per repo):**
+- `AGENTS.md`
+- `CLAUDE.md` (if separate file)
+- `.claude/CLAUDE.md` (project-level, if present)
+
+**Testing:** No code change; the PR is documentation-only. Reviewers verify text adherence to §14's boilerplate.
+
+**Acceptance:** All four repos merged with matching boilerplate; any future contributor (human or AI) reading the doc sees the same rule set.
+
+### Agent 4.D — Final validator rule pruning
+**Charter:** After Phase 3 completes, several validator rules become dead weight (every resource is compliant; the rule has nothing to flag). Retire: `knownLowercaseSuffixViolations` legacy checks on now-compliant resources. Keep `screamingIDRE` and Rule 45 (partial-casing-migrations) permanently — they're forward-looking guardrails.
+
+**Files:** `meshery/schemas/validation/casing.go`, `rules_naming.go`.
+
+**Testing:** `make validate-schemas` green; `make audit-schemas-full` green; no regressions in existing test fixtures.
+
+**Acceptance:** Validator has the minimum rule set that enforces Option B going forward.
+
+### Agent 4.E — Before/after impact report publication
+**Charter:** Re-run the baseline agents (0.A–0.D) to produce "after" numbers. Publish the before/after report per §15 of this plan; commit to `meshery/schemas/docs/` as the governance artifact.
+
+**Files:** `meshery/schemas/docs/option-b-impact-report.md`.
+
+**Acceptance:** Report published; metrics confirm §2 objectives met.
+
+---
+
+## 11. Orchestration DAG
+
+```
+                          ┌─────────────────────────────┐
+                          │ Phase 0: baseline metrics   │
+                          │ (0.A, 0.B, 0.C, 0.D)        │
+                          └──────────────┬──────────────┘
+                                         │
+                                         ▼
+                          ┌─────────────────────────────┐
+                          │ Phase 1: schemas governance │
+                          │ 1.A → 1.B → 1.C → 1.D → 1.E │
+                          │     → 1.F → 1.G → 1.H → 1.I │
+                          └──────────────┬──────────────┘
+                                         │
+                    ┌────────────────────┴────────────────────┐
+                    │                                         │
+                    ▼                                         ▼
+      ┌──────────────────────────┐          ┌─────────────────────────────┐
+      │ Phase 2: non-breaking    │          │ Phase 3: per-resource       │
+      │ alignment (parallel)     │          │ migrations (parallel)       │
+      │ 2.A 2.B 2.C 2.D 2.E 2.F  │          │ 3.Workspace, 3.Environment, │
+      │ 2.G 2.H 2.I 2.J          │          │ 3.Organization, ... (22)    │
+      └──────────┬───────────────┘          └──────────────┬──────────────┘
+                 │                                         │
+                 └──────────────────┬──────────────────────┘
+                                    │
+                                    ▼
+                          ┌─────────────────────────────┐
+                          │ Phase 4: finalization       │
+                          │ 4.A → 4.B → 4.C → 4.D → 4.E │
+                          └─────────────────────────────┘
+```
+
+**Dependency rules:**
+- No Phase 2 agent runs before Phase 1.I publishes the new schemas version.
+- No Phase 3 resource agent runs before Phase 1.I AND the resource's Phase 2 non-breaking precursors (if any) are merged. Phase 3 resources may run in parallel with each other.
+- Phase 4 agents run only after all Phase 3 resources are merged AND one release cycle has elapsed.
+
+**Orchestrator responsibilities:**
+- Track every agent's PR URL, CI status, merge SHA in a shared ledger (TaskList + optionally a Google Sheet).
+- Enforce the DAG — do not dispatch blocked agents.
+- Handle escalations (§5.7) by pausing downstream agents until resolved.
+
+---
+
+## 12. Documentation mandate
+
+Every agent's PR includes documentation updates whenever its change affects user-visible behavior. Three categories:
+
+1. **Code-level documentation** — Go/TS docstrings on changed public symbols. Explain *why*, not *what*. Reference this plan's §1 for the canonical rule.
+2. **In-repo developer docs** — `docs/` directory in each repo; Kanvas Developer Guide for Kanvas; `server/docs/` or API reference for Meshery server and Cloud.
+3. **External user docs** — `layer5io/docs` (for the public Meshery docs site) updated whenever an API shape changes that external users consume.
+
+**Per-PR doc checklist:**
+- [ ] Public symbol docstrings updated
+- [ ] Repo `docs/` touched where the feature is described
+- [ ] External user docs linked or updated (PR to `layer5io/docs` if needed)
+- [ ] `CHANGELOG.md` entry
+
+**Explicit doc sites whose names and URLs will change under Option B:**
+- API reference sample bodies (`{ "user_id": "..." }` → `{ "userId": "..." }`).
+- Query-string examples (`?orgID=` → `?orgId=`).
+- Go import paths (version bumps).
+
+---
+
+## 13. Testing mandate
+
+Each agent's PR must contain proportional tests. Non-negotiable minimums:
+
+| Change type | Test requirement |
+|---|---|
+| New validator rule | Unit test with fixture covering pass + fail; regression test ensuring existing fixtures still pass |
+| Handler casing fix | Handler-level test asserting the new param name works and the old does not (post-deprecation) |
+| JSON tag change | Serialization round-trip test (`json.Marshal`+`json.Unmarshal`) asserting the new wire shape |
+| RTK hook change | Hook integration test using mock server asserting the URL and body shape |
+| Wrapper-key change | Mock-server test asserting outbound body wrapper; companion test on the receiving side asserting acceptance |
+| Per-resource version bump | End-to-end integration covering happy path on new version; backward-compat smoke on old version (until sunset) |
+| Doc-only PR | None required, but CI must be clean |
+
+**Running tests locally is mandatory before PR open** (§5.2 step 4). The agent must not rely on CI alone — CI catches regressions, but local runs catch the agent's own bugs.
+
+---
+
+## 14. Per-repo `AGENTS.md` + `CLAUDE.md` mandate
+
+Every repo's `AGENTS.md` (symlinked as `CLAUDE.md`) must contain the following boilerplate section, placed immediately after the repo's "Repository Overview" section:
+
+```markdown
+## Identifier Naming Conventions — MANDATORY
+
+This repository adheres to the **Option B** identifier-naming contract
+defined authoritatively in `meshery/schemas/AGENTS.md § Casing rules at a
+glance`. The contract is **not optional**; deviations block PRs via the
+schemas consumer-audit CI gate.
+
+### The rule in one sentence
+
+*Wire is camelCase everywhere; DB is snake_case; Go fields follow Go
+idiom; the ORM layer is the sole translation boundary.*
+
+### Per-layer canonical forms
+
+| Layer | Form |
+|---|---|
+| DB column / `db:` tag | `snake_case` — `user_id`, `org_id`, `created_at` |
+| Go struct field | `PascalCase` with Go-idiomatic initialisms — `UserID`, `OrgID`, `CreatedAt` |
+| JSON tag | `camelCase` — `json:"userId"`, `json:"orgId"`, `json:"createdAt"` |
+| URL query/path param | `camelCase + Id` — `{orgId}`, `?userId=...` |
+| TypeScript property | `camelCase` — `response.userId`, `queryArg.orgId` |
+| OpenAPI schema property | `camelCase` |
+| OpenAPI `operationId` | `lower camelCase verbNoun` — `getWorkspaces` |
+| `components/schemas` type name | `PascalCase` — `WorkspacePayload` |
+
+### Forbidden (MUST NOT)
+
+- MUST NOT introduce a `json:` tag that matches the `db:` tag on a new
+  DB-backed field. Wire is camel; DB is snake; they differ by design.
+- MUST NOT declare an RTK query endpoint hand-rolled when
+  `@meshery/schemas/{mesheryApi,cloudApi}` provides a canonical equivalent.
+- MUST NOT locally redeclare a Go type that has an equivalent in
+  `github.com/meshery/schemas/models/...`.
+- MUST NOT use `ID` (ALL CAPS) in URL query parameters, JSON tags, or
+  TypeScript properties. `Id` (camelCase) is canonical.
+- MUST NOT mix casing conventions within a single resource. If wire
+  format must change, introduce a new API version per
+  `schemas/AGENTS.md § Dual-Schema Pattern`.
+
+### Required on every PR
+
+- MUST run the schemas validator locally before pushing:
+  `cd ../schemas && make validate-schemas && make consumer-audit`.
+- MUST include test updates for any casing or tag change.
+- MUST include doc updates for any user-visible API change.
+- MUST sign off commits (`git commit -s`).
+
+### Authority
+
+`meshery/schemas/AGENTS.md` is authoritative. On any conflict between
+this repo's documentation and the schemas AGENTS.md, schemas wins. File
+discrepancies as issues against `meshery/schemas`, not locally.
+
+### Migration
+
+The Option B migration is tracked at
+`meshery/schemas/docs/identifier-naming-option-b-migration.md`. All
+contributors — human and AI agents — MUST read this plan before making
+any schema-aware change.
+```
+
+Each repo's AGENTS.md also retains its repo-specific sections (build, tools, tests). The Option B section is additive.
+
+---
+
+## 15. Before/after impact report (projected; actual numbers filled by Agent 4.E)
+
+### 15.1 Metrics table
+
+| Metric | Before | After (projected) | Delta |
+|---|---|---|---|
+| Distinct JSON-tag conventions in wire models | 3 (snake, camel, mixed) | 1 (camel) | −2 |
+| Conditional rules in validator | 1 (DB-backed → snake) | 0 | −1 |
+| Validator rules total | ~20 encoded + gaps | ~24 encoded (Rule 45, 46, 4-ext, consumer_ts) | +4 / 0 gaps |
+| Drift-masking workarounds (`utils.QueryParam` dual-accept) | ≥6 sites | 0 (after Phase 2.C PR 2) | −6 |
+| Locally-declared Go types duplicating schemas | 5+ (MesheryPattern ×2, MesheryPatternRequestBody, MesheryFilter, MesheryApplication) | 0 | −5 |
+| Hand-rolled RTK endpoints duplicating generated clients | 30+ in Cloud UI, 3+ in Kanvas, 2+ in Meshery UI | 0 to <5 (documented legitimate customizations only) | −30+ |
+| CI gates on schema conventions | 2 (blocking-validation, advisory-audit) | 4 (blocking-validation, advisory-audit, consumer-audit advisory then blocking, consumer-audit-ts) | +2 |
+| Same-file casing contradictions | ≥8 (user.ts, design.ts, mesherySdk.ts, meshery_pattern.go, etc.) | 0 | −8 |
+| ALL-CAPS `ID` on wire | ~70 sites (`orgID`, `json:"ID"`, etc.) | 0 | −70+ |
+| API versions with snake-case-on-wire JSON tags | ~20 | 0 after Phase 3 sunset | −20 |
+
+### 15.2 Narrative impact
+
+**Cognitive overhead per contributor:** reduced from "remember three conventions, know DB-backing per field, recall intentional exceptions" to "camel on wire, snake at DB, PascalCase in Go". One rule, one DB boundary, one Go idiom. A new contributor reading `AGENTS.md § Option B` has everything they need in one screen.
+
+**AI-audit false-positive rate:** the conditional "DB-backed → snake" rule is the single largest source of false positives in automated reviewers. Removing it collapses the rule surface and removes the ambiguity that produces the false-positive class.
+
+**Validator rule count:** counter-intuitively rises slightly (+4 net), because the new rules are strict (partial-casing-migrations, sibling-parity, query-param casing, TS consumer). But total enforcement *scope* — the set of drifts that can reach production — shrinks dramatically because the consumer auditor becomes blocking in Phase 4.B.
+
+**CI latency:** the new `consumer-audit` job adds ~60s to every PR in the schemas repo. Acceptable.
+
+**Migration cost:** ~50 JSON-tag flips across 22 resources, concentrated in ID primitives (`user_id` → `userId`, `org_id` → `orgId`, `created_at` → `createdAt`). Per-resource versioning means no big-bang — each resource migrates independently, consumers opt in, old versions sunset after one release.
+
+**End-state uniformity:** any identifier, in any repo, in any layer, has exactly one canonical form derivable from the layer name alone. No conditional, no per-field DB lookup, no partial-migration forgiveness. A reader seeing `json:"org_id"` on a new field knows it's wrong without consulting any other file.
+
+---
+
+## 16. Rollback & resilience
+
+### 16.1 Per-phase rollback
+- **Phase 1:** Revert schemas version bump (1.I); downstream repos pin to the pre-bump version until fixed. Validator rule changes (1.B–1.F) are additive under the advisory baseline — rolling back one rule is safe.
+- **Phase 2:** Each PR is independent; revert individually. No cross-PR state.
+- **Phase 3:** Per-resource rollback = delete the new API-version directory in schemas and revert each downstream consumer PR. Old version still serves traffic; no outage.
+- **Phase 4:** Deprecation sunset (4.A) is reversible for one release cycle by restoring the deleted version directory from git history.
+
+### 16.2 Failure modes per agent
+Each agent has explicit escalation per §5.7. Additional per-class guidance:
+- **Validator rule triggers unexpected volume:** baseline the violations in `validation/baseline/advisory.yaml`; file follow-up issues; do not revert the rule.
+- **Consumer audit misidentifies a route:** capture the false positive in `consumer_*.go` test fixtures; fix the parser; no downstream rollback needed.
+- **Schema regeneration produces broken Go:** revert the version bump; diagnose `oapi-codegen` incompatibility; address before re-attempt.
+- **Downstream PR breaks production:** standard incident response — revert PR; coordinate a fix; verify; re-land.
+
+### 16.3 Live-traffic safety
+- Phase 3 migrations never remove an endpoint; they add a new versioned one. Old traffic continues.
+- Phase 4.A sunsets only after consumer-migration telemetry confirms no remaining callers (e.g., via server-side logging of API version headers).
+- Canary deploy every downstream PR that touches handler logic before full rollout.
+
+---
+
+## 17. Success criteria & sign-off gates
+
+### Phase 1 sign-off
+- [ ] `AGENTS.md` Option B amendment merged; maintainer-approved.
+- [ ] Rules 4-extended, 45, 46 encoded with tests.
+- [ ] `consumer_ts.go` authoring complete with tests.
+- [ ] Advisory baseline refreshed; `make validate-schemas` and `make audit-schemas-full` green.
+- [ ] `consumer-audit` job wired as advisory in CI.
+- [ ] `@meshery/schemas` version published to npm and Go module registry.
+
+### Phase 2 sign-off
+- [ ] All 10 Phase 2 PRs merged across three repos.
+- [ ] Schemas `consumer-audit` shows a reduced but non-zero divergence count (the remaining divergences are Phase 3's domain).
+- [ ] No open high-priority review-bot comments across the 10 PRs.
+
+### Phase 3 sign-off (per resource)
+- [ ] New version authored in schemas; validators green.
+- [ ] Each downstream repo's consumer PR merged.
+- [ ] Old version annotated deprecated; sunset date set.
+- [ ] End-to-end integration test green on new version.
+- [ ] `consumer-audit` clean on this resource.
+
+### Phase 3 sign-off (overall)
+- [ ] All 22 resources migrated.
+- [ ] Aggregate `consumer-audit` shows 0 wire-casing divergences.
+- [ ] One release cycle elapsed since the last resource migration.
+
+### Phase 4 sign-off
+- [ ] All deprecated versions removed from schemas.
+- [ ] `consumer-audit` promoted to blocking; a test drift reliably fails CI.
+- [ ] All four repos' AGENTS.md and CLAUDE.md contain the boilerplate from §14.
+- [ ] Unused validator rules pruned.
+- [ ] Before/after impact report published.
+
+### Overall success (all phases)
+- [ ] Every identifier in every repo, in every layer, has exactly one canonical form derivable from the §1 contract.
+- [ ] No same-file casing contradictions remain.
+- [ ] No locally-declared types duplicating schemas remain (or each has a `// LOCAL:` justification and an open schemas-export issue).
+- [ ] Reviewers (human + AI) have one rule table to consult.
+- [ ] Drift re-entry is prevented by the now-blocking consumer audit.
+
+---
+
+## 18. Appendix A — Resource migration template (Phase 3.{Resource})
+
+Reusable spec; substitute `{resource}`, `{new-version}`, `{old-version}`. Dispatch to the Agent tool with this prompt:
+
+```
+You are Phase 3.{Resource} agent.
+
+CHARTER
+Migrate the {resource} resource from {old-version} to {new-version}
+under the Option B contract defined in
+meshery/schemas/docs/identifier-naming-option-b-migration.md §1.
+
+STEPS
+1. In /Users/l/code/schemas, create schemas/constructs/{new-version}/{resource}/
+   by copying from schemas/constructs/{old-version}/{resource}/.
+2. In the new api.yml and {resource}.yaml:
+   - Convert every JSON tag on every component schema property to camelCase.
+   - Every DB-backed field keeps its `db:` tag in x-oapi-codegen-extra-tags;
+     the `json:` tag is camelCase regardless.
+   - Every query/path parameter: camelCase with `Id` suffix.
+   - Every operationId: lower camelCase verbNoun.
+   - Add any missing parameter references identified by the sibling-parity
+     audit.
+   - Mark the old version's operations `deprecated: true` and set
+     `x-sunset-date` to (today + one release cycle).
+3. Regenerate: cd /Users/l/code/schemas && make generate-golang &&
+   make generate-rtk && make build-ts.
+4. Run validators: make validate-schemas && make audit-schemas-full.
+   Both green (new version clean; old version's deprecation is baselined).
+5. Bump schemas package version (semver minor) and publish.
+6. Open a PR on meshery/schemas. Follow the Common Agent Protocol (§5)
+   for review/iterate/merge.
+7. For each consumer repo in
+   [meshery/meshery, layer5io/meshery-cloud, layer5labs/meshery-extensions]:
+   a. Create a branch fix/{resource}-{new-version}-consume.
+   b. Update go.mod / package.json to the new schemas version.
+   c. Repoint imports from {old-version} to {new-version} for the
+      {resource} type and its related types.
+   d. Update handlers / hooks / UI / tests accordingly.
+   e. Update docs / CHANGELOG.
+   f. Follow the Common Agent Protocol.
+8. Verify end-to-end integration in a dev environment.
+9. Mark the task complete with the merge SHA of each PR and the
+   deprecation sunset date.
+
+ACCEPTANCE
+- New-version schemas validators green.
+- All 3 consumer PRs merged.
+- Old version deprecated and still functional.
+- consumer-audit shows 0 divergences on {resource}.
+```
+
+---
+
+## 19. Appendix B — Repository map & key paths
+
+| Repo | Path | Notes |
+|---|---|---|
+| `meshery/schemas` | `/Users/l/code/schemas` | Source of truth |
+| — AGENTS.md | `AGENTS.md` (symlink `CLAUDE.md`) | Authoritative conventions |
+| — Validation framework | `validation/` | Rule files, casing helpers, consumer auditors |
+| — Makefile targets | `Makefile` lines 85–130 | `validate-schemas`, `audit-schemas-*`, `consumer-audit*` |
+| — CI workflow | `.github/workflows/schema-audit.yml` | Blocking + advisory jobs |
+| — OpenAPI sources | `schemas/constructs/v*/` | One subdir per resource per version |
+| — Generated Go models | `models/v*/` | From `oapi-codegen` |
+| — Generated TS clients | `dist/` | From RTK codegen |
+| `meshery/meshery` | `/Users/l/code/meshery` | Server + UI + `mesheryctl` |
+| — Server handlers | `server/handlers/` | Query-param extraction |
+| — Server models | `server/models/` | Local types (candidates for schemas displacement) |
+| — Remote provider | `server/models/remote_provider.go` | Outbound URL construction |
+| — UI RTK query | `ui/rtk-query/` | Hook aliases |
+| — UI components | `ui/components/` | Hook call sites |
+| — CLAUDE.md | `CLAUDE.md` | Project instructions |
+| `layer5io/meshery-cloud` | `/Users/l/code/meshery-cloud` | Remote provider |
+| — Server handlers | `server/handlers/` | Plain-text 400 error paths (see PR #18858) |
+| — Server models | `server/models/` | Mapping models, locally-declared types |
+| — Constants | `server/utils/constants.go:138` | `QueryParamOrganizationID` |
+| — Middleware | `server/handlers/middlewares_authz_*.go` | `utils.QueryParam` dual-accept |
+| — UI RTK | `ui/api/api.ts` | 30+ hand-rolled endpoints |
+| — CLAUDE.md | `CLAUDE.md` (verify present) | |
+| `layer5labs/meshery-extensions` | `/Users/l/code/meshery-extensions` | Kanvas |
+| — Kanvas source | `meshmap/src/` | |
+| — Kanvas RTK query | `meshmap/src/rtk-query/` | `catalog.ts`, `designs.ts`, `user.ts`, `views.ts` |
+| — SDK (cross-boundary) | `meshmap/src/globals/mesherySdk.ts` | Event-type ↔ dispatcher boundary |
+| — GraphQL plugin | `meshmap/graphql/` | Go side; `schema.graphql` |
+| — CLAUDE.md | `CLAUDE.md` | Project instructions |
+| — Plan (this file) | `docs/identifier-naming-option-b-migration.md` | Canonical execution reference |
+
+---
+
+## 20. Revision history
+
+| Revision | Date | Author | Change |
+|---|---|---|---|
+| 1.0 | 2026-04-22 | Lee Calcote (via orchestrator) | Initial authoring. Option B decision recorded. Phases 0–4 defined. Agent templates inlined. |
+
+End of plan.

--- a/docs/option-b-plan-meshery-cloud.md
+++ b/docs/option-b-plan-meshery-cloud.md
@@ -1,0 +1,137 @@
+# Option B Migration — High-Level Plan: `layer5io/meshery-cloud`
+
+> Handoff artifact for the downstream detailed-plan agent. Contains the known scope, concrete findings, and dependencies — not the final runbook. A subsequent agent will expand this into per-file / per-PR specifications.
+
+## 1. Role in the Option B migration
+
+`layer5io/meshery-cloud` is the Go remote provider (Echo-based server) plus the Cloud Next.js UI. It is the receiving end of every Meshery-Server-proxied request and the largest surface of locally-declared RTK endpoints (~30+ in `ui/api/api.ts`). Its job in the migration: accept the Option B canonical query/body shapes on the wire, stop masking drift via `utils.QueryParam` fallbacks, align all 9 mapping-model JSON tags, and displace duplicated RTK endpoints with schemas-generated equivalents.
+
+## 2. The Option B contract — recap
+
+- **Wire (JSON tags, URL query/path params, TS properties, OpenAPI properties):** camelCase, `Id` suffix.
+- **DB column / `db:` tag:** snake_case (unchanged).
+- **Go field names:** PascalCase with Go-idiomatic initialisms.
+- **No same-resource partial migrations.** Version-bump if wire changes.
+
+## 3. Dependencies on other repos
+
+| Upstream | Blocks this repo's |
+|---|---|
+| `meshery/schemas` Phase 1 (governance + validator hardening + package publish) | All non-trivial Option B work |
+| `meshery/schemas` Phase 3 per-resource versioned schemas | Any handler / model / hook that imports a migrated-resource type |
+| `meshery/meshery` Phase 2.A and 2.B (server query-param + outbound URL alignment) | Retirement of `utils.QueryParam` dual-accept (cannot retire until server emits single form) |
+
+## 4. Known divergences (audit findings, concrete)
+
+### 4.1 Go backend
+
+**Query-parameter constant pinned to wrong form:**
+- `server/utils/constants.go:138` — `QueryParamOrganizationID = "orgID"` (ALL CAPS). Should be `"orgId"`. Cascades to every consumer of the constant across middleware and handlers.
+
+**Dual-accept pattern (masks drift):**
+- `server/handlers/meshery_patterns.go:542` — `utils.QueryParam(q, "orgId", "orgID")`.
+- `server/handlers/meshery_patterns.go:515` — `utils.QueryParam(q, "userId", "user_id")`.
+- `server/handlers/meshery_views.go:123` — same `userId`/`user_id` dual-accept.
+- `server/handlers/flow_emails.go:245` — `orgId`/`orgID` dual-accept.
+- `server/handlers/middlewares_authz_scope.go:241` — `orgId`/`orgID` dual-accept.
+- Additional sites to be located via `grep -rn 'QueryParam.*"[a-z]*Id".*"[a-z_]*id"' server/`.
+- **Outlier with no fallback:** `server/handlers/meshery_filters.go:212` — reads only `q.Get("user_id")` (snake), silently drops `userId` if received. Either add fallback or align to Option B canonical.
+
+**Mapping-model JSON tags — `json:"ID"` ALL CAPS across 9 files** (AGENTS.md requires lowercase `"id"`):
+- `server/models/model_environment_connection_mapping.go:13` — `EnvironmentConnectionMapping.ID`.
+- `server/models/model_workspaces_teams_mapping.go:13` — `WorkspacesTeamsMapping.ID`.
+- `server/models/model_users_organizations_mapping.go:14` — `UsersOrganizationsMapping.ID`.
+- `server/models/model_workspaces_designs_mapping.go:13` — `WorkspacesDesignsMapping.ID`.
+- `server/models/model_resource_access_mapping.go:11` — `ResourceAccessMapping.ID`.
+- `server/models/model_workspaces_environments_mapping.go:13` — `WorkspacesEnvironmentsMapping.ID`.
+- `server/models/model_users_teams_mapping.go:14` — `UsersTeamsMapping.ID`.
+- `server/models/model_workspaces_views_mapping.go:13` — `WorkspacesViewsMapping.ID`.
+- `server/models/model_keychain_filter.go:10` — `KeychainFilter` — `roleID json:"roleID"` (ALL CAPS) with `db:"role_id"`.
+
+**Go field / JSON tag / DB tag three-way splits:**
+- `server/models/users.go:246` — `CatalogRequest.ContentID`: Go `ContentID`, `json:"contentId"`, `db:"content_id"`. **Actually correct under Option B** — confirm and mark as resolved rather than fix.
+- `server/models/users.go:332` — `Messages.UserId`: field `UserId` with `json:"userId"`. No DB tag (in-memory). Consistent within the struct; **correct under Option B** (Go field PascalCase + camelCase JSON on non-DB-backed).
+- `server/models/meshery_patterns.go:62` — `MesheryPattern.OrgID` with `json:"orgId" db:"-"`. Correct under Option B on JSON; `db:"-"` omits it (computed / joined field), so no DB conflict. **Verify and mark resolved.**
+
+**Locally-declared request body duplicating schemas:**
+- `server/handlers/meshery_patterns.go:140` — `MesheryPatternRequestBody` with a `TODO(local-struct migration)` comment referencing `github.com/meshery/schemas/models/v1beta2/design.MesheryPatternRequestBody`. Awaiting schemas issue #5063. When schemas resolves, displace.
+
+**Other locally-declared types to evaluate for schemas displacement:**
+- `server/models/meshery_patterns.go` — full `MesheryPattern` struct. Is Cloud's version divergent from Meshery Server's? Audit and unify.
+- `server/models/meshery_filters.go` — `MesheryFilter`.
+- `server/models/catalog_request.go` (if present) — `CatalogRequest`.
+
+### 4.2 TypeScript frontend (`ui/`)
+
+**~30+ hand-rolled RTK endpoints in `ui/api/api.ts`** — unknown proportion duplicate what `@meshery/schemas/cloudApi` provides. Requires systematic audit:
+- `ui/api/api.ts:1255-1266` — `getWorkspaces`.
+- `ui/api/api.ts:1269-1280` — `getWorkspaceById`.
+- `ui/api/api.ts:~1200` — `getTeams`.
+- `ui/api/api.ts:~90-96` — `getUsersForOrg`.
+- Many more to be enumerated.
+
+**Parameter case-flip transformations (frontend emits `orgID` to match Cloud's current wire form):**
+- `ui/api/api.ts:1264,1272,1201` — input `orgId` → URL `orgID`. Must remove once backend `QueryParamOrganizationID` flips to `"orgId"`.
+- `ui/api/api.ts:~96` — input `teamId` → URL `teamID`.
+
+**Consumer-side casing consistency across Cloud UI components:**
+- `ui/types/user.ts` — type field `user_id` (snake) while component props use `userId` (camel). Adapter layer required or normalize once.
+- `ui/components/workspaces/*.js` — 9 endpoints consuming the hand-rolled Cloud UI RTK; migrations fan out across these consumers.
+
+### 4.3 Server router surface (consumer-audit scope)
+
+- `server/router/router.go` — parsed by `schemas/validation/consumer_echo.go` during consumer-audit. Every registered Echo route's path params and query params are validated. No local findings needed here beyond what Phase 1.H's CI job will surface.
+
+## 5. Expected deliverables (rough)
+
+| Deliverable | Phase | Est. PRs |
+|---|---|---|
+| `QueryParamOrganizationID` constant flip | Phase 2 | 1 |
+| `utils.QueryParam` dual-accept removal (after one deprecation release) | Phase 2 (second release) | 1 |
+| 9 mapping-model `json:"ID"` → `json:"id"` | Phase 2 | 1 (potentially with MarshalJSON shim if API-breaking) |
+| `meshery_filters.go:212` user-id extraction alignment | Phase 2 | 1 (trivial) |
+| Confirm-and-close for `CatalogRequest.ContentID`, `Messages.UserId`, `MesheryPattern.OrgID` | Phase 2 | 1 (docs-only or baseline update) |
+| `ui/api/api.ts` endpoint audit + displacement | Phase 2–3 (spans both) | 3–5 (batched by component group) |
+| Frontend case-flip removal | Phase 2 | 1 (coupled with backend constant flip) |
+| `MesheryPatternRequestBody` displacement | Phase 3 | 1 (after schemas issue #5063 lands) |
+| Per-resource migrations consuming new schemas versions | Phase 3 | ~22 |
+
+## 6. Testing requirements (non-negotiable per agent)
+
+- `go build ./...` clean before every commit.
+- `go test ./...` green; new Pop ORM DAO tests for any model-tag change (round-trip Marshal/Unmarshal against fixture DB rows).
+- Allure-Go test reports updated for handler changes.
+- Cloud UI: `npm run build`, `npm test`, ESLint + Prettier clean.
+- Jest regression tests already exist under `ui/__tests__/components/workspaces/*regression*.test.tsx` — extend these with Option B assertions.
+- Integration test against staging Cloud endpoint after backend changes.
+
+## 7. Documentation requirements (every PR)
+
+- `AGENTS.md` / `CLAUDE.md` at repo root — reflect new conventions.
+- `server/docs/` — API reference updates for any endpoint shape change.
+- `ui/CONTRIBUTING.md` — new paragraph when endpoint-dedup policy changes.
+- `CHANGELOG.md` entry per PR.
+- Inline comments on public Go symbols referencing `schemas/AGENTS.md § Casing rules at a glance`.
+
+## 8. Sequencing notes for the detailed-plan agent
+
+- **Do not remove `utils.QueryParam` dual-accept (Phase 2.C PR 2) until all Meshery Server outbound URLs and all Cloud UI RTK URLs emit `orgId`.** Dual-accept is the compatibility layer during the migration; premature removal breaks in-flight requests.
+- **`QueryParamOrganizationID` constant flip (Phase 2.C PR 1) is non-breaking** — backend accepts `orgId` via the fallback already; the constant flip just makes `orgId` the canonical form in error messages and logs.
+- **9 mapping-model JSON tag fix is API-breaking** for any consumer reading the `ID` field by name. Survey consumers across all three downstream repos before merging; add a `MarshalJSON` shim emitting both `ID` and `id` for one release if needed.
+- **`ui/api/api.ts` dedup is the largest Cloud-specific workstream.** Best tackled by component group (workspaces endpoints first, then events, then catalog, etc.) rather than as one mega-PR.
+- **Cloud UI already has regression tests guarding orgID behavior** (`workspace-widget-orgid.regression.test.tsx`, etc.) — extend these to guard Option B canonicality as well.
+
+## 9. Known open questions for the detailed-plan agent
+
+1. Which of the 30+ `ui/api/api.ts` endpoints have genuine customizations that cannot be served by the schemas-generated `cloudApi`? Generate the exhaustive list via the consumer-audit TypeScript consumer (Phase 1.F).
+2. For the 9 mapping-model `json:"ID"` fix: is the breaking-change blast radius small enough to ship without a `MarshalJSON` shim, or must we stage?
+3. Does Cloud's `meshery_patterns.go MesheryPattern` diverge from Meshery Server's in ways that block a single schemas-sourced struct? Or is it field-identical modulo JSON tags?
+4. Is there a Cloud-specific identifier (e.g., `PlanId`, `SubscriptionId`, `BadgeId`) whose current wire format conflicts with the schemas canonical? Enumerate before Phase 3.
+5. What is Cloud's stance on supporting Meshery Server versions that predate the Option B migration? The `utils.QueryParam` removal window needs to be coordinated with the oldest supported Meshery Server release.
+
+## 10. Reference
+
+- Full detailed plan draft (for reference; not operative): `schemas/docs/identifier-naming-option-b-migration.md`
+- Source of truth: `schemas/AGENTS.md § Casing rules at a glance` (post Phase 1.A amendment)
+- Cloud consumer-audit input: `schemas/validation/consumer_echo.go` (parses `server/router/router.go`)
+- Related prior PRs: #18856 (patternData wrapper), #18858 (JSON error body — sets precedent for wire-error-shape normalization).

--- a/docs/option-b-plan-meshery-extensions.md
+++ b/docs/option-b-plan-meshery-extensions.md
@@ -1,0 +1,129 @@
+# Option B Migration — High-Level Plan: `layer5labs/meshery-extensions` (Kanvas)
+
+> Handoff artifact for the downstream detailed-plan agent. Contains the known scope, concrete findings, and dependencies — not the final runbook. A subsequent agent will expand this into per-file / per-PR specifications.
+
+## 1. Role in the Option B migration
+
+`layer5labs/meshery-extensions` houses Kanvas (the Meshery UI extension — React/TypeScript) plus a Go GraphQL plugin. It is a **consumer only**: it does not own any wire contract but consumes both `@meshery/schemas/mesheryApi` and `@meshery/schemas/cloudApi`, emits RTK requests to Meshery Server, and crosses an injection boundary (via `mesherySdk.ts`) to Meshery UI. Its job in the migration: stop the client-side case-flip transformations, align its request-body wrappers with what Meshery Server expects post-Option-B, resolve same-file casing contradictions, and displace its hand-rolled RTK endpoints where schemas equivalents exist.
+
+## 2. The Option B contract — recap
+
+- **Wire (JSON tags, URL query/path params, TS properties, OpenAPI properties):** camelCase, `Id` suffix.
+- **DB column / `db:` tag:** snake_case (unchanged).
+- **Go field names:** PascalCase with Go-idiomatic initialisms.
+- **No same-resource partial migrations.** Version-bump if wire changes.
+
+## 3. Dependencies on other repos
+
+| Upstream | Blocks this repo's |
+|---|---|
+| `meshery/schemas` Phase 1 (governance + validator hardening + package publish) | All non-trivial Option B work |
+| `meshery/meshery` Phase 2.A (handler query-param alignment) | `getWorkspaceForCatalog` case-flip removal (no harm in leading; no harm in trailing) |
+| `meshery/meshery` Phase 2.B (outbound URL alignment) | Server-side; unrelated here |
+| `meshery/schemas` Phase 3.Design / Phase 3.Workspace | Any Kanvas endpoint that references those resources' types |
+
+## 4. Known divergences (audit findings, concrete)
+
+### 4.1 Kanvas frontend RTK (`meshmap/src/rtk-query/`)
+
+**Client-side case-flip transformation (sends `orgID` to match Cloud legacy wire):**
+- `meshmap/src/rtk-query/catalog.ts:110` — `getWorkspaceForCatalog` endpoint maps input `queryArg.orgId` → URL param `orgID: queryArg.orgId`. Must remove once backend canonical is `orgId`.
+- `meshmap/src/rtk-query/catalog.ts:58-59` — `getPatternsPerUser` uses mixed `orgID` (caps) and `user_id` (snake) params in the same endpoint. Align to Option B canonical.
+
+**Mutation body wrapper-key drift** (snake wrappers with camelCase inner fields — partial-migration violation):
+- `meshmap/src/rtk-query/designs.ts:308` — `uploadPatternBySourceType` body is `{ pattern_data: { name, patternFile }, save }`. Wrapper snake, inner camel. Should be `{ patternData: { ... } }` to align with the precedent set by PR #18856 (`SaveMesheryPattern` wire contract).
+- `meshmap/src/rtk-query/designs.ts:336-342` — `patternFiletoCytoJson` body uses `pattern_data: { id, pattern_file, catalog_data, name }` — all snake inner. Should be all camel.
+- `meshmap/src/rtk-query/designs.ts:188` — `k8sYamlToPattern` body wrapper `{ k8s_manifest: k8sManifest }` — wrapper snake, variable camel. Align to `{ k8sManifest }`.
+
+**Locally-declared RTK endpoints that duplicate schemas-provided ones:**
+- `meshmap/src/rtk-query/catalog.ts:90-100` — `getOrgsForCatalog` (wraps `/api/extensions/api/identity/orgs` with catalog-specific pagination). Evaluate against `@meshery/schemas/mesheryApi.getOrganizations`.
+- `meshmap/src/rtk-query/catalog.ts:102-114` — `getWorkspaceForCatalog` (wraps `/api/extensions/api/workspaces` with orgId filter). Evaluate against `@meshery/schemas/mesheryApi.getWorkspaces` (once the workspace v1beta3 schema declares `orgIdQuery`).
+- `meshmap/src/rtk-query/catalog.ts:48-62` — `getPatternsPerUser`. Evaluate against `@meshery/schemas/mesheryApi.getPatterns` plus user-id filter.
+- `meshmap/src/rtk-query/designs.ts` — `saveDesign`, `getDesign`, `deleteDesign`, `deployPattern`, `undeployPattern`, `cloneDesign`, `uploadPatternBySourceType`, `uploadPatternJson`, `patternToCytoscape`, `k8sYamlToPattern`, `evaluateRelationships`, `meshmodelValidate`, `getPatterns`. Audit each against schemas.
+- `meshmap/src/rtk-query/user.ts` — `getUserProfile`, `getUserProfileSummaryById`, `notifyMentionedUsers`, `getAccessToken`, `getPerformanceProfiles`, `getAllUsers`. Audit each against schemas.
+- `meshmap/src/rtk-query/views.ts` — several. Audit.
+
+### 4.2 Cross-boundary SDK (`meshmap/src/globals/mesherySdk.ts`)
+
+**Same-file casing contradiction (event types ↔ dispatcher signatures):**
+- Line 30 — event type `OpenViewScopedToDesign` uses `design_id` (snake).
+- Line 38 — event type `OpenDesignInKanvas` uses `design_id` (snake).
+- Line 46 — event type `OpenViewInKanvas` uses `view_id` (snake).
+- Line 141-142 — `SetCurrentLoadedResourceInOrgWorkspaceSession` dispatcher signature uses `workspaceId`, `orgId` (camel).
+- **Resolution:** Convert event-type fields to camelCase to match dispatcher signatures.
+
+**Boundary mapping at response ingest:**
+- `meshmap/src/modules/editor/modes/designer/designActor.ts:308-311` — reads `event.output.workspace_id` (snake — from HTTP response) and maps to `workspaceId` (camel — dispatcher). The snake input comes from the wire response body of `getDesign`. Once Phase 3.Design lands a camelCase wire, this mapping collapses to pass-through. Document the intentional mapping as a helper function in the interim.
+
+### 4.3 Collaboration module
+
+**User-ID field duality (ambiguous canonical):**
+- `meshmap/src/modules/editor/collab/config.ts:32-40` — `getNameAndAvatar` interface declares **both** `user_id` and `id` fields on the user type. Canonical choice needed. Per AGENTS.md, `id` is the property default for identity.
+
+### 4.4 Injected-prop shapes (from Meshery UI)
+
+**`meshmap/src/App.tsx:85-89`** declares injected-prop type `SetCurrentLoadedResourceInOrgWorkspaceSession: (params: { id, workspaceId, orgId }) => void`. Consistent camelCase on Kanvas's side. The receiving end is Meshery UI's `WorkspaceModalContextProvider.tsx:51` `onLoadResource({ id, workspaceId, orgId })` — also camelCase. **Correct; no fix needed.** Document as a contract that must remain camelCase.
+
+### 4.5 GraphQL plugin (`meshmap/graphql/`)
+
+**Minimal divergence:**
+- `graphql/schema/schema.graphql` — uses UPPERCASE composite identifiers: `designID`, `k8sclusterIDs`, `connectionID`.
+- Under Option B, GraphQL identifier fields should align with the canonical wire form (camelCase + `Id`), same as REST.
+- `graphql/model/models_gen.go` — generated types; will follow schema changes.
+
+**Candidate changes:**
+- `designID` → `designId`, `connectionID` → `connectionId`, `k8sclusterIDs` → `k8sclusterIds`.
+- Requires schema file edits, `make graphql` regeneration, and go.mod sync with `meshery/meshery` (per the project CLAUDE.md invariant).
+
+## 5. Expected deliverables (rough)
+
+| Deliverable | Phase | Est. PRs |
+|---|---|---|
+| `catalog.ts` case-flip removal (`getWorkspaceForCatalog`, `getPatternsPerUser`) | Phase 2 | 1 |
+| `designs.ts` body wrapper unification (`pattern_data` → `patternData`, `k8s_manifest` → `k8sManifest`) | Phase 2 | 1 (coordinated with receiving handler verification) |
+| `mesherySdk.ts` event-type camelCase alignment | Phase 2 | 1 |
+| `collab/config.ts` user-ID duality resolution | Phase 2 | 1 |
+| Kanvas RTK endpoint dedup vs. schemas (catalog, designs, user, views) | Phase 2–3 | 2–4 (by group) |
+| GraphQL identifier alignment (`designID` → `designId`, etc.) | Phase 3 | 1 |
+| Per-resource consumer updates when schemas publishes new versions | Phase 3 | ~5 (not all 22 resources touch Kanvas) |
+
+## 6. Testing requirements (non-negotiable per agent)
+
+- `cd meshmap && npm run build` clean before every commit.
+- `npm test` green; Jest unit tests under `meshmap/src/__tests__/`.
+- E2E tests under `tests/` (playwright) — at minimum the save-design flow and catalog-modal flow after `designs.ts` and `catalog.ts` changes.
+- Lint: `make kanvas-lint` (ESLint + Prettier) clean.
+- Kanvas dev server (`make kanvas`) loads against a live Meshery server; manually verify save, load, delete design flows.
+- `cd graphql && make graphql-lint && make graphql` clean for any GraphQL changes.
+- Meshery Server + Kanvas integration smoke: design save succeeds end-to-end after Option B wrapper changes.
+
+## 7. Documentation requirements (every PR)
+
+- `CLAUDE.md` at repo root — updated per §14 of the detailed-plan draft.
+- Kanvas Developer Guide under `docs/Kanvas Developer Guide/` — touched sections updated when the feature's wire shape changes.
+- `meshmap/src/rtk-query/` inline docstrings referencing the canonical rule.
+- `CHANGELOG.md` entry per PR.
+
+## 8. Sequencing notes for the detailed-plan agent
+
+- **`catalog.ts` case-flip removal can land standalone** — the receiving handler (`meshery-cloud/server/handlers/workspaces.go` accessed via Meshery Server's extension proxy) already tolerates `orgId` via `utils.QueryParam`. No server-side coordination required for this specific PR.
+- **`designs.ts:308` wrapper-key change IS coordinated** — the receiving handler in `meshery/server/handlers/meshery_pattern_handler.go` must accept `patternData`. Verify by reading the handler's unmarshal target struct's JSON tags before merging; add a companion Meshery Server PR if the handler currently only accepts `pattern_data`.
+- **RTK endpoint dedup is best tackled by group:** catalog first (small, isolated), then designs (large, coupled to save-design flow), then user (small), then views (small).
+- **GraphQL identifier rename is Phase 3 territory** — it's a schema-driven change that requires the schemas repo to publish an updated GraphQL SDL first, then Kanvas regenerates.
+- **`mesherySdk.ts` event-type alignment is Kanvas-internal** — no cross-repo coordination; can ship standalone as soon as Phase 1 schemas landing closes the governance doc.
+
+## 9. Known open questions for the detailed-plan agent
+
+1. For the `designs.ts:308` `pattern_data` → `patternData` wrapper change: does the meshery server `meshery_pattern_handler.go` unmarshal target currently read `pattern_data` from the request body, or already `patternData`? Concrete answer determines whether a companion meshery server PR is needed.
+2. Which of the RTK endpoints in `catalog.ts` and `designs.ts` have genuine catalog-specific customizations vs. bare duplications of `@meshery/schemas/mesheryApi.*` hooks?
+3. Is the GraphQL schema's UPPERCASE ID convention (`designID`, `connectionID`) authored here, or inherited from a schema SDL elsewhere? Source-of-truth question before any rename.
+4. Does the Kanvas `kanvas/.meshery/provider/Layer5/capabilities.json` file declare endpoint paths that would be affected by Phase 3 URL changes? Audit.
+5. What is Kanvas's minimum-supported Meshery Server version? RTK endpoint changes must be compatible with that version's handler contract.
+
+## 10. Reference
+
+- Full detailed plan draft (for reference; not operative): `schemas/docs/identifier-naming-option-b-migration.md`
+- Source of truth: `schemas/AGENTS.md § Casing rules at a glance` (post Phase 1.A amendment)
+- Kanvas Redux store setup (correctly uses schemas slices): `meshmap/src/redux/store.ts`
+- Prior PRs: #18856 (patternData wrapper precedent — sets the `designs.ts` target shape), #18857 (merged k8s panic fix — unrelated), #18858 (JSON error body — Meshery Server side).
+- Related Kanvas-specific automations: `meshery-extensions/CLAUDE.md § Claude Code Automation Setup`.

--- a/docs/option-b-plan-meshery.md
+++ b/docs/option-b-plan-meshery.md
@@ -1,0 +1,117 @@
+# Option B Migration — High-Level Plan: `meshery/meshery`
+
+> Handoff artifact for the downstream detailed-plan agent. Contains the known scope, concrete findings, and dependencies — not the final runbook. A subsequent agent will expand this into per-file / per-PR specifications.
+
+## 1. Role in the Option B migration
+
+`meshery/meshery` is the Go server + Meshery UI (Next.js) + `mesheryctl` CLI. It consumes `@meshery/schemas` as the source of truth and hosts the routing logic that the schemas consumer-audit validates against. Its job in the migration: align every identifier it emits (outbound URLs, JSON bodies), every identifier it reads (query params, response shapes), and every hook it exposes to Kanvas with the Option B canonical form.
+
+## 2. The Option B contract — recap
+
+- **Wire (JSON tags, URL query/path params, TS properties, OpenAPI properties):** camelCase, `Id` suffix (lowercase `d`).
+- **DB column / `db:` tag:** snake_case (unchanged; the sole remaining translation boundary).
+- **Go field names:** PascalCase with Go-idiomatic initialisms (`UserID`, `OrgID`, `WorkspaceID`).
+- **No same-resource partial migrations.** If a resource's wire format changes, bump its API version.
+
+## 3. Dependencies on other repos
+
+| Upstream | Blocks this repo's |
+|---|---|
+| `meshery/schemas` Phase 1 (governance + validator hardening + package publish) | All non-trivial Option B work in this repo |
+| `meshery/schemas` Phase 3 per-resource versioned schemas | Any handler / model / hook that imports a migrated-resource type |
+| `layer5io/meshery-cloud` Phase 2.C (constant + dual-accept retirement) | Timing of outbound URL alignment — can land before or after; no hard ordering |
+
+## 4. Known divergences (audit findings, concrete)
+
+### 4.1 Go backend
+
+**Query-parameter extraction drift (sibling endpoints, different keys):**
+- `server/handlers/workspace_handlers.go:24,46` — reads `q.Get("orgID")` (ALL CAPS). Should be `q.Get("orgId")`. *Non-breaking if companion UI fix lands.*
+- `server/handlers/meshery_pattern_handler.go:557` — `q["orgID"]`. Same fix.
+- `server/handlers/environments_handlers.go:24,45` — already reads `q.Get("orgId")`. **Correct under Option B.**
+
+**Outbound URL construction (Meshery Server → Meshery Cloud):**
+- `server/models/remote_provider.go:5174` — `q.Set("orgID", orgID)` in `GetEnvironments`. Change to `"orgId"`.
+- `server/models/remote_provider.go:5215` — `q.Set("orgID", orgID)` in `GetWorkspaces`. Change to `"orgId"`.
+- `server/models/remote_provider.go:5607` — `q.Set("orgID", orgID)` in `GetCatalogMesheryPatterns`.
+- `server/models/remote_provider.go:5671` — `q.Set("orgID", orgID)` in `GetUsersKeys`.
+- Companion change: Meshery Cloud must already accept `orgId` (it does via its `utils.QueryParam` fallback today; becomes canonical after Cloud's Phase 2.C).
+
+**JSON tag drift on locally-declared Go models (partial-casing-migration violations):**
+- `server/models/meshery_pattern.go:93,109,110` — `MesheryPattern` struct mixes three JSON-tag conventions on three DB-backed ID fields: `json:"user_id"`, `json:"workspace_id"`, `json:"orgId"`. Violates AGENTS.md "Partial casing migrations forbidden". Two resolution paths:
+  - **Phase 2 interim:** Normalize back to all snake (revert `orgId` → `org_id`) so the struct is consistent with DB-backing — non-breaking, internal consistency restored.
+  - **Phase 3 final:** Displace the local struct with `github.com/meshery/schemas/models/v1beta3/design.MesheryPattern` once the v1beta3 design schema lands under Option B.
+- `server/models/meshery_filter.go:19,36` — `MesheryFilter.UserID json:"user_id"`. Candidate for schemas export + displacement.
+- `server/models/meshery_application.go:42` — same class.
+- `server/models/k8s_context.go:37-38` — `MesheryInstanceID json:"meshery_instance_id"`, `KubernetesServerID json:"kubernetes_server_id"`. Meshery-local (not in schemas); wire form needs Option B camelCase (`mesheryInstanceId`, `kubernetesServerId`) once a `v1beta*` K8sContext schema is authored.
+
+**`mesheryctl` CLI (not yet surveyed — gap):**
+- Subsequent audit pass needed. Expected divergences: command-line flag casing (`--org-id` vs `--orgId`), config-file key casing.
+
+### 4.2 TypeScript frontend (`ui/`)
+
+**Same-file casing contradictions:**
+- `ui/rtk-query/user.ts:87` — `orgID: selectedOrganization?.id` (ALL CAPS).
+- `ui/rtk-query/user.ts:107` — `orgId: queryArg?.orgId` (camelCase). **Same file; two conventions.**
+- `ui/rtk-query/design.ts:44` — `user_id: queryArg.user_id` (snake).
+- `ui/rtk-query/design.ts:49` — `orgID: queryArg.orgID` (ALL CAPS). **Same file; two conventions.**
+
+**Thin wrappers that exist only to alias parameter names:**
+- `ui/rtk-query/environments.ts:11-21` — wraps `useSchemasGetEnvironmentsQuery` solely to pass `orgId` through. Eliminate; have callers import the generated hook directly.
+- `ui/rtk-query/workspace.ts:19-80` — custom `queryFn` exists because the schemas-generated `getWorkspaces` was missing the `orgId` param. Once schemas Phase 3.Workspace authors v1beta3 with the `orgIdQuery` ref, retire the custom queryFn.
+
+**Hand-rolled endpoints to evaluate for schemas displacement:**
+- `ui/rtk-query/workspace.ts` — custom `getWorkspaces` (expand-info multi-dispatch).
+- `ui/rtk-query/user.ts` — `useGetOrganizations` and others using custom `queryFn` with URL transformation.
+
+## 5. Expected deliverables (rough)
+
+| Deliverable | Phase | Est. PRs |
+|---|---|---|
+| `q.Get("orgID")` → `q.Get("orgId")` in handlers | Phase 2 | 1 |
+| `q.Set("orgID", ...)` → `q.Set("orgId", ...)` in `remote_provider.go` | Phase 2 | 1 |
+| Meshery UI RTK hook unification (user.ts, design.ts, environments.ts) | Phase 2 | 1–2 |
+| `MesheryPattern` struct JSON tag normalization (Phase 2 interim) | Phase 2 | 1 |
+| `mesheryctl` CLI flag / config audit + fix | Phase 2 | 1 |
+| Per-resource migrations consuming new schemas versions | Phase 3 | ~22 (one per resource, coordinated with schemas) |
+| Local Go type displacements (`MesheryPattern`, `MesheryFilter`, `MesheryApplication` → schemas imports) | Phase 3 | 3+ |
+| `K8sContext` JSON tag migration (new schemas type or in-place update) | Phase 3 | 1 |
+
+## 6. Testing requirements (non-negotiable per agent)
+
+- `go build ./...` clean before every commit.
+- `go test ./...` green for touched packages; new tests for any new behavior.
+- Handler-level tests asserting new query-param names work and old names fail (post-deprecation).
+- Serialization round-trip tests (`json.Marshal`/`Unmarshal`) for any struct JSON tag change.
+- E2E smoke in `tests/` (playwright) for UI changes.
+- `make kanvas-lint` / ESLint / Prettier green on UI changes.
+
+## 7. Documentation requirements (every PR)
+
+- `CLAUDE.md` at repo root — reflect new conventions as landed.
+- `docs/` subpages that reference the changed endpoint, hook, or model.
+- API reference (server swagger / generated docs) updated.
+- `CHANGELOG.md` entry per PR.
+- Comments on public Go symbols explaining rationale, referencing `schemas/AGENTS.md § Casing rules at a glance`.
+
+## 8. Sequencing notes for the detailed-plan agent
+
+- **Phase 2 non-breaking fixes can all ship independently** — no inter-PR ordering required. They should land BEFORE Phase 3 starts to reduce noise in per-resource diffs.
+- **Phase 3 per-resource migrations wait for schemas:** each resource's Phase 3 in this repo cannot start until `meshery/schemas` has authored and published the new version of that resource.
+- **Workspace is priority-1 for Phase 3** because of the known `orgId`-drop production bug (PR #18858 context). This repo's side of that migration is small once schemas publishes v1beta3.
+- **`mesheryctl` audit has not been done yet** — a pre-Phase-2 audit agent is needed to inventory CLI flag and config-file identifier casing.
+
+## 9. Known open questions for the detailed-plan agent
+
+1. Does the `mesheryctl` config file format need its own versioning for an Option B migration, or can it migrate in place?
+2. Should `K8sContext` be exported to `meshery/schemas` for reuse (it currently is not), and if so, under which version?
+3. Which resources in the 22-resource inventory have meshery-server-specific shape extensions (e.g., pagination envelope on `/api/pattern`) that need schemas-side updates before this repo can consume them?
+4. Are there generated GraphQL types in `server/internal/graphql/generated/generated.go` that reference snake-case identifiers inherited from a GraphQL SDL file? That file was mentioned in prior audits but not traced end-to-end.
+5. Deprecation strategy for handlers that currently dual-accept casing: flip to single-accept in Phase 2, or hold until Phase 3 per-resource?
+
+## 10. Reference
+
+- Full detailed plan draft (for reference; not the operative document): `schemas/docs/identifier-naming-option-b-migration.md`
+- Source of truth: `schemas/AGENTS.md § Casing rules at a glance` (post Phase 1.A amendment)
+- Prior audit sub-reports in this session's transcript (meshery-cloud, meshery, meshery-extensions audits)
+- PR #18856 (patternData wrapper precedent), PR #18857 (merged k8s panic fix — unrelated), PR #18858 (JSON error body — Option B-adjacent)

--- a/docs/option-b-session-kickoff.md
+++ b/docs/option-b-session-kickoff.md
@@ -48,7 +48,7 @@ Persistent execution state lives in GitHub issues on `meshery/schemas`, labeled 
 - Phase 3 — Per-resource versioned migration: https://github.com/meshery/schemas/issues/779
 - Phase 4 — Deprecation sunset + enforcement finalization: https://github.com/meshery/schemas/issues/780
 
-Governance PR carrying this plan: *(URL populated once the PR on `meshery/schemas` is opened — see §10)*
+Governance PR carrying this plan: https://github.com/meshery/schemas/pull/781
 
 Use the issues as the authoritative state:
 - Claim a sub-agent by checking its checklist item with your session ID and start time.

--- a/docs/option-b-session-kickoff.md
+++ b/docs/option-b-session-kickoff.md
@@ -1,0 +1,150 @@
+# Option B — Session Kickoff
+
+**Read this first. This document is the entry point for every execution session of the Option B identifier-naming migration.**
+
+## 0. What this session is doing
+
+You are one execution session in a multi-session migration that standardizes identifier naming across `meshery/schemas`, `meshery/meshery`, `layer5io/meshery-cloud`, and `layer5labs/meshery-extensions`. The migration direction is **Option B**: camelCase on wire, snake_case only at the DB/ORM boundary.
+
+You are **not** a design session. You do not re-audit, re-plan, re-argue the contract, or introduce new conventions. You read the plan and execute.
+
+## 1. Working directory
+
+```
+/Users/l/code/schemas
+```
+
+Sibling repos (for read/write during agent execution):
+- `/Users/l/code/meshery`
+- `/Users/l/code/meshery-cloud`
+- `/Users/l/code/meshery-extensions`
+
+## 2. Preconditions (verify before starting)
+
+- `gh auth status -a` — authenticated for `github.com`.
+- `git config user.email` — resolves to a committer identity authorized for sign-offs.
+- Go 1.25+, Node 20+, the repo Makefile targets runnable.
+- `uv` installed for `iterate-pr` skill scripts.
+- You can push to `layer5io/meshery-cloud`, `layer5labs/meshery-extensions`, and `meshery/meshery` (or to a fork with auto-PR flow configured).
+
+## 3. Required reading order
+
+Read these in order. Do not skip. Do not skim.
+
+1. `docs/identifier-naming-option-b-migration.md` — master plan. §1 defines the contract; §5 defines the Common Agent Protocol every sub-agent follows; §11 is the orchestration DAG; §14 is the per-repo AGENTS.md boilerplate to paste; §17 is the sign-off gate you check your work against.
+2. `docs/option-b-plan-meshery.md` — high-level handoff scoped to `meshery/meshery`.
+3. `docs/option-b-plan-meshery-cloud.md` — high-level handoff scoped to `layer5io/meshery-cloud`.
+4. `docs/option-b-plan-meshery-extensions.md` — high-level handoff scoped to `layer5labs/meshery-extensions`.
+
+After reading, you understand: the contract, the phase DAG, the Common Agent Protocol, the divergences in each downstream repo, the dependency ordering.
+
+## 4. State of record (cross-session)
+
+Persistent execution state lives in GitHub issues on `meshery/schemas`, labeled `option-b-migration`. Each issue is a phase with a checklist of sub-agents. Issue URLs:
+
+- Phase 0 — Baseline metrics: https://github.com/meshery/schemas/issues/776
+- Phase 1 — Schemas governance + validator hardening: https://github.com/meshery/schemas/issues/777
+- Phase 2 — Non-breaking downstream alignment: https://github.com/meshery/schemas/issues/778
+- Phase 3 — Per-resource versioned migration: https://github.com/meshery/schemas/issues/779
+- Phase 4 — Deprecation sunset + enforcement finalization: https://github.com/meshery/schemas/issues/780
+
+Governance PR carrying this plan: *(URL populated once the PR on `meshery/schemas` is opened — see §10)*
+
+Use the issues as the authoritative state:
+- Claim a sub-agent by checking its checklist item with your session ID and start time.
+- Post progress as issue comments; link each merged PR by SHA + URL.
+- If blocked, post a `BLOCKED:` comment (see §7) and move on.
+
+Do not rely on Claude Code's in-session `TaskList` for cross-session state. The in-session tasks are per-session scratch space only.
+
+## 5. Bootstrap action (what to do after you've read §3)
+
+1. Run `gh issue list --repo meshery/schemas --label option-b-migration --state open`.
+2. Identify the lowest-priority-number phase that is not yet `completed`.
+3. Within that phase issue, identify the first unchecked sub-agent whose dependencies (per §11 of master plan's DAG) are satisfied.
+4. Claim it by posting a comment: `Claimed by session <short-session-id> at <ISO timestamp>.`
+5. Execute per the Common Agent Protocol (master plan §5). Specifically:
+   - Cut a fresh branch from the target repo's default branch.
+   - Implement.
+   - Build locally.
+   - Test locally (new tests for new behavior; updated tests for modified behavior).
+   - Update documentation in the same PR (master plan §12 mandates this).
+   - Commit with sign-off.
+   - Push, open PR with the §5.6 standard body template.
+   - Wait for Copilot + Gemini automated review; address or refute each thread.
+   - Arm `gh pr merge --auto` as soon as CI passes.
+   - When merged, post the merge SHA + URL as a comment on the phase issue, and check the sub-agent's box in the checklist.
+6. Claim the next unblocked sub-agent. Repeat until you hit a checkpoint or stop condition (§7).
+
+## 6. Orchestration model
+
+This session is **the orchestrator**. You spawn sub-agents via the Claude Code Agent tool when:
+- The task is clearly parallelizable (e.g., Phase 0 baseline agents, Phase 3 per-resource migrations).
+- The task benefits from isolated context (e.g., a read-heavy audit scan of one repo).
+
+You do the task yourself when:
+- It's small (single-file fix, doc tweak).
+- It requires cross-referencing multiple in-flight PRs.
+- It's an orchestration step (claiming issues, updating checkpoints).
+
+Sub-agents you spawn follow the same Common Agent Protocol. You give them the exact charter from the master plan (e.g., "Execute Agent 2.A as defined in §8 of `/Users/l/code/schemas/docs/identifier-naming-option-b-migration.md`") plus the acceptance criteria. You do not re-author their prompts from scratch.
+
+## 7. Stop conditions — when to checkpoint and exit
+
+Exit cleanly at any of these, do not try to power through:
+
+- **Phase boundary complete** — all sub-agents in a phase checked off, sign-off criteria (§17) met. Post a summary comment on the phase issue.
+- **2 hours continuous work** — time-box so another session can pick up fresh.
+- **Blocked agent** — a sub-agent hit a failure you cannot resolve (§5.7 of master plan). Post a `BLOCKED: <reason>` comment on the phase issue and on the sub-agent's PR if open. Do not force through.
+- **Review-thread requires human judgment** — a Copilot or Gemini thread requests a design decision outside the master plan's scope. Post the thread link on the phase issue and stop.
+- **CI flaking** — same CI failure after 3 push attempts. Stop and escalate.
+- **Repo disagrees with plan** — you find a repo-level concern that contradicts the master plan (e.g., a handler whose existence the plan doesn't anticipate). Do not silently extend the plan. Post a `PLAN GAP:` comment and stop.
+
+Before exit, every in-flight PR must be pushed with current state. Leave nothing uncommitted locally.
+
+## 8. Session-to-session checkpoint protocol
+
+Before exiting any session:
+
+1. All local changes pushed; no uncommitted files except session scratch (`state.json`, `.claude/`).
+2. Every open PR labeled `option-b-migration` and with the phase label.
+3. Progress comment posted on the active phase issue: what landed (SHAs), what's in flight, what the next session should claim first.
+4. If a new risk or gap surfaced, update the relevant per-repo handoff doc (`docs/option-b-plan-*.md`) in a follow-up commit.
+
+## 9. Do-not-do list
+
+- Do NOT re-run the identifier-naming audit. The findings are in the per-repo plans; they are the input, not something to reproduce.
+- Do NOT change the contract defined in master plan §1. If you think it should change, post a `PLAN GAP:` comment and stop.
+- Do NOT combine sub-agents' PRs. Each sub-agent ships its own PR.
+- Do NOT skip review-bot feedback. Every Copilot and Gemini thread gets a fix or a documented refutation.
+- Do NOT force push to any branch other than your own throwaway branches.
+- Do NOT merge your own governance PR without the human-review gate being satisfied (master plan §5.3).
+- Do NOT modify the master plan or this kickoff doc to match what you happen to have implemented. The plan is the contract.
+- Do NOT create new identifier conventions, new casing rules, or new validator approaches. All governance decisions are fixed.
+
+## 10. Bootstrap checklist for the very first session (after plan is merged)
+
+The first session after the governance PR merges has a one-time setup:
+
+1. Confirm the governance PR is merged on `meshery/schemas`.
+2. Confirm the 5 phase-tracking issues exist on `meshery/schemas` with the `option-b-migration` label.
+3. Back-fill the governance PR URL in §4 above (this doc) via a follow-up commit.
+4. Then proceed per §5 — starting with Phase 0 baseline agents.
+
+## 11. Session-start command (for every subsequent session)
+
+In a fresh Claude Code session opened at `/Users/l/code/schemas`, paste:
+
+```
+Read docs/option-b-session-kickoff.md and execute per §5 of the master plan it references.
+```
+
+No additional context required. The kickoff doc and master plan carry everything.
+
+## 12. Escalation channel
+
+Post `PLAN GAP:` or `BLOCKED:` comments on the active phase issue. Mention @leecalcote for any decision outside the plan's scope. Do not proceed on governance questions without explicit human sign-off.
+
+---
+
+**End of kickoff. Proceed to §3.**


### PR DESCRIPTION
## Summary

Introduces the governance artifacts for the Option B identifier-naming migration — the cross-repo standardization that collapses the current three-convention JSON-tag state (snake / camel / ALL CAPS) into a single rule: **camelCase on wire, snake_case only at the DB/ORM boundary.**

This PR contains documentation only. No code is touched. No execution begins until this PR merges.

This supersedes layer5labs/meshery-extensions#4205 (which was the initial landing spot for the plan). The docs are moved to \`meshery/schemas\` because that's where the conventions (AGENTS.md) and the validation framework (validation/) that will enforce them already live.

## What's in this PR

- \`docs/identifier-naming-option-b-migration.md\` — master plan (~1550 lines, 20 sections). Contract (§1), Common Agent Protocol every sub-agent follows (§5), orchestration DAG (§11), per-repo AGENTS.md boilerplate (§14), sign-off gates (§17), reusable resource-migration agent prompt (Appendix A).
- \`docs/option-b-plan-meshery.md\` — high-level scope for \`meshery/meshery\` (server + UI + mesheryctl).
- \`docs/option-b-plan-meshery-cloud.md\` — high-level scope for \`layer5io/meshery-cloud\`.
- \`docs/option-b-plan-meshery-extensions.md\` — high-level scope for \`layer5labs/meshery-extensions\`.
- \`docs/option-b-session-kickoff.md\` — session entry-point bootstrap.

## The contract (one table)

| Layer | Form |
|---|---|
| DB column / \`db:\` tag | snake_case — \`user_id\`, \`org_id\`, \`created_at\` |
| Go struct field | PascalCase with Go-idiomatic initialisms — \`UserID\`, \`OrgID\` |
| JSON tag | camelCase — \`json:\"userId\"\`, \`json:\"orgId\"\` |
| URL query/path param | camelCase + \`Id\` — \`{orgId}\`, \`?userId=...\` |
| TypeScript property | camelCase |
| OpenAPI schema property | camelCase |
| \`operationId\` | lower camelCase verbNoun |
| \`components/schemas\` type name | PascalCase |

The one-sentence rule: *Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.*

## Governance scope

- Authority flows from \`AGENTS.md § Casing rules at a glance\` (to be amended as the first execution step, Phase 1.A in the master plan).
- Every downstream repo's \`AGENTS.md\` / \`CLAUDE.md\` will carry the boilerplate mandate defined in master plan §14.
- Enforcement via \`validation/\` — new rules added (Partial-casing-migrations, sibling-endpoint parameter parity, query-parameter casing extension) and \`consumer_ts.go\` authored. Consumer-audit CI job promoted from advisory to blocking after Phase 3.

## Phased execution overview

- **Phase 0** — baseline metrics (tracked in #776).
- **Phase 1** — schemas governance doc + validator rules + CI wiring + package publish (#777).
- **Phase 2** — 10 non-breaking alignment PRs across three downstream repos (#778).
- **Phase 3** — 22 per-resource versioned migrations, parallel (#779).
- **Phase 4** — deprecation sunset + consumer-audit promotion to blocking + universal AGENTS.md/CLAUDE.md finalization + impact report (#780).

Estimated total: 12–17 weeks. Phases 2 and 3 are heavily parallel.

## Review focus

- §1 (contract) — is this the right end state?
- §5 (Common Agent Protocol) — is the review/test/doc loop sufficient?
- §14 (per-repo AGENTS.md boilerplate) — is the text acceptable to paste verbatim into every repo?
- §17 (sign-off gates) — are the acceptance criteria per phase correct?
- Scope coverage — any identifier class or repo scope missing?

## Test plan

- [x] Files render correctly on GitHub preview.
- [ ] Human governance sign-off from a maintainer (required before merge per master plan §5.3).

## Post-merge actions

1. Back-fill \`docs/option-b-session-kickoff.md\` §4 with this PR's URL via a follow-up commit.
2. Open the first execution session using the kickoff command in §11 of the kickoff doc.

## Rollback

Single-commit PR. Revert via GitHub button. No code consequence.