### PR TITLE
chore(baseline): add Phase 0 Agent 0.B tag-divergence artifact

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,14 @@ audit-schemas-debt-full:
 baseline-field-count:
 	go run ./cmd/phase0-field-count
 
+## Regenerate the Option B Phase 0 tag-divergence baseline artifact
+## (scans json/db struct tags in $(MESHERY_REPO) and $(CLOUD_REPO))
+.PHONY: baseline-tag-divergence
+baseline-tag-divergence:
+	@go run ./cmd/phase0-tag-divergence \
+		$(if $(MESHERY_REPO),--meshery-repo=$(MESHERY_REPO)) \
+		$(if $(CLOUD_REPO),--cloud-repo=$(CLOUD_REPO))
+
 #-----------------------------------------------------------------------------
 # Consumer audit (schemas vs. consumer repos)
 #-----------------------------------------------------------------------------

--- a/cmd/phase0-tag-divergence/main.go
+++ b/cmd/phase0-tag-divergence/main.go
@@ -1,0 +1,567 @@
+// Command phase0-tag-divergence scans Go struct tags across the meshery and
+// meshery-cloud server/models directories and produces the Phase 0 Agent 0.B
+// tag-divergence baseline (validation/baseline/tag-divergence.json) used by
+// the Option B identifier-naming migration
+// (docs/identifier-naming-option-b-migration.md §6).
+//
+// Each scanned field is evaluated against three criteria from Agent 0.B's
+// charter:
+//
+//  1. `json:` tag differs from `db:` tag — either in form (camelCase json vs
+//     snake_case db) or in value (mapping to a different column name).
+//  2. Multiple JSON-tag conventions appear within a single struct (e.g., one
+//     field camelCase, another snake_case).
+//  3. The `json:` tag is ALL CAPS or contains an all-caps acronym token like
+//     `ID` / `URL` that Option B retires.
+//
+// Output JSON is structured as a flat record list plus a summary of per-
+// classification counts, suitable for diff-auditing across the migration.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+)
+
+type casingForm string
+
+const (
+	casingCamel     casingForm = "camelCase"
+	casingSnake     casingForm = "snake_case"
+	casingPascal    casingForm = "PascalCase"
+	casingScreaming casingForm = "SCREAMING"
+	casingLower     casingForm = "lowercase"
+	casingMixed     casingForm = "mixed"
+	casingEmpty     casingForm = ""
+)
+
+// classification flags a field against Agent 0.B's criteria. A field can
+// carry more than one flag; the zero value (an empty slice) means the field
+// is clean under Option B.
+type classification string
+
+const (
+	classJSONDBFormMismatch  classification = "json_db_form_mismatch"   // casings differ
+	classJSONDBValueMismatch classification = "json_db_value_mismatch"  // names differ after normalizing casing
+	classScreamingJSON       classification = "screaming_json"          // json tag contains ALL CAPS
+	classMixedStruct         classification = "mixed_struct_conventions" // host struct has multiple JSON casings
+	classSuppressed          classification = "json_dash"                // json:"-" — not serialized, reported for visibility
+)
+
+type fieldRecord struct {
+	Repo            string           `json:"repo"`
+	File            string           `json:"file"`
+	Line            int              `json:"line"`
+	Type            string           `json:"type"`
+	Field           string           `json:"field"`
+	JSONTag         string           `json:"json_tag"`
+	JSONTagCasing   casingForm       `json:"json_tag_casing,omitempty"`
+	DBTag           string           `json:"db_tag,omitempty"`
+	DBTagCasing     casingForm       `json:"db_tag_casing,omitempty"`
+	Classifications []classification `json:"classifications,omitempty"`
+}
+
+type summaryCounts struct {
+	TotalStructs        int `json:"total_structs_scanned"`
+	StructsWithTags     int `json:"structs_with_any_tag"`
+	TotalFieldsWithTag  int `json:"total_fields_with_any_tag"`
+
+	FormMismatch       int `json:"json_db_form_mismatch"`
+	ValueMismatch      int `json:"json_db_value_mismatch"`
+	ScreamingJSON      int `json:"screaming_json"`
+	MixedStructs       int `json:"mixed_struct_conventions_structs"`
+	JSONDash           int `json:"json_dash"`
+
+	JSONByCasing map[casingForm]int `json:"json_tags_by_casing"`
+	DBByCasing   map[casingForm]int `json:"db_tags_by_casing"`
+}
+
+type baselineReport struct {
+	GeneratedAt     time.Time      `json:"generated_at"`
+	GeneratedBy     string         `json:"generated_by"`
+	Scope           string         `json:"scope"`
+	Repos           []string       `json:"repos"`
+	FilesProcessed  int            `json:"files_processed"`
+	Summary         summaryCounts  `json:"summary"`
+	Records         []fieldRecord  `json:"records,omitempty"`
+}
+
+type repoSpec struct {
+	label string
+	path  string
+	rel   string // relative directory under the repo root to scan
+}
+
+func main() {
+	mesheryRepo := flag.String("meshery-repo", "../meshery",
+		"Path to the meshery/meshery repository root")
+	cloudRepo := flag.String("cloud-repo", "../meshery-cloud",
+		"Path to the layer5io/meshery-cloud repository root")
+	mesheryRel := flag.String("meshery-models-dir", "server/models",
+		"Relative directory under meshery-repo to scan for Go struct models")
+	cloudRel := flag.String("cloud-models-dir", "server/models",
+		"Relative directory under cloud-repo to scan for Go struct models")
+	output := flag.String("o", "validation/baseline/tag-divergence.json",
+		"Output path for the JSON report (relative to repo root)")
+	withRecords := flag.Bool("records", false,
+		"Include the full per-field record list in the report (useful for local verification; omitted from the committed artifact by default)")
+	verbose := flag.Bool("v", false, "Print per-file progress to stderr")
+	flag.Parse()
+
+	rootDir, err := findRepoRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: could not find schemas repository root: %v\n", err)
+		os.Exit(1)
+	}
+
+	repos := []repoSpec{
+		{label: "meshery/meshery", path: *mesheryRepo, rel: *mesheryRel},
+		{label: "layer5io/meshery-cloud", path: *cloudRepo, rel: *cloudRel},
+	}
+
+	report := baselineReport{
+		GeneratedAt: time.Now().UTC().Truncate(time.Second),
+		GeneratedBy: "cmd/phase0-tag-divergence",
+		Scope:       "Go struct fields with json:/db: tags under each repo's server/models directory",
+	}
+	for _, r := range repos {
+		report.Repos = append(report.Repos, r.label)
+	}
+
+	var allRecords []fieldRecord
+	for _, r := range repos {
+		abs, err := resolveAbsolutePath(rootDir, r.path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warn: repo %q (%s): %v — skipping\n", r.label, r.path, err)
+			continue
+		}
+		modelsDir := filepath.Join(abs, filepath.FromSlash(r.rel))
+		if info, err := os.Stat(modelsDir); err != nil || !info.IsDir() {
+			fmt.Fprintf(os.Stderr, "warn: %s: %s is not a directory — skipping\n", r.label, modelsDir)
+			continue
+		}
+		recs, fileCount, structCount, err := scanRepo(r.label, abs, r.rel, *verbose)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warn: %s: %v\n", r.label, err)
+			continue
+		}
+		report.FilesProcessed += fileCount
+		report.Summary.TotalStructs += structCount
+		allRecords = append(allRecords, recs...)
+	}
+
+	sort.SliceStable(allRecords, func(i, j int) bool {
+		a, b := allRecords[i], allRecords[j]
+		if a.Repo != b.Repo {
+			return a.Repo < b.Repo
+		}
+		if a.File != b.File {
+			return a.File < b.File
+		}
+		if a.Type != b.Type {
+			return a.Type < b.Type
+		}
+		return a.Line < b.Line
+	})
+
+	report.Summary = aggregateSummary(report.Summary, allRecords)
+	report.Records = allRecords
+	if !*withRecords {
+		report.Records = nil
+	}
+
+	outPath := filepath.Join(rootDir, filepath.FromSlash(*output))
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "error: creating output dir: %v\n", err)
+		os.Exit(1)
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: marshaling report: %v\n", err)
+		os.Exit(1)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(outPath, data, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "error: writing %s: %v\n", outPath, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("phase0-tag-divergence: %d files, %d structs, %d tagged fields -> %s\n",
+		report.FilesProcessed, report.Summary.TotalStructs, report.Summary.TotalFieldsWithTag,
+		relPath(rootDir, outPath))
+	fmt.Printf("  form-mismatch=%d  value-mismatch=%d  screaming-json=%d  mixed-structs=%d  json-dash=%d\n",
+		report.Summary.FormMismatch, report.Summary.ValueMismatch,
+		report.Summary.ScreamingJSON, report.Summary.MixedStructs, report.Summary.JSONDash)
+}
+
+// scanRepo parses every non-test .go file under `<repoAbs>/<rel>` and returns
+// the field records plus count of files + structs scanned.
+func scanRepo(label, repoAbs, rel string, verbose bool) (records []fieldRecord, fileCount, structCount int, err error) {
+	root := filepath.Join(repoAbs, filepath.FromSlash(rel))
+
+	walkErr := filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		name := d.Name()
+		if !strings.HasSuffix(name, ".go") {
+			return nil
+		}
+		if strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+
+		frecs, structs, ferr := scanFile(label, repoAbs, p)
+		if ferr != nil {
+			if verbose {
+				fmt.Fprintf(os.Stderr, "  %s: %s: %v\n", label, p, ferr)
+			}
+			return nil // non-fatal: treat malformed files as no-data
+		}
+		if verbose {
+			fmt.Fprintf(os.Stderr, "%s: %s: %d structs, %d tagged fields\n", label, relFrom(repoAbs, p), structs, len(frecs))
+		}
+		fileCount++
+		structCount += structs
+		records = append(records, frecs...)
+		return nil
+	})
+	return records, fileCount, structCount, walkErr
+}
+
+// scanFile parses one Go source file and returns records for every struct
+// field that carries a `json` or `db` tag.
+func scanFile(label, repoAbs, absPath string) ([]fieldRecord, int, error) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, absPath, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, 0, err
+	}
+	rel := relFrom(repoAbs, absPath)
+
+	var records []fieldRecord
+	var structs int
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		ts, ok := n.(*ast.TypeSpec)
+		if !ok {
+			return true
+		}
+		st, ok := ts.Type.(*ast.StructType)
+		if !ok {
+			return true
+		}
+		structs++
+
+		typeName := ts.Name.Name
+		var structRecords []fieldRecord
+		for _, field := range st.Fields.List {
+			if field.Tag == nil {
+				continue
+			}
+			// Struct tag literal includes surrounding backticks; trim them.
+			rawTag := strings.Trim(field.Tag.Value, "`")
+			st := reflect.StructTag(rawTag)
+			jsonRaw, jsonOk := st.Lookup("json")
+			dbRaw, dbOk := st.Lookup("db")
+			if !jsonOk && !dbOk {
+				continue
+			}
+
+			jsonName := tagName(jsonRaw)
+			dbName := tagName(dbRaw)
+
+			pos := fset.Position(field.Pos())
+			fieldName := namedField(field)
+			if fieldName == "" {
+				// Embedded / unnamed fields are not the target of Option B's
+				// identifier-naming rules.
+				continue
+			}
+
+			rec := fieldRecord{
+				Repo:          label,
+				File:          rel,
+				Line:          pos.Line,
+				Type:          typeName,
+				Field:         fieldName,
+				JSONTag:       jsonRaw,
+				JSONTagCasing: classify(jsonName),
+				DBTag:         dbRaw,
+				DBTagCasing:   classify(dbName),
+			}
+			rec.Classifications = classifyField(jsonName, dbName)
+			structRecords = append(structRecords, rec)
+		}
+
+		// Second pass within this struct: mixed conventions are flagged when
+		// the struct carries fields from two genuinely different casing
+		// groups. lowercase single-word tags (`name`, `metadata`) count as
+		// the camelCase default for that word and do not conflict with
+		// camelCase; similar for explicitly classifying ambiguous boundaries.
+		groups := map[string]struct{}{}
+		for _, r := range structRecords {
+			g := casingGroup(r.JSONTagCasing)
+			if g == "" {
+				continue
+			}
+			groups[g] = struct{}{}
+		}
+		if len(groups) > 1 {
+			for i := range structRecords {
+				structRecords[i].Classifications = appendClassification(structRecords[i].Classifications, classMixedStruct)
+			}
+		}
+
+		records = append(records, structRecords...)
+		return true
+	})
+
+	return records, structs, nil
+}
+
+// namedField returns the first declared field name, or "" if the field is
+// embedded / unnamed.
+func namedField(f *ast.Field) string {
+	if len(f.Names) == 0 {
+		return ""
+	}
+	return f.Names[0].Name
+}
+
+// tagName extracts the first segment of a struct-tag value (`name,omitempty`
+// -> `name`). Returns "" on an empty tag.
+func tagName(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	if idx := strings.Index(raw, ","); idx >= 0 {
+		return raw[:idx]
+	}
+	return raw
+}
+
+// classify names the casing form of a tag token. See Agent 0.B's charter and
+// the Option B contract for the discriminators.
+func classify(s string) casingForm {
+	if s == "" {
+		return casingEmpty
+	}
+	if s == "-" {
+		return casingEmpty // json:"-" / db:"-" is not a name form
+	}
+	hasUnderscore := strings.Contains(s, "_")
+	hasUpper := strings.IndexFunc(s, func(r rune) bool { return r >= 'A' && r <= 'Z' }) >= 0
+	hasLower := strings.IndexFunc(s, func(r rune) bool { return r >= 'a' && r <= 'z' }) >= 0
+	first := rune(s[0])
+	switch {
+	case hasUnderscore && !hasUpper:
+		return casingSnake
+	case hasUnderscore && hasUpper:
+		return casingMixed
+	case !hasLower && hasUpper:
+		return casingScreaming
+	case first >= 'A' && first <= 'Z' && hasLower:
+		return casingPascal
+	case first >= 'a' && first <= 'z' && hasUpper:
+		return casingCamel
+	case first >= 'a' && first <= 'z' && !hasUpper:
+		return casingLower
+	default:
+		return casingMixed
+	}
+}
+
+// casingGroup collapses the casing taxonomy into four buckets used for the
+// per-struct mixed-convention check: camel-family (camelCase and
+// single-word lowercase share the same wire contract), snake, Pascal,
+// screaming. Empty inputs return "" to exclude them from the group set.
+func casingGroup(c casingForm) string {
+	switch c {
+	case casingCamel, casingLower:
+		return "camel"
+	case casingSnake:
+		return "snake"
+	case casingPascal:
+		return "pascal"
+	case casingScreaming:
+		return "screaming"
+	case casingMixed:
+		return "mixed"
+	default:
+		return ""
+	}
+}
+
+// hasScreamingToken detects an ALL-CAPS acronym token of 2+ letters in a
+// camelCase or PascalCase name (e.g., `userID`, `OrgID`, `ContentURL`).
+func hasScreamingToken(s string) bool {
+	run := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'A' && c <= 'Z' {
+			run++
+			if run >= 2 {
+				return true
+			}
+			continue
+		}
+		if c == '_' {
+			run = 0
+			continue
+		}
+		run = 0
+	}
+	return false
+}
+
+// classifyField applies Agent 0.B criteria (i), (iii), and json:"-" tracking.
+// Mixed-convention (criterion ii) is handled at the struct level by the
+// caller.
+func classifyField(jsonName, dbName string) []classification {
+	var out []classification
+	if jsonName == "-" {
+		out = append(out, classSuppressed)
+	}
+	if jsonName != "" && jsonName != "-" {
+		if jsonName == strings.ToUpper(jsonName) && strings.ContainsAny(jsonName, "ABCDEFGHIJKLMNOPQRSTUVWXYZ") {
+			out = append(out, classScreamingJSON)
+		} else if hasScreamingToken(jsonName) {
+			out = append(out, classScreamingJSON)
+		}
+	}
+	if jsonName != "" && dbName != "" && jsonName != "-" && dbName != "-" {
+		jc := classify(jsonName)
+		dc := classify(dbName)
+		if jc != dc {
+			out = append(out, classJSONDBFormMismatch)
+		}
+		if normalizeName(jsonName) != normalizeName(dbName) {
+			out = append(out, classJSONDBValueMismatch)
+		}
+	}
+	return out
+}
+
+// normalizeName lowercases an identifier and strips non-alphanumerics so
+// camelCase and snake_case variants of the same base name compare equal.
+// "userId" -> "userid", "user_id" -> "userid", "userID" -> "userid".
+func normalizeName(s string) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for _, r := range s {
+		if r == '_' || r == '-' || r == '.' {
+			continue
+		}
+		if r >= 'A' && r <= 'Z' {
+			r = r + ('a' - 'A')
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
+}
+
+func appendClassification(existing []classification, c classification) []classification {
+	for _, e := range existing {
+		if e == c {
+			return existing
+		}
+	}
+	return append(existing, c)
+}
+
+// aggregateSummary populates summary counters from the record list.
+func aggregateSummary(base summaryCounts, records []fieldRecord) summaryCounts {
+	s := base
+	s.JSONByCasing = map[casingForm]int{}
+	s.DBByCasing = map[casingForm]int{}
+
+	structsWithTags := map[string]bool{}
+	mixedStructs := map[string]bool{}
+	for _, r := range records {
+		s.TotalFieldsWithTag++
+		structsWithTags[r.Repo+"|"+r.File+"|"+r.Type] = true
+		if r.JSONTagCasing != casingEmpty {
+			s.JSONByCasing[r.JSONTagCasing]++
+		}
+		if r.DBTagCasing != casingEmpty {
+			s.DBByCasing[r.DBTagCasing]++
+		}
+		for _, c := range r.Classifications {
+			switch c {
+			case classJSONDBFormMismatch:
+				s.FormMismatch++
+			case classJSONDBValueMismatch:
+				s.ValueMismatch++
+			case classScreamingJSON:
+				s.ScreamingJSON++
+			case classMixedStruct:
+				mixedStructs[r.Repo+"|"+r.File+"|"+r.Type] = true
+			case classSuppressed:
+				s.JSONDash++
+			}
+		}
+	}
+	s.StructsWithTags = len(structsWithTags)
+	s.MixedStructs = len(mixedStructs)
+	return s
+}
+
+// findRepoRoot walks up from cwd looking for go.mod.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found in any parent directory")
+		}
+		dir = parent
+	}
+}
+
+// resolveAbsolutePath resolves a possibly-relative repo path against the
+// schemas rootDir so that `--meshery-repo=../meshery` works regardless of
+// the caller's cwd.
+func resolveAbsolutePath(rootDir, p string) (string, error) {
+	if filepath.IsAbs(p) {
+		return p, nil
+	}
+	abs := filepath.Join(rootDir, p)
+	return filepath.Clean(abs), nil
+}
+
+func relFrom(base, p string) string {
+	rel, err := filepath.Rel(base, p)
+	if err != nil {
+		return p
+	}
+	return filepath.ToSlash(rel)
+}
+
+func relPath(rootDir, absPath string) string {
+	rel, err := filepath.Rel(rootDir, absPath)
+	if err != nil {
+		return absPath
+	}
+	return filepath.ToSlash(rel)
+}

--- a/cmd/phase0-tag-divergence/main.go
+++ b/cmd/phase0-tag-divergence/main.go
@@ -88,13 +88,14 @@ type summaryCounts struct {
 }
 
 type baselineReport struct {
-	GeneratedAt     time.Time      `json:"generated_at"`
-	GeneratedBy     string         `json:"generated_by"`
-	Scope           string         `json:"scope"`
-	Repos           []string       `json:"repos"`
-	FilesProcessed  int            `json:"files_processed"`
-	Summary         summaryCounts  `json:"summary"`
-	Records         []fieldRecord  `json:"records,omitempty"`
+	GeneratedAt    time.Time     `json:"generated_at"`
+	GeneratedBy    string        `json:"generated_by"`
+	Scope          string        `json:"scope"`
+	Repos          []string      `json:"repos"`
+	FilesProcessed int           `json:"files_processed"`
+	ParseErrors    []string      `json:"parse_errors,omitempty"`
+	Summary        summaryCounts `json:"summary"`
+	Records        []fieldRecord `json:"records,omitempty"`
 }
 
 type repoSpec struct {
@@ -140,6 +141,7 @@ func main() {
 	}
 
 	var allRecords []fieldRecord
+	var allParseErrors []string
 	for _, r := range repos {
 		abs, err := resolveAbsolutePath(rootDir, r.path)
 		if err != nil {
@@ -151,7 +153,7 @@ func main() {
 			fmt.Fprintf(os.Stderr, "warn: %s: %s is not a directory — skipping\n", r.label, modelsDir)
 			continue
 		}
-		recs, fileCount, structCount, err := scanRepo(r.label, abs, r.rel, *verbose)
+		recs, fileCount, structCount, parseErrors, err := scanRepo(r.label, abs, r.rel, *verbose)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warn: %s: %v\n", r.label, err)
 			continue
@@ -159,7 +161,9 @@ func main() {
 		report.FilesProcessed += fileCount
 		report.Summary.TotalStructs += structCount
 		allRecords = append(allRecords, recs...)
+		allParseErrors = append(allParseErrors, parseErrors...)
 	}
+	report.ParseErrors = allParseErrors
 
 	sort.SliceStable(allRecords, func(i, j int) bool {
 		a, b := allRecords[i], allRecords[j]
@@ -206,8 +210,11 @@ func main() {
 }
 
 // scanRepo parses every non-test .go file under `<repoAbs>/<rel>` and returns
-// the field records plus count of files + structs scanned.
-func scanRepo(label, repoAbs, rel string, verbose bool) (records []fieldRecord, fileCount, structCount int, err error) {
+// the field records plus counts of files + structs scanned and any parse
+// errors surfaced along the way. Parse errors do not abort the walk but are
+// returned so the caller can decide (e.g., fail the baseline build when
+// invoked from CI).
+func scanRepo(label, repoAbs, rel string, verbose bool) (records []fieldRecord, fileCount, structCount int, parseErrors []string, err error) {
 	root := filepath.Join(repoAbs, filepath.FromSlash(rel))
 
 	walkErr := filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
@@ -227,10 +234,13 @@ func scanRepo(label, repoAbs, rel string, verbose bool) (records []fieldRecord, 
 
 		frecs, structs, ferr := scanFile(label, repoAbs, p)
 		if ferr != nil {
-			if verbose {
-				fmt.Fprintf(os.Stderr, "  %s: %s: %v\n", label, p, ferr)
-			}
-			return nil // non-fatal: treat malformed files as no-data
+			// Parse errors make the baseline untrustworthy: report them on
+			// stderr unconditionally and record the path so the caller can
+			// decide whether to fail. We continue walking so one malformed
+			// file doesn't abort the full scan.
+			fmt.Fprintf(os.Stderr, "warn: %s: %s: parse error: %v\n", label, relFrom(repoAbs, p), ferr)
+			parseErrors = append(parseErrors, fmt.Sprintf("%s:%s", label, relFrom(repoAbs, p)))
+			return nil
 		}
 		if verbose {
 			fmt.Fprintf(os.Stderr, "%s: %s: %d structs, %d tagged fields\n", label, relFrom(repoAbs, p), structs, len(frecs))
@@ -240,7 +250,7 @@ func scanRepo(label, repoAbs, rel string, verbose bool) (records []fieldRecord, 
 		records = append(records, frecs...)
 		return nil
 	})
-	return records, fileCount, structCount, walkErr
+	return records, fileCount, structCount, parseErrors, walkErr
 }
 
 // scanFile parses one Go source file and returns records for every struct
@@ -285,27 +295,34 @@ func scanFile(label, repoAbs, absPath string) ([]fieldRecord, int, error) {
 			jsonName := tagName(jsonRaw)
 			dbName := tagName(dbRaw)
 
-			pos := fset.Position(field.Pos())
-			fieldName := namedField(field)
-			if fieldName == "" {
+			if len(field.Names) == 0 {
 				// Embedded / unnamed fields are not the target of Option B's
 				// identifier-naming rules.
 				continue
 			}
-
-			rec := fieldRecord{
-				Repo:          label,
-				File:          rel,
-				Line:          pos.Line,
-				Type:          typeName,
-				Field:         fieldName,
-				JSONTag:       jsonRaw,
-				JSONTagCasing: classify(jsonName),
-				DBTag:         dbRaw,
-				DBTagCasing:   classify(dbName),
+			// Multi-name declarations (`A, B string `tag...``) share one tag
+			// literal; emit a record per declared name so nothing is silently
+			// dropped. Each record's Line points at the specific name token,
+			// not the shared field position, so downstream readers can
+			// locate each identifier precisely.
+			for _, ident := range field.Names {
+				if ident == nil {
+					continue
+				}
+				rec := fieldRecord{
+					Repo:          label,
+					File:          rel,
+					Line:          fset.Position(ident.Pos()).Line,
+					Type:          typeName,
+					Field:         ident.Name,
+					JSONTag:       jsonRaw,
+					JSONTagCasing: classify(jsonName),
+					DBTag:         dbRaw,
+					DBTagCasing:   classify(dbName),
+				}
+				rec.Classifications = classifyField(jsonName, dbName)
+				structRecords = append(structRecords, rec)
 			}
-			rec.Classifications = classifyField(jsonName, dbName)
-			structRecords = append(structRecords, rec)
 		}
 
 		// Second pass within this struct: mixed conventions are flagged when
@@ -332,15 +349,6 @@ func scanFile(label, repoAbs, absPath string) ([]fieldRecord, int, error) {
 	})
 
 	return records, structs, nil
-}
-
-// namedField returns the first declared field name, or "" if the field is
-// embedded / unnamed.
-func namedField(f *ast.Field) string {
-	if len(f.Names) == 0 {
-		return ""
-	}
-	return f.Names[0].Name
 }
 
 // tagName extracts the first segment of a struct-tag value (`name,omitempty`
@@ -457,9 +465,15 @@ func classifyField(jsonName, dbName string) []classification {
 	return out
 }
 
-// normalizeName lowercases an identifier and strips non-alphanumerics so
-// camelCase and snake_case variants of the same base name compare equal.
-// "userId" -> "userid", "user_id" -> "userid", "userID" -> "userid".
+// normalizeName lowercases an identifier and drops the separator runes
+// `_`, `-`, and `.` so camelCase and snake_case variants of the same base
+// name compare equal. Non-ASCII and digit characters are preserved verbatim
+// (only uppercase ASCII is lowercased). Examples:
+//
+//	"userId"  -> "userid"
+//	"user_id" -> "userid"
+//	"userID"  -> "userid"
+//	"plan-v2" -> "planv2"
 func normalizeName(s string) string {
 	var b strings.Builder
 	b.Grow(len(s))

--- a/cmd/phase0-tag-divergence/main_test.go
+++ b/cmd/phase0-tag-divergence/main_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func TestClassify(t *testing.T) {
+	cases := []struct {
+		in   string
+		want casingForm
+	}{
+		{"", casingEmpty},
+		{"-", casingEmpty},
+		{"id", casingLower},
+		{"userId", casingCamel},
+		{"user_id", casingSnake},
+		{"UserID", casingPascal},
+		{"ID", casingScreaming},
+		{"URL", casingScreaming},
+		{"ORG_ID", casingMixed}, // SCREAMING_SNAKE
+		{"user_Id", casingMixed},
+	}
+	for _, tc := range cases {
+		got := classify(tc.in)
+		if got != tc.want {
+			t.Errorf("classify(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestTagName(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"", ""},
+		{"name", "name"},
+		{"name,omitempty", "name"},
+		{"-", "-"},
+		{",omitempty", ""},
+	}
+	for _, tc := range cases {
+		if got := tagName(tc.in); got != tc.want {
+			t.Errorf("tagName(%q) = %q; want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestNormalizeName(t *testing.T) {
+	if normalizeName("userId") != "userid" {
+		t.Errorf("userId should normalize to userid")
+	}
+	if normalizeName("user_id") != "userid" {
+		t.Errorf("user_id should normalize to userid")
+	}
+	if normalizeName("USER_ID") != "userid" {
+		t.Errorf("USER_ID should normalize to userid")
+	}
+	if normalizeName("user-id.2") != "userid2" {
+		t.Errorf("user-id.2 should normalize to userid2, got %q", normalizeName("user-id.2"))
+	}
+}
+
+func TestHasScreamingToken(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"id", false},
+		{"name", false},
+		{"userId", false}, // one isolated capital → not a screaming token
+		{"userID", true},  // ID = 2 consecutive caps
+		{"ContentURL", true},
+		{"HPAReplicas", true},
+		{"isMesheryUIRestricted", true},
+		{"patternFile", false},
+	}
+	for _, tc := range cases {
+		if got := hasScreamingToken(tc.in); got != tc.want {
+			t.Errorf("hasScreamingToken(%q) = %v; want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestClassifyFieldMismatches(t *testing.T) {
+	cases := []struct {
+		name     string
+		json, db string
+		want     []classification
+	}{
+		{"perfectly consistent camel+snake (Option B canonical)", "userId", "user_id",
+			[]classification{classJSONDBFormMismatch}}, // form differs (camel vs snake)
+		{"snake+snake (legacy)", "user_id", "user_id", nil},
+		{"value-name divergence", "type", "source_type",
+			[]classification{classJSONDBFormMismatch, classJSONDBValueMismatch}},
+		{"screaming json alone", "URL", "",
+			[]classification{classScreamingJSON}},
+		{"camel with acronym suffix", "roleID", "",
+			[]classification{classScreamingJSON}},
+		{"json dash", "-", "user_id",
+			[]classification{classSuppressed}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyField(tc.json, tc.db)
+			sortedEq := func(a, b []classification) bool {
+				if len(a) != len(b) {
+					return false
+				}
+				as := make([]string, len(a))
+				bs := make([]string, len(b))
+				for i := range a {
+					as[i] = string(a[i])
+				}
+				for i := range b {
+					bs[i] = string(b[i])
+				}
+				sort.Strings(as)
+				sort.Strings(bs)
+				for i := range as {
+					if as[i] != bs[i] {
+						return false
+					}
+				}
+				return true
+			}
+			if !sortedEq(got, tc.want) {
+				t.Errorf("got %v; want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCasingGroup(t *testing.T) {
+	if casingGroup(casingCamel) != casingGroup(casingLower) {
+		t.Errorf("camelCase and lowercase should share a group (camel family)")
+	}
+	if casingGroup(casingSnake) == casingGroup(casingCamel) {
+		t.Errorf("snake and camel should be different groups")
+	}
+	if casingGroup(casingEmpty) != "" {
+		t.Errorf("empty casing should have empty group")
+	}
+}
+
+func TestScanFileCoversAuditFindings(t *testing.T) {
+	dir := t.TempDir()
+	src := `package models
+
+type MesheryPattern struct {
+	ID          string ` + "`json:\"id,omitempty\" db:\"id\"`" + `
+	UserID      string ` + "`json:\"user_id\"`" + `
+	WorkspaceID string ` + "`json:\"workspace_id,omitempty\" db:\"-\"`" + `
+	OrgID       string ` + "`json:\"orgId,omitempty\" db:\"-\"`" + `
+	PatternFile string ` + "`json:\"patternFile\" db:\"pattern_file\"`" + `
+}
+
+type Mapping struct {
+	ID string ` + "`json:\"ID,omitempty\" db:\"id\"`" + `
+}
+`
+	path := filepath.Join(dir, "sample.go")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	records, structs, err := scanFile("test/repo", dir, path)
+	if err != nil {
+		t.Fatalf("scanFile: %v", err)
+	}
+	if structs != 2 {
+		t.Errorf("got %d structs, want 2", structs)
+	}
+	byField := map[string]fieldRecord{}
+	for _, r := range records {
+		byField[r.Field] = r
+	}
+
+	orgID, ok := byField["OrgID"]
+	if !ok {
+		t.Fatal("missing OrgID record")
+	}
+	hasClass := func(list []classification, c classification) bool {
+		for _, x := range list {
+			if x == c {
+				return true
+			}
+		}
+		return false
+	}
+	if !hasClass(orgID.Classifications, classMixedStruct) {
+		t.Errorf("OrgID should be flagged mixed_struct_conventions; got %v", orgID.Classifications)
+	}
+
+	patternFile := byField["PatternFile"]
+	if !hasClass(patternFile.Classifications, classJSONDBFormMismatch) {
+		t.Errorf("PatternFile should be flagged json_db_form_mismatch; got %v", patternFile.Classifications)
+	}
+
+	mappingID := byField["ID"]
+	// Mapping.ID has json=ID (screaming) — should be flagged.
+	if !hasClass(mappingID.Classifications, classScreamingJSON) {
+		t.Errorf("Mapping.ID (json=ID) should be flagged screaming_json; got %v", mappingID.Classifications)
+	}
+	// Mapping struct has only one tagged field, so no mixed_struct flag.
+	if hasClass(mappingID.Classifications, classMixedStruct) {
+		t.Errorf("single-field Mapping struct should not carry mixed_struct_conventions")
+	}
+}

--- a/cmd/phase0-tag-divergence/main_test.go
+++ b/cmd/phase0-tag-divergence/main_test.go
@@ -206,3 +206,46 @@ type Mapping struct {
 		t.Errorf("single-field Mapping struct should not carry mixed_struct_conventions")
 	}
 }
+
+// TestScanFileMultiNameFieldDeclaration covers the multi-name field form
+// `A, B string` + shared tag, which is easily undercounted if only the
+// first identifier is recorded.
+func TestScanFileMultiNameFieldDeclaration(t *testing.T) {
+	dir := t.TempDir()
+	src := `package models
+
+type Multi struct {
+	First, Second string ` + "`json:\"shared,omitempty\" db:\"shared\"`" + `
+	Solo          int    ` + "`json:\"solo\"`" + `
+}
+`
+	path := filepath.Join(dir, "multi.go")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	records, _, err := scanFile("test/repo", dir, path)
+	if err != nil {
+		t.Fatalf("scanFile: %v", err)
+	}
+	byField := map[string]fieldRecord{}
+	for _, r := range records {
+		byField[r.Field] = r
+	}
+	if _, ok := byField["First"]; !ok {
+		t.Error("missing First from multi-name declaration")
+	}
+	if _, ok := byField["Second"]; !ok {
+		t.Error("missing Second from multi-name declaration — baseline would be undercounted")
+	}
+	if byField["First"].JSONTag != "shared,omitempty" || byField["Second"].JSONTag != "shared,omitempty" {
+		t.Errorf("First/Second should share the tag literal: %q %q", byField["First"].JSONTag, byField["Second"].JSONTag)
+	}
+	// Each record should point at the identifier's own source token, not the
+	// shared field position.
+	if byField["First"].Line != byField["Second"].Line {
+		// On a single-line declaration they share a line; make sure it's the
+		// line of the declaration itself. This check exists mostly to assert
+		// we didn't accidentally drop one of them.
+		t.Logf("First line=%d Second line=%d (both on the same line is fine for a single-line decl)", byField["First"].Line, byField["Second"].Line)
+	}
+}

--- a/validation/baseline/tag-divergence.json
+++ b/validation/baseline/tag-divergence.json
@@ -1,0 +1,31 @@
+{
+  "generated_at": "2026-04-22T22:58:18Z",
+  "generated_by": "cmd/phase0-tag-divergence",
+  "scope": "Go struct fields with json:/db: tags under each repo's server/models directory",
+  "repos": [
+    "meshery/meshery",
+    "layer5io/meshery-cloud"
+  ],
+  "files_processed": 172,
+  "summary": {
+    "total_structs_scanned": 468,
+    "structs_with_any_tag": 372,
+    "total_fields_with_any_tag": 1706,
+    "json_db_form_mismatch": 33,
+    "json_db_value_mismatch": 5,
+    "screaming_json": 22,
+    "mixed_struct_conventions_structs": 172,
+    "json_dash": 4,
+    "json_tags_by_casing": {
+      "PascalCase": 6,
+      "SCREAMING": 10,
+      "camelCase": 213,
+      "lowercase": 863,
+      "snake_case": 609
+    },
+    "db_tags_by_casing": {
+      "lowercase": 177,
+      "snake_case": 260
+    }
+  }
+}

--- a/validation/baseline/tag-divergence.json
+++ b/validation/baseline/tag-divergence.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-22T22:58:18Z",
+  "generated_at": "2026-04-22T23:06:13Z",
   "generated_by": "cmd/phase0-tag-divergence",
   "scope": "Go struct fields with json:/db: tags under each repo's server/models directory",
   "repos": [


### PR DESCRIPTION
## Summary
- Implements Phase 0 Agent 0.B of the [Option B identifier-naming migration](../blob/master/docs/identifier-naming-option-b-migration.md). Scans Go struct tags across `meshery/meshery/server/models/` and `layer5io/meshery-cloud/server/models/` and produces a committed JSON baseline of json/db divergences, mixed-convention structs, and SCREAMING json tags.
- Adds `cmd/phase0-tag-divergence` (Go, uses `go/parser` + `reflect.StructTag`) and `make baseline-tag-divergence` target with MESHERY_REPO / CLOUD_REPO overrides.
- Commits summary-only artifact at `validation/baseline/tag-divergence.json` (799 bytes; per-record list omitted by default, regeneratable with `--records`).

## Why
Phase 0 baselines drive Phase 1 rule authoring and Phase 3 per-resource sequencing. Agent 0.A captured schema-side JSON tags; Agent 0.B captures the downstream Go struct side so the pre-migration drift surface is fully quantified. Closes the 0.B checklist item on meshery/schemas#776.

## Changes
- `cmd/phase0-tag-divergence/main.go` — AST walker + field classifier + per-struct mixed-convention detector.
- `cmd/phase0-tag-divergence/main_test.go` — unit tests (classify, tagName, normalizeName, hasScreamingToken, classifyField, casingGroup, scanFile).
- `Makefile` — `baseline-tag-divergence` target.
- `validation/baseline/tag-divergence.json` — committed artifact.

## Tests
- [x] Unit tests added: `go test ./cmd/phase0-tag-divergence/` — PASS
- [x] Local build clean: `go build ./...` — PASS
- [x] Local test suite clean: `go test ./...` — PASS
- [x] Schema validator clean: `make validate-schemas` — PASS

## Docs
- Tool documented by top-of-file Go doc in `cmd/phase0-tag-divergence/main.go`.
- `make baseline-tag-divergence` added to top-level help (`## Regenerate the Option B Phase 0 tag-divergence baseline artifact`).
- No AGENTS.md changes (Phase 1.A is the first governance doc amendment).

## Spot-check (audit findings)
| Audit finding | Where | Flagged in baseline |
|---|---|---|
| 9 mapping-model `json:"ID"` (cloud) | `model_*_mapping.go` | screaming_json on each ✓ |
| `KeychainFilter.RoleID json:"roleID"` (cloud) | `model_keychain_filter.go:10` | screaming_json ✓ |
| `MesheryPattern` mixes conventions (meshery) | `meshery_pattern.go:93,109,110` | mixed_struct_conventions ✓ |
| `MesheryPattern` in cloud too | `meshery_patterns.go:38..62` | mixed_struct_conventions ✓ |
| `CatalogRequest.ContentID` diverges between repos | both `users.go:246` / `meshery_catalog.go:11` | form_mismatch on cloud side ✓ |
| `K8sContext.{MesheryInstanceID,KubernetesServerID}` | both repos' `k8s_context.go` | mixed_struct_conventions ✓ |

## Current-state numbers
```
172 files, 468 structs, 1706 tagged fields
form-mismatch=33  value-mismatch=5  screaming-json=22  mixed-structs=172  json-dash=4
json casings: camel=213  snake=609  Pascal=6  SCREAMING=10  lowercase=863
db casings:   snake=260  lowercase=177
```

## Migration impact
- Breaking: no.
- API-version bump required: no.
- Consumer repos that must be updated: none (new read-only tool + artifact).

## Rollback
Revert the commit; tool and artifact disappear; no downstream dependency.