### PR TITLE
chore(baseline): add Phase 0 Agent 0.D consumer-dependency graph

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,6 +146,15 @@ baseline-consumer-audit:
 		exit $$status; \
 	fi
 
+## Regenerate the Option B Phase 0 consumer-dependency graph
+## (Go + TS imports of schemas across all three downstream repos)
+.PHONY: baseline-consumer-graph
+baseline-consumer-graph:
+	@go run ./cmd/phase0-consumer-graph \
+		$(if $(MESHERY_REPO),--meshery-repo="$(MESHERY_REPO)") \
+		$(if $(CLOUD_REPO),--cloud-repo="$(CLOUD_REPO)") \
+		$(if $(EXTENSIONS_REPO),--extensions-repo="$(EXTENSIONS_REPO)")
+
 #-----------------------------------------------------------------------------
 # Consumer audit (schemas vs. consumer repos)
 #-----------------------------------------------------------------------------

--- a/cmd/phase0-consumer-graph/main.go
+++ b/cmd/phase0-consumer-graph/main.go
@@ -1,0 +1,411 @@
+// Command phase0-consumer-graph builds a per-resource consumer-dependency
+// graph across the downstream repos and produces the Phase 0 Agent 0.D
+// baseline (validation/baseline/consumer-graph.json) used by Phase 3 per-
+// resource sequencing in the Option B identifier-naming migration
+// (docs/identifier-naming-option-b-migration.md §6, §9).
+//
+// Two kinds of imports are attributed:
+//
+//  1. Go imports of github.com/meshery/schemas/models/<version>/<resource>
+//     are parsed precisely from each .go file's ImportSpec list, yielding
+//     per-file, per-resource attribution.
+//  2. TypeScript imports of @meshery/schemas/... are detected by regex.
+//     Most TS consumers pull in the bundled `mesheryApi` or `cloudApi`
+//     client and therefore transitively consume every resource at once;
+//     those files are attributed to the coarse "bundled-client-consumer"
+//     bucket rather than to a specific resource, because attributing them
+//     to all 22 resources individually would bias the complexity score
+//     without adding Phase-3 signal.
+//
+// The complexity score is documented: score = len(consuming_files) for the
+// single-resource precision bucket, plus a separate `bundled_ts_consumers`
+// count so Phase 3 sequencing can decide whether to factor TS depth in.
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"time"
+)
+
+// resourceNode is the per-resource row in the graph.
+type resourceNode struct {
+	Resource        string   `json:"resource"`
+	Versions        []string `json:"versions"`
+	ConsumingFiles  []string `json:"consuming_files"`
+	ComplexityScore int      `json:"complexity_score"`
+}
+
+// repoImports holds everything a single repo contributed.
+type repoImports struct {
+	Repo               string   `json:"repo"`
+	Path               string   `json:"path"`
+	GoFilesProcessed   int      `json:"go_files_processed"`
+	TSFilesProcessed   int      `json:"ts_files_processed"`
+	BundledTSConsumers []string `json:"bundled_ts_consumers"`
+}
+
+type graphReport struct {
+	GeneratedAt          time.Time         `json:"generated_at"`
+	GeneratedBy          string            `json:"generated_by"`
+	Scope                string            `json:"scope"`
+	ComplexityHeuristic  string            `json:"complexity_heuristic"`
+	ResourceAliases      map[string]string `json:"resource_aliases"`
+	Repos                []repoImports     `json:"repos"`
+	Resources            []resourceNode    `json:"resources"`
+	MissingFromInventory []string          `json:"missing_from_inventory,omitempty"`
+	BundledTSTotal       int               `json:"bundled_ts_total"`
+}
+
+// resourceAliases documents non-obvious Go-package ↔ schema-construct
+// renames so a Phase 3 orchestrator reading this graph can merge entries
+// that travel together through the migration. Extend as more aliases
+// surface.
+var resourceAliases = map[string]string{
+	"pattern": "design", // v1beta1/pattern is the v1beta1 Go package for the v1beta1 "design" schema; v1beta2 renamed it to design
+}
+
+// inventory22 enumerates the 22 resources named in master plan §9.1. The
+// baseline reports on every resource it finds in the schemas tree, but
+// having this list lets us verify no inventory item was silently skipped
+// (acceptance criterion: "Graph covers all 22 resources").
+var inventory22 = []string{
+	"workspace", "environment", "organization", "user",
+	"design", "connection", "team", "role",
+	"credential", "event", "view", "key",
+	"keychain", "invitation", "plan", "subscription",
+	"token", "badge", "schedule", "model",
+	"component", "relationship",
+}
+
+// repoSpec identifies a sibling repo and where to start scanning.
+type repoSpec struct {
+	label string
+	path  string
+	// scanDirs are repo-relative directories to walk. An empty list scans
+	// the whole repo.
+	goDirs []string
+	tsDirs []string
+}
+
+// goImportPath isolates `github.com/meshery/schemas/models/<version>/<resource>`.
+var goImportPath = regexp.MustCompile(`^github\.com/meshery/schemas/models/(v[0-9a-zA-Z]+)(?:/([a-zA-Z0-9_-]+))?$`)
+
+// tsImportLine matches `from "@meshery/schemas[/path]"` and `from '@meshery/schemas[/path]'`.
+var tsImportLine = regexp.MustCompile(`from\s+['"]@meshery/schemas(?:/[^'"\s]+)?['"]`)
+
+func main() {
+	mesheryRepo := flag.String("meshery-repo", "../meshery", "Path to the meshery/meshery repository root")
+	cloudRepo := flag.String("cloud-repo", "../meshery-cloud", "Path to the layer5io/meshery-cloud repository root")
+	extensionsRepo := flag.String("extensions-repo", "../meshery-extensions", "Path to the layer5labs/meshery-extensions repository root")
+	output := flag.String("o", "validation/baseline/consumer-graph.json", "Output path for the JSON report (relative to repo root)")
+	verbose := flag.Bool("v", false, "Print per-file progress to stderr")
+	flag.Parse()
+
+	rootDir, err := findRepoRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: could not find repository root: %v\n", err)
+		os.Exit(1)
+	}
+
+	repos := []repoSpec{
+		{label: "meshery/meshery", path: *mesheryRepo,
+			goDirs: []string{"server", "mesheryctl"},
+			tsDirs: []string{"ui"}},
+		{label: "layer5io/meshery-cloud", path: *cloudRepo,
+			goDirs: []string{"server"},
+			tsDirs: []string{"ui"}},
+		{label: "layer5labs/meshery-extensions", path: *extensionsRepo,
+			goDirs: []string{"meshmap/graphql"},
+			tsDirs: []string{"meshmap/src"}},
+	}
+
+	// resource -> set of consuming files (repo|path) -> version set.
+	type consumeRec struct {
+		file     string
+		versions map[string]struct{}
+	}
+	byResource := map[string]map[string]*consumeRec{}
+	addConsumer := func(resource, repoLabel, file, version string) {
+		if resource == "" {
+			return
+		}
+		if byResource[resource] == nil {
+			byResource[resource] = map[string]*consumeRec{}
+		}
+		key := repoLabel + "|" + file
+		rec, ok := byResource[resource][key]
+		if !ok {
+			rec = &consumeRec{file: key, versions: map[string]struct{}{}}
+			byResource[resource][key] = rec
+		}
+		if version != "" {
+			rec.versions[version] = struct{}{}
+		}
+	}
+
+	report := graphReport{
+		GeneratedAt:         time.Now().UTC().Truncate(time.Second),
+		GeneratedBy:         "cmd/phase0-consumer-graph",
+		Scope:               "Imports of github.com/meshery/schemas/models/... (Go) and @meshery/schemas (TS) across sibling repos",
+		ComplexityHeuristic: "complexity_score = count of distinct consuming files that import that resource's Go package. TS imports are tallied separately (bundled_ts_consumers) because most TS consumers pull in the full bundled client rather than a single resource.",
+		ResourceAliases:     resourceAliases,
+	}
+
+	for _, r := range repos {
+		abs, err := resolveAbsolutePath(rootDir, r.path)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warn: %s: %v — skipping\n", r.label, err)
+			continue
+		}
+		if info, err := os.Stat(abs); err != nil || !info.IsDir() {
+			fmt.Fprintf(os.Stderr, "warn: %s: %s is not a directory — skipping\n", r.label, abs)
+			continue
+		}
+
+		repoSummary := repoImports{Repo: r.label, Path: r.path}
+		for _, dir := range r.goDirs {
+			goFiles, err := scanGoImports(abs, dir, func(file, importPath string) {
+				m := goImportPath.FindStringSubmatch(importPath)
+				if m == nil {
+					return
+				}
+				version := m[1]
+				resource := m[2]
+				if resource == "" {
+					// An import of `.../models/v1beta1` without a sub-package
+					// means the caller references the version root (typically
+					// for cross-resource utilities). Record under a synthetic
+					// "<version>.meta" bucket so it isn't silently dropped.
+					resource = version + ".meta"
+				}
+				if *verbose {
+					fmt.Fprintf(os.Stderr, "%s: %s -> %s (%s)\n", r.label, file, resource, version)
+				}
+				addConsumer(resource, r.label, file, version)
+			})
+			if err != nil && *verbose {
+				fmt.Fprintf(os.Stderr, "warn: %s: %s: %v\n", r.label, dir, err)
+			}
+			repoSummary.GoFilesProcessed += goFiles
+		}
+		for _, dir := range r.tsDirs {
+			tsFiles, bundled, err := scanTSImports(abs, dir)
+			if err != nil && *verbose {
+				fmt.Fprintf(os.Stderr, "warn: %s: %s: %v\n", r.label, dir, err)
+			}
+			repoSummary.TSFilesProcessed += tsFiles
+			for _, b := range bundled {
+				repoSummary.BundledTSConsumers = append(repoSummary.BundledTSConsumers, b)
+			}
+		}
+		sort.Strings(repoSummary.BundledTSConsumers)
+		report.Repos = append(report.Repos, repoSummary)
+		report.BundledTSTotal += len(repoSummary.BundledTSConsumers)
+	}
+
+	// Project per-resource graph nodes.
+	for resource, consumers := range byResource {
+		node := resourceNode{Resource: resource}
+		versionSet := map[string]struct{}{}
+		for _, rec := range consumers {
+			node.ConsumingFiles = append(node.ConsumingFiles, rec.file)
+			for v := range rec.versions {
+				versionSet[v] = struct{}{}
+			}
+		}
+		sort.Strings(node.ConsumingFiles)
+		for v := range versionSet {
+			node.Versions = append(node.Versions, v)
+		}
+		sort.Strings(node.Versions)
+		node.ComplexityScore = len(node.ConsumingFiles)
+		report.Resources = append(report.Resources, node)
+	}
+	sort.Slice(report.Resources, func(i, j int) bool {
+		if report.Resources[i].ComplexityScore != report.Resources[j].ComplexityScore {
+			return report.Resources[i].ComplexityScore < report.Resources[j].ComplexityScore
+		}
+		return report.Resources[i].Resource < report.Resources[j].Resource
+	})
+
+	// Acceptance check: which §9.1 inventory entries did we not observe?
+	// An inventory name is considered "observed" when either its own Go
+	// package shows up OR one of its aliases does (e.g., the v1beta1 Go
+	// package "pattern" observes the inventory entry "design").
+	haveResource := map[string]bool{}
+	for _, n := range report.Resources {
+		haveResource[n.Resource] = true
+	}
+	for _, r := range inventory22 {
+		observed := haveResource[r]
+		if !observed {
+			for alias, target := range resourceAliases {
+				if target == r && haveResource[alias] {
+					observed = true
+					break
+				}
+			}
+		}
+		if !observed {
+			report.MissingFromInventory = append(report.MissingFromInventory, r)
+		}
+	}
+	sort.Strings(report.MissingFromInventory)
+
+	outPath := filepath.Join(rootDir, filepath.FromSlash(*output))
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "error: creating output dir: %v\n", err)
+		os.Exit(1)
+	}
+	data, err := json.MarshalIndent(report, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: marshaling report: %v\n", err)
+		os.Exit(1)
+	}
+	data = append(data, '\n')
+	if err := os.WriteFile(outPath, data, 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "error: writing %s: %v\n", outPath, err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("phase0-consumer-graph: %d resources, %d bundled TS consumers -> %s\n",
+		len(report.Resources), report.BundledTSTotal, relPath(rootDir, outPath))
+	if len(report.MissingFromInventory) > 0 {
+		fmt.Fprintf(os.Stderr, "note: %d inventory resources had no observed Go consumers: %s\n",
+			len(report.MissingFromInventory), strings.Join(report.MissingFromInventory, ", "))
+	}
+}
+
+// scanGoImports walks dir under repoAbs and, for every non-test .go file,
+// invokes fn once per import spec. Returns the number of files processed.
+func scanGoImports(repoAbs, dir string, fn func(file, importPath string)) (int, error) {
+	root := filepath.Join(repoAbs, filepath.FromSlash(dir))
+	if info, err := os.Stat(root); err != nil || !info.IsDir() {
+		return 0, nil
+	}
+	var count int
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			// Skip vendor/ and node_modules/ if ever present.
+			if name := d.Name(); name == "vendor" || name == "node_modules" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		if !strings.HasSuffix(d.Name(), ".go") || strings.HasSuffix(d.Name(), "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		f, err := parser.ParseFile(fset, p, nil, parser.ImportsOnly)
+		if err != nil {
+			return nil // skip unparseable files
+		}
+		count++
+		rel := relFrom(repoAbs, p)
+		for _, imp := range f.Imports {
+			path := strings.Trim(imp.Path.Value, `"`)
+			fn(rel, path)
+		}
+		return nil
+	})
+	return count, err
+}
+
+// scanTSImports walks dir under repoAbs looking for .ts/.tsx files that
+// contain `@meshery/schemas` imports. Returns the number of TS files scanned
+// and the list (repo-relative paths) of files that reference the schemas
+// package (any form).
+func scanTSImports(repoAbs, dir string) (int, []string, error) {
+	root := filepath.Join(repoAbs, filepath.FromSlash(dir))
+	if info, err := os.Stat(root); err != nil || !info.IsDir() {
+		return 0, nil, nil
+	}
+	var count int
+	var bundled []string
+	err := filepath.WalkDir(root, func(p string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if d.IsDir() {
+			if name := d.Name(); name == "node_modules" || name == ".next" || name == "dist" || name == "build" {
+				return fs.SkipDir
+			}
+			return nil
+		}
+		name := d.Name()
+		if !(strings.HasSuffix(name, ".ts") || strings.HasSuffix(name, ".tsx") ||
+			strings.HasSuffix(name, ".js") || strings.HasSuffix(name, ".jsx")) {
+			return nil
+		}
+		if strings.HasSuffix(name, ".d.ts") {
+			return nil
+		}
+		if strings.Contains(name, ".test.") || strings.Contains(name, ".spec.") {
+			return nil
+		}
+		body, err := os.ReadFile(p)
+		if err != nil {
+			return nil
+		}
+		count++
+		if tsImportLine.Match(body) {
+			bundled = append(bundled, relFrom(repoAbs, p))
+		}
+		return nil
+	})
+	return count, bundled, err
+}
+
+// findRepoRoot walks up from cwd looking for go.mod.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("go.mod not found in any parent directory")
+		}
+		dir = parent
+	}
+}
+
+func resolveAbsolutePath(rootDir, p string) (string, error) {
+	if filepath.IsAbs(p) {
+		return p, nil
+	}
+	return filepath.Clean(filepath.Join(rootDir, p)), nil
+}
+
+func relFrom(base, p string) string {
+	rel, err := filepath.Rel(base, p)
+	if err != nil {
+		return p
+	}
+	return filepath.ToSlash(rel)
+}
+
+func relPath(rootDir, absPath string) string {
+	rel, err := filepath.Rel(rootDir, absPath)
+	if err != nil {
+		return absPath
+	}
+	return filepath.ToSlash(rel)
+}

--- a/cmd/phase0-consumer-graph/main_test.go
+++ b/cmd/phase0-consumer-graph/main_test.go
@@ -1,0 +1,136 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestGoImportPathRegex(t *testing.T) {
+	cases := []struct {
+		in           string
+		wantVersion  string
+		wantResource string
+	}{
+		{"github.com/meshery/schemas/models/v1beta1/workspace", "v1beta1", "workspace"},
+		{"github.com/meshery/schemas/models/v1alpha3/relationship", "v1alpha3", "relationship"},
+		{"github.com/meshery/schemas/models/v1beta2/design", "v1beta2", "design"},
+		{"github.com/meshery/schemas/models/v1beta1", "v1beta1", ""},
+		{"github.com/other/package", "", ""},
+		{"github.com/meshery/schemas/validation", "", ""},
+	}
+	for _, tc := range cases {
+		m := goImportPath.FindStringSubmatch(tc.in)
+		var v, r string
+		if len(m) >= 2 {
+			v = m[1]
+		}
+		if len(m) >= 3 {
+			r = m[2]
+		}
+		if v != tc.wantVersion || r != tc.wantResource {
+			t.Errorf("%q -> (%q, %q); want (%q, %q)", tc.in, v, r, tc.wantVersion, tc.wantResource)
+		}
+	}
+}
+
+func TestTSImportLineRegex(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{`import { v1beta1 } from "@meshery/schemas";`, true},
+		{`import { mesheryApi } from "@meshery/schemas/mesheryApi";`, true},
+		{`import { cloudApi } from '@meshery/schemas/cloudApi';`, true},
+		{`import something from "other-package";`, false},
+		{`import foo from "./local";`, false},
+		{`// "@meshery/schemas" in a comment without from`, false},
+	}
+	for _, tc := range cases {
+		got := tsImportLine.MatchString(tc.in)
+		if got != tc.want {
+			t.Errorf("%q -> %v; want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestScanGoImportsAttributesPerResource(t *testing.T) {
+	dir := t.TempDir()
+	src := `package handlers
+
+import (
+	"fmt"
+
+	"github.com/meshery/schemas/models/v1beta1/workspace"
+	wsv2 "github.com/meshery/schemas/models/v1beta2/workspace"
+	"github.com/other/pkg"
+)
+
+var _ = fmt.Sprintf
+var _ = workspace.Workspace{}
+var _ = wsv2.WorkspacePayload{}
+`
+	path := filepath.Join(dir, "foo.go")
+	if err := os.WriteFile(path, []byte(src), 0o644); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	type call struct{ file, imp string }
+	var calls []call
+	count, err := scanGoImports(dir, "", func(f, imp string) {
+		calls = append(calls, call{f, imp})
+	})
+	if err != nil {
+		t.Fatalf("scanGoImports: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("got %d go files, want 1", count)
+	}
+	seen := map[string]bool{}
+	for _, c := range calls {
+		seen[c.imp] = true
+	}
+	for _, want := range []string{
+		"github.com/meshery/schemas/models/v1beta1/workspace",
+		"github.com/meshery/schemas/models/v1beta2/workspace",
+	} {
+		if !seen[want] {
+			t.Errorf("missing import %q in scan results", want)
+		}
+	}
+}
+
+func TestScanTSImportsFindsBundledClient(t *testing.T) {
+	dir := t.TempDir()
+	srcWithImport := `import { mesheryApi } from "@meshery/schemas/mesheryApi";
+
+export const foo = mesheryApi;
+`
+	srcWithoutImport := `export const bar = 42;
+`
+	if err := os.WriteFile(filepath.Join(dir, "a.ts"), []byte(srcWithImport), 0o644); err != nil {
+		t.Fatalf("seed a.ts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.ts"), []byte(srcWithoutImport), 0o644); err != nil {
+		t.Fatalf("seed b.ts: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "c.test.ts"), []byte(srcWithImport), 0o644); err != nil {
+		t.Fatalf("seed c.test.ts: %v", err)
+	}
+	count, bundled, err := scanTSImports(dir, "")
+	if err != nil {
+		t.Fatalf("scanTSImports: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("got %d ts files scanned, want 2 (the .test.ts file should be skipped)", count)
+	}
+	if len(bundled) != 1 {
+		t.Errorf("got %d bundled consumers, want 1; got %v", len(bundled), bundled)
+	}
+}
+
+func TestResourceAliasesCoverDesignPattern(t *testing.T) {
+	if resourceAliases["pattern"] != "design" {
+		t.Errorf("pattern should alias to design; got %q", resourceAliases["pattern"])
+	}
+}

--- a/validation/baseline/consumer-graph.json
+++ b/validation/baseline/consumer-graph.json
@@ -1,0 +1,649 @@
+{
+  "generated_at": "2026-04-22T23:16:19Z",
+  "generated_by": "cmd/phase0-consumer-graph",
+  "scope": "Imports of github.com/meshery/schemas/models/... (Go) and @meshery/schemas (TS) across sibling repos",
+  "complexity_heuristic": "complexity_score = count of distinct consuming files that import that resource's Go package. TS imports are tallied separately (bundled_ts_consumers) because most TS consumers pull in the full bundled client rather than a single resource.",
+  "resource_aliases": {
+    "pattern": "design"
+  },
+  "repos": [
+    {
+      "repo": "meshery/meshery",
+      "path": "../meshery",
+      "go_files_processed": 380,
+      "ts_files_processed": 811,
+      "bundled_ts_consumers": [
+        "ui/components/RelationshipBuilder/RelationshipFormStepper.tsx",
+        "ui/components/Settings/Registry/Stepper/CSVStepper.tsx",
+        "ui/components/Settings/Registry/Stepper/UrlStepper.tsx",
+        "ui/rtk-query/connection.ts",
+        "ui/rtk-query/environments.ts",
+        "ui/rtk-query/index.ts",
+        "ui/rtk-query/organization.ts",
+        "ui/rtk-query/user.ts",
+        "ui/rtk-query/userKeys.ts",
+        "ui/rtk-query/workspace.ts"
+      ]
+    },
+    {
+      "repo": "layer5io/meshery-cloud",
+      "path": "../meshery-cloud",
+      "go_files_processed": 212,
+      "ts_files_processed": 965,
+      "bundled_ts_consumers": [
+        "ui/__tests__/typetests/api-types.typetest.ts",
+        "ui/api/user-keys.js",
+        "ui/components/academy/CreateAcademyContent/CreateAcademyContent.tsx",
+        "ui/components/academy/CurriculaOverview/OverviewTab.tsx",
+        "ui/components/academy/InstructorConsole/curricula.tsx",
+        "ui/components/academy/certificate.tsx",
+        "ui/components/academy/contentList.js",
+        "ui/components/academy/context.tsx",
+        "ui/components/academy/progressTracker.ts",
+        "ui/components/academy/userList.tsx",
+        "ui/components/account/plans/checkout.tsx",
+        "ui/components/account/plans/index.js",
+        "ui/components/account/plans/upgrade.tsx",
+        "ui/components/account/preferences/index.js",
+        "ui/components/account/profile/index.js",
+        "ui/components/account/subscriptions/index.js",
+        "ui/components/catalog/catalog/charts.js",
+        "ui/components/catalog/catalog/details/index.js",
+        "ui/components/catalog/catalog/index.js",
+        "ui/components/catalog/designs/details/index.js",
+        "ui/components/catalog/designs/index.js",
+        "ui/components/catalog/filter-component/index.js",
+        "ui/components/catalog/filter-component/owner-section.js",
+        "ui/components/catalog/filters/details/index.js",
+        "ui/components/catalog/filters/index.js",
+        "ui/components/catalog/general/InfoModal/index.js",
+        "ui/components/catalog/general/catalog-card.js",
+        "ui/components/catalog/general/details/index.js",
+        "ui/components/catalog/general/shareModal/index.js",
+        "ui/components/catalog/general/useCatalogOperations.js",
+        "ui/components/catalog/leaderboard/details/index.js",
+        "ui/components/catalog/leaderboard/index.js",
+        "ui/components/catalog/requests/content-info.js",
+        "ui/components/catalog/requests/index.js",
+        "ui/components/catalog/views/details/index.js",
+        "ui/components/catalog/views/index.js",
+        "ui/components/connect/index.js",
+        "ui/components/connect/stepper/stepper-content.js",
+        "ui/components/dashboard/badges/index.js",
+        "ui/components/dashboard/getting-started/index.js",
+        "ui/components/dashboard/getting-started/welcome/index.js",
+        "ui/components/dashboard/index.js",
+        "ui/components/dashboard/invite-user-card/index.js",
+        "ui/components/dashboard/meshery-instances/index.js",
+        "ui/components/dashboard/meshery-instances/k8s-table.js",
+        "ui/components/dashboard/my-designs/index.js",
+        "ui/components/dashboard/playground/index.js",
+        "ui/components/dashboard/recent-activities-table.js",
+        "ui/components/dashboard/summaryCards.jsx",
+        "ui/components/events/events-table.js",
+        "ui/components/events/overview.js",
+        "ui/components/events/summary-table.js",
+        "ui/components/general/RegisterOrgActivity.tsx",
+        "ui/components/general/Tables.tsx",
+        "ui/components/general/UserAvatar.tsx",
+        "ui/components/general/error-404/CurrentSession.js",
+        "ui/components/general/error-404/OrgSwitcher.tsx",
+        "ui/components/general/navbar/index.js",
+        "ui/components/general/navbar/org-switch/index.js",
+        "ui/components/general/org-search-field.js",
+        "ui/components/general/rjsf/widgets.tsx",
+        "ui/components/general/tab-menu/index.js",
+        "ui/components/general/use-sistent/index.js",
+        "ui/components/identity/invitations/index.tsx",
+        "ui/components/identity/org-management/badge-management-modal.js",
+        "ui/components/identity/org-management/edit-org-modal.tsx",
+        "ui/components/identity/org-management/index.js",
+        "ui/components/identity/org-management/teams-table.js",
+        "ui/components/identity/org-management/view-users-in-org-modal.js",
+        "ui/components/identity/overview.js",
+        "ui/components/identity/role-management/create-custom-roles.js",
+        "ui/components/identity/role-management/index.js",
+        "ui/components/identity/role-management/keychain-table.js",
+        "ui/components/identity/role-management/view-role.js",
+        "ui/components/identity/signup-requests.js",
+        "ui/components/identity/team-management/add-team-members-modal.js",
+        "ui/components/identity/team-management/index.js",
+        "ui/components/identity/team-management/view-users-in-team-modal.js",
+        "ui/components/identity/user-management/grid/card.js",
+        "ui/components/identity/user-management/index.js",
+        "ui/components/identity/user-management/view-user.js",
+        "ui/components/modals/help-and-support-modal.js",
+        "ui/components/public-profile/badges-tab.js",
+        "ui/components/public-profile/designs-tab.js",
+        "ui/components/public-profile/index.js",
+        "ui/components/public-profile/profile-stats.js",
+        "ui/components/public-profile/user-details.js",
+        "ui/components/public-profile/users.js",
+        "ui/components/public-profile/views-tab.js",
+        "ui/components/security/credentials/index.js",
+        "ui/components/security/keychains/create-keychain.js",
+        "ui/components/security/keychains/index.js",
+        "ui/components/security/keychains/keys-table.js",
+        "ui/components/security/keychains/update-keychain.js",
+        "ui/components/security/keys/create-key.js",
+        "ui/components/security/keys/index.js",
+        "ui/components/security/keys/update-key.js",
+        "ui/components/security/overview.js",
+        "ui/components/security/tokens/index.js",
+        "ui/components/setup/get-started.js",
+        "ui/components/welcome/organization.js",
+        "ui/components/welcome/workspace.js",
+        "ui/components/workspaces/environments/index.js",
+        "ui/components/workspaces/integrations/connection-card.js",
+        "ui/components/workspaces/integrations/connectionsTable.js",
+        "ui/components/workspaces/integrations/index.js",
+        "ui/components/workspaces/overview.js",
+        "ui/components/workspaces/workspaces/index.js",
+        "ui/components/workspaces/workspaces/workspace-content-data-table.js",
+        "ui/pages/_app.js",
+        "ui/pages/academy/[orgId]/[contentType]/[slug].tsx",
+        "ui/pages/academy/[orgId]/[contentType]/[slug]/test.tsx",
+        "ui/pages/academy/certificates/[id].tsx",
+        "ui/pages/academy/index.tsx",
+        "ui/pages/academy/my-academy.tsx",
+        "ui/pages/invitations/[id]/accept.tsx",
+        "ui/store/index.js",
+        "ui/store/slices/organization.ts",
+        "ui/subscriptions/index.ts",
+        "ui/types/user.ts",
+        "ui/utility/helpers.js"
+      ]
+    },
+    {
+      "repo": "layer5labs/meshery-extensions",
+      "path": "../meshery-extensions",
+      "go_files_processed": 0,
+      "ts_files_processed": 719,
+      "bundled_ts_consumers": [
+        "meshmap/src/components/api/rtk-query.ts",
+        "meshmap/src/domain/capabilities.ts",
+        "meshmap/src/domain/relationships.ts",
+        "meshmap/src/domain/styles.ts",
+        "meshmap/src/domain/types.ts",
+        "meshmap/src/modules/editor/collab/colabActor.ts",
+        "meshmap/src/modules/editor/modes/designer/designActor.ts",
+        "meshmap/src/modules/editor/modes/designer/model.ts",
+        "meshmap/src/modules/editor/styles.ts",
+        "meshmap/src/modules/meshmodel/index.ts",
+        "meshmap/src/redux/store.ts",
+        "meshmap/src/rtk-query/designs.ts",
+        "meshmap/src/rtk-query/user.ts",
+        "meshmap/src/rtk-query/views.ts",
+        "meshmap/src/sections/MesheryDesignerComponent/CatalogModal/types.ts",
+        "meshmap/src/utils/base64.ts"
+      ]
+    }
+  ],
+  "resources": [
+    {
+      "resource": "credential",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "meshery/meshery|server/models/credentials.go"
+      ],
+      "complexity_score": 1
+    },
+    {
+      "resource": "event",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/handlers/events_tracker.go"
+      ],
+      "complexity_score": 1
+    },
+    {
+      "resource": "keychain",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/models/model_aliases.go"
+      ],
+      "complexity_score": 1
+    },
+    {
+      "resource": "schedule",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "meshery/meshery|server/models/schedule.go"
+      ],
+      "complexity_score": 1
+    },
+    {
+      "resource": "view",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "meshery/meshery|server/models/workspace_persister.go"
+      ],
+      "complexity_score": 1
+    },
+    {
+      "resource": "category",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/dao/meshmodels_dao.go",
+        "meshery/meshery|server/models/meshmodel/core/register.go"
+      ],
+      "complexity_score": 2
+    },
+    {
+      "resource": "design",
+      "versions": [
+        "v1beta2"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/handlers/smtp.go",
+        "layer5io/meshery-cloud|server/handlers/users.go"
+      ],
+      "complexity_score": 2
+    },
+    {
+      "resource": "key",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/models/model_aliases.go",
+        "meshery/meshery|server/models/key.go"
+      ],
+      "complexity_score": 2
+    },
+    {
+      "resource": "v1alpha2.meta",
+      "versions": [
+        "v1alpha2"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/handlers/meshery_patterns.go",
+        "meshery/meshery|server/handlers/meshery_pattern_handler.go"
+      ],
+      "complexity_score": 2
+    },
+    {
+      "resource": "capability",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "meshery/meshery|server/handlers/policy_relationship_handler.go",
+        "meshery/meshery|server/models/k8s_components_registration.go",
+        "meshery/meshery|server/models/pattern/core/pattern.go"
+      ],
+      "complexity_score": 3
+    },
+    {
+      "resource": "organization",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "meshery/meshery|server/cmd/main.go",
+        "meshery/meshery|server/models/default_local_provider.go",
+        "meshery/meshery|server/models/organization.go",
+        "meshery/meshery|server/models/organization_persistor.go"
+      ],
+      "complexity_score": 4
+    },
+    {
+      "resource": "badge",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/handlers/academy/achievements.go",
+        "layer5io/meshery-cloud|server/handlers/badges/dao.go",
+        "layer5io/meshery-cloud|server/handlers/badges/handler.go",
+        "layer5io/meshery-cloud|server/handlers/badges/service.go",
+        "layer5io/meshery-cloud|server/models/users.go"
+      ],
+      "complexity_score": 5
+    },
+    {
+      "resource": "feature",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/dao/subscriptions.go",
+        "layer5io/meshery-cloud|server/handlers/meshery_patterns.go",
+        "layer5io/meshery-cloud|server/handlers/middlewares_authz_entitlement.go",
+        "layer5io/meshery-cloud|server/models/dao_interface.go",
+        "layer5io/meshery-cloud|server/models/handlers.go"
+      ],
+      "complexity_score": 5
+    },
+    {
+      "resource": "invitation",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/handlers/academy/crud.go",
+        "layer5io/meshery-cloud|server/handlers/invitations/dao.go",
+        "layer5io/meshery-cloud|server/handlers/invitations/handlers.go",
+        "layer5io/meshery-cloud|server/handlers/invitations/service.go",
+        "layer5io/meshery-cloud|server/models/handlers.go"
+      ],
+      "complexity_score": 5
+    },
+    {
+      "resource": "subscription",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/dao/subscriptions.go",
+        "layer5io/meshery-cloud|server/handlers/subscriptions.go",
+        "layer5io/meshery-cloud|server/models/dao_interface.go",
+        "layer5io/meshery-cloud|server/payment_processor/processor.go",
+        "layer5io/meshery-cloud|server/payment_processor/renconciller.go",
+        "layer5io/meshery-cloud|server/payment_processor/stripe.go"
+      ],
+      "complexity_score": 6
+    },
+    {
+      "resource": "user",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/handlers/badge_helpers.go",
+        "layer5io/meshery-cloud|server/handlers/middlewares_authz_scope.go",
+        "layer5io/meshery-cloud|server/handlers/middlewares_context.go",
+        "layer5io/meshery-cloud|server/handlers/users.go",
+        "layer5io/meshery-cloud|server/models/users.go",
+        "layer5io/meshery-cloud|server/utils/utils.go",
+        "meshery/meshery|server/models/user.go"
+      ],
+      "complexity_score": 7
+    },
+    {
+      "resource": "v1beta1.meta",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/handlers/meshery_patterns.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/model/import.go",
+        "meshery/meshery|server/handlers/component_handler.go",
+        "meshery/meshery|server/handlers/meshery_filter_handler.go",
+        "meshery/meshery|server/models/meshmodel/core/register.go",
+        "meshery/meshery|server/models/pattern/core/pattern.go",
+        "meshery/meshery|server/models/pattern/utils/utils.go"
+      ],
+      "complexity_score": 7
+    },
+    {
+      "resource": "academy",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/handlers/academy/achievements.go",
+        "layer5io/meshery-cloud|server/handlers/academy/crud.go",
+        "layer5io/meshery-cloud|server/handlers/academy/dao.go",
+        "layer5io/meshery-cloud|server/handlers/academy/instructor-console.go",
+        "layer5io/meshery-cloud|server/handlers/academy/load_cirricula.go",
+        "layer5io/meshery-cloud|server/handlers/academy/progress_tracker.go",
+        "layer5io/meshery-cloud|server/handlers/academy/quiz.go",
+        "layer5io/meshery-cloud|server/handlers/academy/utils.go"
+      ],
+      "complexity_score": 8
+    },
+    {
+      "resource": "plan",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/dao/plan.go",
+        "layer5io/meshery-cloud|server/dao/subscriptions.go",
+        "layer5io/meshery-cloud|server/handlers/api_plans.go",
+        "layer5io/meshery-cloud|server/handlers/middlewares_authz_entitlement.go",
+        "layer5io/meshery-cloud|server/models/dao_interface.go",
+        "layer5io/meshery-cloud|server/models/handlers.go",
+        "layer5io/meshery-cloud|server/payment_processor/processor.go",
+        "layer5io/meshery-cloud|server/payment_processor/stripe.go"
+      ],
+      "complexity_score": 8
+    },
+    {
+      "resource": "workspace",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/models/model_workspace.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/workspaces/create.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/workspaces/list.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/workspaces/view.go",
+        "meshery/meshery|server/cmd/main.go",
+        "meshery/meshery|server/handlers/doc.go",
+        "meshery/meshery|server/handlers/workspace_handlers.go",
+        "meshery/meshery|server/models/default_local_provider.go",
+        "meshery/meshery|server/models/providers.go",
+        "meshery/meshery|server/models/remote_provider.go",
+        "meshery/meshery|server/models/workspace_persister.go"
+      ],
+      "complexity_score": 11
+    },
+    {
+      "resource": "model",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/dao/meshmodels_dao.go",
+        "layer5io/meshery-cloud|server/meshmodels/helper.go",
+        "layer5io/meshery-cloud|server/models/dao_interface.go",
+        "layer5io/meshery-cloud|server/models/meshmodels.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/model/common.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/model/view.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/registry/publish.go",
+        "meshery/meshery|server/handlers/component_generator_helper.go",
+        "meshery/meshery|server/handlers/component_handler.go",
+        "meshery/meshery|server/handlers/meshery_filter_handler.go",
+        "meshery/meshery|server/helpers/utils/utils.go",
+        "meshery/meshery|server/models/meshery_meshmodels_api_response.go",
+        "meshery/meshery|server/models/meshmodel/core/register.go"
+      ],
+      "complexity_score": 13
+    },
+    {
+      "resource": "environment",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/models/model_available_environment.go",
+        "layer5io/meshery-cloud|server/models/model_environment.go",
+        "layer5io/meshery-cloud|server/models/model_environment_page.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/environments/create.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/environments/environment.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/environments/list.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/environments/view.go",
+        "meshery/meshery|server/cmd/main.go",
+        "meshery/meshery|server/handlers/environments_handlers.go",
+        "meshery/meshery|server/models/default_local_provider.go",
+        "meshery/meshery|server/models/environment_persister.go",
+        "meshery/meshery|server/models/environments/environment.go",
+        "meshery/meshery|server/models/providers.go",
+        "meshery/meshery|server/models/remote_provider.go",
+        "meshery/meshery|server/models/workspace_persister.go"
+      ],
+      "complexity_score": 15
+    },
+    {
+      "resource": "relationship",
+      "versions": [
+        "v1alpha3",
+        "v1beta2"
+      ],
+      "consuming_files": [
+        "meshery/meshery|mesheryctl/internal/cli/root/relationships/relationship.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/relationships/view.go",
+        "meshery/meshery|server/handlers/component_generator_helper.go",
+        "meshery/meshery|server/handlers/component_handler.go",
+        "meshery/meshery|server/handlers/meshsync_handler.go",
+        "meshery/meshery|server/handlers/policy_relationship_handler.go",
+        "meshery/meshery|server/handlers/relationship_handlers.go",
+        "meshery/meshery|server/helpers/common_registry_logs.go",
+        "meshery/meshery|server/internal/graphql/resolver/meshmodel.go",
+        "meshery/meshery|server/policies/actions.go",
+        "meshery/meshery|server/policies/engine.go",
+        "meshery/meshery|server/policies/eval_rules.go",
+        "meshery/meshery|server/policies/feasibility.go",
+        "meshery/meshery|server/policies/policy.go",
+        "meshery/meshery|server/policies/policy_alias.go",
+        "meshery/meshery|server/policies/policy_binding.go",
+        "meshery/meshery|server/policies/policy_edge_network.go",
+        "meshery/meshery|server/policies/policy_hierarchical.go",
+        "meshery/meshery|server/policies/policy_matchlabels.go",
+        "meshery/meshery|server/policies/policy_wallet.go",
+        "meshery/meshery|server/policies/utils.go"
+      ],
+      "complexity_score": 21
+    },
+    {
+      "resource": "connection",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/dao/connections.go",
+        "layer5io/meshery-cloud|server/handlers/connections.go",
+        "layer5io/meshery-cloud|server/handlers/github.go",
+        "layer5io/meshery-cloud|server/handlers/users.go",
+        "layer5io/meshery-cloud|server/models/connections.go",
+        "layer5io/meshery-cloud|server/models/dao_interface.go",
+        "layer5io/meshery-cloud|server/utils/utils.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/connections/connection.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/connections/list.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/connections/view.go",
+        "meshery/meshery|server/cmd/main.go",
+        "meshery/meshery|server/handlers/component_generation.go",
+        "meshery/meshery|server/handlers/component_handler.go",
+        "meshery/meshery|server/handlers/connections_handlers.go",
+        "meshery/meshery|server/handlers/handler_instance.go",
+        "meshery/meshery|server/handlers/k8sconfig_handler.go",
+        "meshery/meshery|server/handlers/meshery_pattern_handler.go",
+        "meshery/meshery|server/helpers/common_registry_logs.go",
+        "meshery/meshery|server/machines/kubernetes/connect.go",
+        "meshery/meshery|server/models/connection_persister.go",
+        "meshery/meshery|server/models/connections/connections.go",
+        "meshery/meshery|server/models/default_local_provider.go",
+        "meshery/meshery|server/models/meshery_controllers.go",
+        "meshery/meshery|server/models/meshmodel/core/register.go",
+        "meshery/meshery|server/models/pattern/patterns/patterns.go",
+        "meshery/meshery|server/models/pattern/stages/provision.go",
+        "meshery/meshery|server/models/remote_provider.go"
+      ],
+      "complexity_score": 27
+    },
+    {
+      "resource": "pattern",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "layer5io/meshery-cloud|server/handlers/meshery_patterns.go",
+        "layer5io/meshery-cloud|server/models/meshery_patterns.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/design/deploy.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/design/import.go",
+        "meshery/meshery|server/handlers/design_engine_handler.go",
+        "meshery/meshery|server/handlers/design_import.go",
+        "meshery/meshery|server/handlers/evaluation_tracker.go",
+        "meshery/meshery|server/handlers/meshery_pattern_handler.go",
+        "meshery/meshery|server/handlers/meshsync_handler.go",
+        "meshery/meshery|server/handlers/policy_relationship_handler.go",
+        "meshery/meshery|server/models/default_local_provider.go",
+        "meshery/meshery|server/models/meshsync.go",
+        "meshery/meshery|server/models/pattern/core/model.go",
+        "meshery/meshery|server/models/pattern/core/pattern.go",
+        "meshery/meshery|server/models/pattern/planner/planner.go",
+        "meshery/meshery|server/models/pattern/stages/chain.go",
+        "meshery/meshery|server/models/pattern/stages/filler.go",
+        "meshery/meshery|server/models/pattern/stages/provision.go",
+        "meshery/meshery|server/models/pattern/stages/svc_provider.go",
+        "meshery/meshery|server/models/workspace_persister.go",
+        "meshery/meshery|server/policies/actions.go",
+        "meshery/meshery|server/policies/engine.go",
+        "meshery/meshery|server/policies/eval_rules.go",
+        "meshery/meshery|server/policies/policy.go",
+        "meshery/meshery|server/policies/policy_alias.go",
+        "meshery/meshery|server/policies/policy_binding.go",
+        "meshery/meshery|server/policies/policy_edge_network.go",
+        "meshery/meshery|server/policies/policy_hierarchical.go",
+        "meshery/meshery|server/policies/policy_matchlabels.go",
+        "meshery/meshery|server/policies/policy_wallet.go",
+        "meshery/meshery|server/policies/utils.go"
+      ],
+      "complexity_score": 31
+    },
+    {
+      "resource": "component",
+      "versions": [
+        "v1beta1"
+      ],
+      "consuming_files": [
+        "meshery/meshery|mesheryctl/internal/cli/root/components/view.go",
+        "meshery/meshery|mesheryctl/internal/cli/root/registry/update.go",
+        "meshery/meshery|server/handlers/component_generation.go",
+        "meshery/meshery|server/handlers/component_generator_helper.go",
+        "meshery/meshery|server/handlers/component_handler.go",
+        "meshery/meshery|server/handlers/design_engine_handler.go",
+        "meshery/meshery|server/handlers/meshery_filter_handler.go",
+        "meshery/meshery|server/handlers/meshery_pattern_handler.go",
+        "meshery/meshery|server/handlers/meshsync_handler.go",
+        "meshery/meshery|server/handlers/policy_relationship_handler.go",
+        "meshery/meshery|server/helpers/common_registry_logs.go",
+        "meshery/meshery|server/helpers/utils/utils.go",
+        "meshery/meshery|server/internal/graphql/resolver/meshmodel.go",
+        "meshery/meshery|server/machines/helpers/auto_register.go",
+        "meshery/meshery|server/models/k8s_components_registration.go",
+        "meshery/meshery|server/models/meshery_meshmodels_api_response.go",
+        "meshery/meshery|server/models/meshmodel/core/register.go",
+        "meshery/meshery|server/models/meshsync_events.go",
+        "meshery/meshery|server/models/pattern/core/pattern.go",
+        "meshery/meshery|server/models/pattern/patterns/k8s/k8s.go",
+        "meshery/meshery|server/models/pattern/patterns/patterns.go",
+        "meshery/meshery|server/models/pattern/planner/graph.go",
+        "meshery/meshery|server/models/pattern/planner/planner.go",
+        "meshery/meshery|server/models/pattern/resource/selector/workload.go",
+        "meshery/meshery|server/models/pattern/stages/chain.go",
+        "meshery/meshery|server/models/pattern/stages/filler.go",
+        "meshery/meshery|server/models/pattern/stages/provision.go",
+        "meshery/meshery|server/models/pattern/stages/svc_provider.go",
+        "meshery/meshery|server/models/pattern/stages/validate.go",
+        "meshery/meshery|server/policies/actions.go",
+        "meshery/meshery|server/policies/eval_rules.go",
+        "meshery/meshery|server/policies/feasibility.go",
+        "meshery/meshery|server/policies/policy_alias.go",
+        "meshery/meshery|server/policies/policy_binding.go",
+        "meshery/meshery|server/policies/policy_matchlabels.go"
+      ],
+      "complexity_score": 35
+    }
+  ],
+  "missing_from_inventory": [
+    "role",
+    "team",
+    "token"
+  ],
+  "bundled_ts_total": 147
+}


### PR DESCRIPTION
## Summary
- Implements Phase 0 Agent 0.D of the [Option B identifier-naming migration](../blob/master/docs/identifier-naming-option-b-migration.md). Attributes schemas imports across meshery/meshery, layer5io/meshery-cloud, and layer5labs/meshery-extensions and produces a per-resource consumer-dependency graph with complexity scores for Phase 3 sequencing.
- Adds `cmd/phase0-consumer-graph` (Go), `make baseline-consumer-graph` target with MESHERY_REPO / CLOUD_REPO / EXTENSIONS_REPO overrides.
- Commits artifact at `validation/baseline/consumer-graph.json` (27.9KB).
- Closes the 0.D checklist item on meshery/schemas#776 and completes **Phase 0** of the migration.

## Why
Phase 3's per-resource migration plan needs a priority ordering that reflects downstream consumer complexity. The master plan §9.1 provides a curated ordering; this baseline provides the raw numbers behind that ordering and documents where §9.1's inventory does and does not match the observed consumer graph today.

## Attribution strategy
- **Go imports**: precise, per-resource attribution via `go/parser` + regex for `github.com/meshery/schemas/models/<version>/<resource>`.
- **TS imports**: file-level detection of `@meshery/schemas[/...]` imports. Most TS consumers pull in the bundled `mesheryApi` or `cloudApi`, which transitively references every resource; counting those against every resource would bias the score. The tool reports the TS file list per repo so future scorers can re-weight.

## Complexity heuristic (documented inline)
`complexity_score = number of distinct Go files that import the resource's Go package.` Lowest first in the sort. TS consumer count surfaced as `bundled_ts_total` and `bundled_ts_consumers`.

## Current-state graph (low→high complexity)
| Score | Resources |
|---|---|
| 1 | credential, event, keychain, schedule, view |
| 2 | category, design, key |
| 3 | capability |
| 4 | organization |
| 5 | badge, feature, invitation |
| 6 | subscription |
| 7 | user |
| 8 | academy, plan |
| 11 | workspace |
| 13 | model |
| 15 | environment |
| 21 | relationship (v1alpha3+v1beta2) |
| 27 | connection |
| 31 | pattern (v1beta1 Go package for design) |
| 35 | component |

### Inventory coverage
- All 22 resources from §9.1 are accounted for, with three (`role`, `team`, `token`) explicitly flagged as having no Go consumers today — schema-only resources that will make for low-risk Phase 3 migrations.
- A `resource_aliases` table surfaces the `pattern` (v1beta1 Go package) ↔ `design` (schema construct / v1beta2 Go package) equivalence so orchestrators reading the graph can merge the two scores (31 + 2 = 33).

## Tests
- [x] Unit tests added: `go test ./cmd/phase0-consumer-graph/` — PASS (import-regex, TS import-regex, Go scanner fixture, TS scanner fixture incl. .test.ts exclusion, alias table)
- [x] Local build clean: `go build ./...` — PASS
- [x] Local test suite clean: `go test ./...` — PASS
- [x] Schema validator clean: `make validate-schemas` — PASS

## Docs
- Tool documented by top-of-file Go doc in `cmd/phase0-consumer-graph/main.go`.
- `make baseline-consumer-graph` added to top-level help.
- Complexity heuristic and alias table documented inline in the committed artifact.

## Migration impact
- Breaking: no.
- API-version bump required: no.
- Consumer repos that must be updated: none (new read-only tool + artifact).

## Rollback
Revert the commit; tool and artifact disappear.