### PR TITLE
fix(phase0): surface scanner walk+parse errors, correct phase0-consumer-graph doc comments

### DIFF
--- a/cmd/phase0-consumer-graph/main.go
+++ b/cmd/phase0-consumer-graph/main.go
@@ -75,9 +75,11 @@ var resourceAliases = map[string]string{
 }
 
 // inventory22 enumerates the 22 resources named in master plan §9.1. The
-// baseline reports on every resource it finds in the schemas tree, but
-// having this list lets us verify no inventory item was silently skipped
-// (acceptance criterion: "Graph covers all 22 resources").
+// baseline derives resource entries from downstream consumer import paths
+// (not from the schemas tree directly), so having this inventory list lets
+// us verify no §9.1 item was silently skipped — e.g., schemas-only
+// resources with no Go consumers surface explicitly in missing_from_inventory
+// rather than silently disappearing.
 var inventory22 = []string{
 	"workspace", "environment", "organization", "user",
 	"design", "connection", "team", "role",
@@ -193,14 +195,17 @@ func main() {
 				}
 				addConsumer(resource, r.label, file, version)
 			})
-			if err != nil && *verbose {
+			if err != nil {
+				// Walk-level errors silently undercount the baseline; surface
+				// them unconditionally (not gated on --verbose) so a
+				// regenerator sees the failure.
 				fmt.Fprintf(os.Stderr, "warn: %s: %s: %v\n", r.label, dir, err)
 			}
 			repoSummary.GoFilesProcessed += goFiles
 		}
 		for _, dir := range r.tsDirs {
 			tsFiles, bundled, err := scanTSImports(abs, dir)
-			if err != nil && *verbose {
+			if err != nil {
 				fmt.Fprintf(os.Stderr, "warn: %s: %s: %v\n", r.label, dir, err)
 			}
 			repoSummary.TSFilesProcessed += tsFiles
@@ -287,7 +292,10 @@ func main() {
 }
 
 // scanGoImports walks dir under repoAbs and, for every non-test .go file,
-// invokes fn once per import spec. Returns the number of files processed.
+// invokes fn once per import spec. Returns the number of files successfully
+// parsed. Parse failures are reported to stderr so a partial baseline is
+// diagnosable (a silently skipped file would simply under-attribute the
+// graph).
 func scanGoImports(repoAbs, dir string, fn func(file, importPath string)) (int, error) {
 	root := filepath.Join(repoAbs, filepath.FromSlash(dir))
 	if info, err := os.Stat(root); err != nil || !info.IsDir() {
@@ -311,7 +319,8 @@ func scanGoImports(repoAbs, dir string, fn func(file, importPath string)) (int, 
 		fset := token.NewFileSet()
 		f, err := parser.ParseFile(fset, p, nil, parser.ImportsOnly)
 		if err != nil {
-			return nil // skip unparseable files
+			fmt.Fprintf(os.Stderr, "warn: %s: parse error: %v\n", relFrom(repoAbs, p), err)
+			return nil
 		}
 		count++
 		rel := relFrom(repoAbs, p)
@@ -324,10 +333,11 @@ func scanGoImports(repoAbs, dir string, fn func(file, importPath string)) (int, 
 	return count, err
 }
 
-// scanTSImports walks dir under repoAbs looking for .ts/.tsx files that
-// contain `@meshery/schemas` imports. Returns the number of TS files scanned
-// and the list (repo-relative paths) of files that reference the schemas
-// package (any form).
+// scanTSImports walks dir under repoAbs looking for .ts/.tsx/.js/.jsx
+// source files (generated `.d.ts` and `*.test.*`/`*.spec.*` files are
+// skipped) that contain `@meshery/schemas` imports. Returns the number of
+// matching source files scanned and the list (repo-relative paths) of
+// files that reference the schemas package in any form.
 func scanTSImports(repoAbs, dir string) (int, []string, error) {
 	root := filepath.Join(repoAbs, filepath.FromSlash(dir))
 	if info, err := os.Stat(root); err != nil || !info.IsDir() {

--- a/validation/baseline/consumer-graph.json
+++ b/validation/baseline/consumer-graph.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-22T23:16:19Z",
+  "generated_at": "2026-04-22T23:21:48Z",
   "generated_by": "cmd/phase0-consumer-graph",
   "scope": "Imports of github.com/meshery/schemas/models/... (Go) and @meshery/schemas (TS) across sibling repos",
   "complexity_heuristic": "complexity_score = count of distinct consuming files that import that resource's Go package. TS imports are tallied separately (bundled_ts_consumers) because most TS consumers pull in the full bundled client rather than a single resource.",


### PR DESCRIPTION
## Summary
Follow-up to meshery/schemas#785 addressing the four LOW-priority copilot threads that arrived post-merge (auto-merge fired before the bot review landed).

- \`scanGoImports\` logs parse errors on stderr unconditionally instead of silently dropping unparseable files.
- \`scanGoImports\` / \`scanTSImports\` WalkDir errors are reported without requiring \`--verbose\` (matches 0.B's scanner treatment).
- \`scanTSImports\` docstring updated: it scans \`.ts/.tsx/.js/.jsx\` (not just \`.ts/.tsx\`) and excludes \`.d.ts\`, \`.test.*\`, \`.spec.*\`.
- \`inventory22\` docstring updated: the baseline derives resource entries from downstream consumer imports (not from the schemas tree), and the inventory list surfaces schemas-only resources (role/team/token) in \`missing_from_inventory\` rather than letting them silently disappear.

Behaviour is unchanged for successful runs; the artifact regenerates byte-identical modulo \`generated_at\`.

## Why
Phase 0 Agent 0.D PR meshery/schemas#785 landed with these comment/ergonomics items open. Picking them up before Phase 1 avoids adding them to Phase 4.E's re-scan noise.

## Tests
- [x] Local build clean: \`go build ./...\`
- [x] Local test suite clean: \`go test ./...\`
- [x] Schema validator clean: \`make validate-schemas\`
- [x] Baseline regenerates cleanly: \`make baseline-consumer-graph\` — 26 resources, 147 bundled TS consumers, missing_from_inventory: role, team, token.

## Process note
PR #785 auto-merged before copilot's review arrived (CI went green first). Adjusted my cadence for Phase 1+: governance-touching PRs block on human review per master plan §5.3; non-governance baselines will wait for both bots per §5.2 step 9 before arming auto-merge.