### PR TITLE
docs(agents): amend AGENTS.md for Option B identifier-naming contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ Before opening a PR, verify:
 
 ## Naming conventions
 
-- Property names: preserve published wire-format casing; new non-DB properties use `camelCase`, DB-backed properties use the exact snake_case database column name
+- Property names: **camelCase on the wire, uniformly.** New schema properties and their JSON tags use `camelCase`. For DB-backed fields, the `x-oapi-codegen-extra-tags.db` tag carries the snake_case DB column name separately from the wire identifier — the ORM layer is the sole translation boundary.
 - ID-suffix fields: `lowerCamelCase` + `Id` (`modelId`, `registrantId`)
 - New enum values: lowercase words (`enabled`, `ignored`, `duplicate`); preserve published enum literals as-is within the same API version
 - Object names: singular nouns (`model`, `component`, `design`)
@@ -148,32 +148,35 @@ Before opening a PR, verify:
 
 ## Casing rules at a glance
 
-Every element in the API has exactly one correct casing. The table below is the single authoritative reference:
+Every element in the API has exactly one correct casing. The table below is the single authoritative reference.
 
-| Element | Casing | Example | Counter-example |
+**The one-sentence rule:** *Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.*
+
+| Layer / element | Casing | Example | Counter-example |
 |---|---|---|---|
-| Schema property names (non-DB) | camelCase | `schemaVersion`, `displayName` | ~~`schema_version`~~, ~~`SchemaVersion`~~ |
-| ID-suffix properties | camelCase + `Id` | `modelId`, `registrantId` | ~~`modelID`~~, ~~`model_id`~~ |
-| DB-backed / DB-mirrored fields | exact snake_case db column name | `created_at`, `updated_at`, `user_id`, `first_name`, `plan_id` | ~~`createdAt`~~, ~~`firstName`~~, ~~`planId`~~ |
+| DB column / `db:` tag | `snake_case` | `user_id`, `org_id`, `created_at`, `pattern_file` | ~~`userId`~~, ~~`orgID`~~ |
+| Go struct field | `PascalCase` with Go-idiomatic initialisms | `UserID`, `OrgID`, `WorkspaceID`, `CreatedAt` | ~~`User_id`~~, ~~`UserIdentifier`~~ |
+| JSON tag / schema property / wire form | `camelCase` (DB-backed **and** non-DB-backed alike) | `json:"userId"`, `json:"orgId"`, `json:"patternFile"`, `json:"createdAt"` | ~~`json:"user_id"`~~, ~~`json:"orgID"`~~ |
+| ID-suffix properties | `camelCase + Id` (lowercase `d`) | `modelId`, `registrantId`, `userId` | ~~`modelID`~~, ~~`model_id`~~ |
 | New enum values | lowercase | `enabled`, `ignored` | ~~`Enabled`~~, ~~`ENABLED`~~ |
-| `components/schemas` names | PascalCase | `ModelDefinition`, `KeychainPayload` | ~~`modelDefinition`~~ |
+| `components/schemas` type names | PascalCase | `ModelDefinition`, `KeychainPayload` | ~~`modelDefinition`~~ |
 | File and folder names | lowercase | `api.yml`, `keychain.yaml` | ~~`Keychain.yaml`~~ |
-| Path segments | kebab-case, plural nouns | `/api/role-holders` | ~~`/api/roleHolders`~~ |
-| Path parameters | camelCase + `Id` | `{orgId}`, `{workspaceId}` | ~~`{orgID}`~~, ~~`{org_id}`~~ |
-| `operationId` | lower camelCase verbNoun | `getAllRoles`, `createWorkspace` | ~~`GetAllRoles`~~, ~~`get_all_roles`~~ |
+| URL path segments | kebab-case, plural nouns | `/api/role-holders`, `/api/workspaces` | ~~`/api/roleHolders`~~ |
+| URL path + query parameters | `camelCase + Id` | `{orgId}`, `?userId=…`, `?workspaceId=…` | ~~`{orgID}`~~, ~~`{org_id}`~~ |
+| `operationId` | lower camelCase verbNoun | `getAllRoles`, `createWorkspace`, `getWorkspaces` | ~~`GetAllRoles`~~, ~~`get_all_roles`~~ |
+| TypeScript property / RTK arg | camelCase | `response.userId`, `queryArg.orgId` | ~~`response.user_id`~~, ~~`queryArg.orgID`~~ |
 | Go type names | PascalCase (generated) | `Connection`, `KeychainPayload` | — |
-| Go field names | PascalCase (generated) | `CreatedAt`, `UpdatedAt` | — |
 | TypeScript type names | PascalCase (generated) | `Connection`, `KeychainPayload` | — |
 
-**The database naming is the compatibility boundary.** If a property has `x-oapi-codegen-extra-tags.db` and that `db` value is snake_case, then the schema property name and JSON tag must use that exact snake_case name. Do not camelize DB-backed fields in-place within an existing API version.
+**The database naming is the ORM boundary, not a wire-format dictator.** Every JSON tag on every property — DB-backed or not — is camelCase. When a property is DB-backed, the snake_case DB column name lives *only* in `x-oapi-codegen-extra-tags.db` (and in the generated Go field's `db:` struct tag); it does not propagate to the JSON tag, the OpenAPI schema property name, URL parameters, or any other wire form. On DB-backed fields the `json:` and `db:` tags differ by design.
 
-**Partial casing migrations are forbidden.** Do not rename selected fields within the same resource from snake_case to camelCase while leaving other published fields unchanged. If the wire format must change, introduce a new API version and migrate the resource consistently there.
+**Partial casing migrations are forbidden.** Do not rename selected fields within the same resource from snake_case to camelCase while leaving other published fields unchanged. If the wire format must change, introduce a new API version and migrate the resource consistently there. See the [Option B migration plan](docs/identifier-naming-option-b-migration.md) for the per-resource rollout.
 
 **Existing enum wire values are compatibility-sensitive.** Use lowercase for newly introduced enum literals, but do not recase published enum values in-place within the same API version. The validator exempts legacy enum values that already exist on the baseline branch.
 
-**Pagination envelopes are fixed API contract fields** — use `page`, `page_size`, and `total_count`, not `pageSize` or `totalCount`.
+**Pagination envelope fields (`page`, `page_size`, `total_count`) are on a deprecation path, not a perpetual exception.** Current forms remain accepted for backward compatibility within an existing API version; each resource migrates to `pageSize` / `totalCount` at its next Option B API-version bump (per the Phase 3 per-resource plan). On a freshly authored API version, use camelCase directly. The field `page` stays `page` under Option B (it's already a camelCase-compatible single-word identifier).
 
-**`page_size` properties must have `minimum: 1`.** A page size of zero is never valid. The validator enforces this (Rule 41) on all properties named `page_size`, `pagesize`, or `pageSize`.
+**`pageSize` / `page_size` properties must have `minimum: 1`.** A page size of zero is never valid. The validator enforces this (Rule 41) on all properties named `page_size`, `pagesize`, or `pageSize`.
 
 ## Per-Property Validation Constraints
 
@@ -359,9 +362,9 @@ These patterns are deliberate. Do not suggest changes during code review:
 1. **`SqlNullTime` vs `NullTime`** — Some entities use `SqlNullTime` for backward compatibility with v1beta1 and downstream GORM/Pop consumers. Do not suggest switching unless the entire entity is being migrated.
 2. **Core Go package** — All core types (both generated scalars like `Uuid`, `Time`, `Id` and manual utilities like `Map`, `NullTime`, `MapObject`) live in a single package: `github.com/meshery/schemas/models/core`. Generator output path overrides and Go import overrides map all schema core versions (`v1alpha1/core`, `v1beta1/core`, `v1beta2/core`) to this single package. Schema `x-go-type-import` for any core type must use `models/core` with alias `core`.
 3. **`x-enum-casing-exempt: true`** — Enums with this annotation contain published values that will never be lowercased (e.g., `PlanName`, `FeatureName`). Do not suggest lowercasing.
-4. **`page_size` / `total_count`** — Pagination envelope fields use snake_case as a published API contract, not because they are database-backed. Do not suggest `pageSize`/`totalCount`.
-5. **Deprecated v1beta1 constructs** — Files with `x-deprecated: true` are kept for backward compatibility. Known casing violations are fixed in v1beta2. Do not flag issues in deprecated constructs.
-6. **Same field name, different casing across constructs** — A property like `subType` may be camelCase in one construct (not DB-backed) and `sub_type` in another (DB-backed with `db: "sub_type"`). Both are correct. Casing is determined per-property by whether it maps to a database column in that specific construct, not by what other constructs use.
+4. **`page_size` / `total_count` — deprecation list, not a perpetual exception.** These snake_case envelope fields remain accepted for backward compatibility within an existing API version. Each resource migrates its pagination envelope to `pageSize` / `totalCount` at its next Option B API-version bump (per the [Phase 3 plan](docs/identifier-naming-option-b-migration.md)). On a newly authored API version, use camelCase directly. `page` stays `page` (already a camelCase-compatible single-word identifier).
+5. **Deprecated v1beta1 constructs** — Files with `x-deprecated: true` are kept for backward compatibility. Known casing violations are fixed in the next Option B-compliant version. Do not flag issues in deprecated constructs.
+6. **Post-Option-B: wire form is camelCase regardless of DB backing.** Under Option B, a property like `subType` is camelCase on every wire (JSON tag, OpenAPI property name, TS field) whether or not it is DB-backed. When it is DB-backed, the snake_case column name lives only in `x-oapi-codegen-extra-tags.db` (e.g., `db: "sub_type"`); the JSON tag stays `subType`. The pre-Option-B pattern of DB-backed fields using snake_case on the wire is retired per-resource across Phase 3; legacy resources that still publish `sub_type` on the wire migrate at their next API-version bump, not in-place.
 7. **`x-id-format: external`** — ID properties annotated with this hold external system identifiers (e.g., Stripe IDs) that are not UUIDs. The validator skips `format: uuid` enforcement for these. Do not remove the annotation or add `format: uuid`.
 
 ## Common Mistakes to Avoid
@@ -390,7 +393,8 @@ These patterns are deliberate. Do not suggest changes during code review:
 22. ❌ Template files with wrong value types — if schema says `type: array`, use `[]` not `{}`; if `type: string`, use `""` not `{}`
 23. ❌ Adding `format: uuid` to ID properties that hold external system identifiers (Stripe IDs, etc.) — use `x-id-format: external` instead
 24. ❌ Setting `minimum: 0` on page-size properties — page size must be at least 1
-23. ❌ Omitting `tags` from operations — every operation must have at least one tag for API documentation and client generation
+25. ❌ Omitting `tags` from operations — every operation must have at least one tag for API documentation and client generation
+26. ❌ Introducing a `json:` tag that matches the `db:` tag on a new DB-backed field — under Option B, wire is camel and DB is snake; they differ by design on DB-backed fields. `db: "user_id"` pairs with `json: "userId"`, never `json: "user_id"`.
 
 ## Checklist for Schema Changes
 
@@ -420,6 +424,25 @@ These patterns are deliberate. Do not suggest changes during code review:
 - [ ] (New property) ID properties have `format: uuid` (or `$ref` to UUID type), OR `x-id-format: external` if they hold non-UUID external identifiers
 - [ ] (New property) Page-size properties have `minimum: 1`
 - [ ] (New endpoint) Operation has at least one `tags` entry matching the construct's top-level tag definition
+- [ ] (New property, Option B) JSON tag and OpenAPI schema property name are camelCase **regardless of DB backing**; when DB-backed, the snake_case column name lives only in `x-oapi-codegen-extra-tags.db` (and must differ from the `json:` tag)
+- [ ] (New resource version) Pagination envelope uses `pageSize` / `totalCount` (not `page_size` / `total_count`) — the deprecated forms are accepted only within existing API versions until Phase 3 migrates each resource
+
+## Option B migration
+
+This repository is mid-migration to **Option B** identifier naming. The authoritative execution plan lives at [`docs/identifier-naming-option-b-migration.md`](docs/identifier-naming-option-b-migration.md) and is the operative document for the migration — all contributors (human and AI agents) must read it before making any schema-aware change.
+
+**The contract in one sentence:** *Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.*
+
+The migration is per-resource: each resource gets a new API version with fully camelCase JSON tags, and its previous version is deprecated for one release cycle before being removed. Do not recase fields in-place inside an already-published API version — introduce a new version instead. See §11 of the plan for the orchestration DAG, §9 for the per-resource inventory, and §14 for the `AGENTS.md` / `CLAUDE.md` boilerplate every downstream repo must adopt.
+
+Baseline metrics and the per-resource consumer graph captured in Phase 0 live under [`validation/baseline/`](validation/baseline/) and can be regenerated with:
+
+```bash
+make baseline-field-count
+make baseline-tag-divergence  MESHERY_REPO=../meshery CLOUD_REPO=../meshery-cloud
+make baseline-consumer-audit  MESHERY_REPO=../meshery CLOUD_REPO=../meshery-cloud
+make baseline-consumer-graph  MESHERY_REPO=../meshery CLOUD_REPO=../meshery-cloud EXTENSIONS_REPO=../meshery-extensions
+```
 
 ## Questions?
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ Before opening a PR, verify:
 
 ## Naming conventions
 
-- Property names: for **Option B–compliant (new) API versions**, use **camelCase on the wire, uniformly.** New schema properties and their JSON tags use `camelCase`. For DB-backed fields, the `x-oapi-codegen-extra-tags.db` tag carries the snake_case DB column name separately from the wire identifier — the ORM layer is the sole translation boundary. For an already-published API version that publishes `snake_case` on the wire, additions to that same version must preserve the version's published wire casing until the resource is version-bumped; do not perform partial casing migrations within a version (see §Casing rules at a glance and the [Option B plan](docs/identifier-naming-option-b-migration.md)).
+- Property names: for **newly authored API versions**, use **camelCase on the wire, uniformly.** New schema properties and their JSON tags use `camelCase`. For DB-backed fields, the `x-oapi-codegen-extra-tags.db` tag carries the snake_case DB column name separately from the wire identifier — the ORM layer is the sole translation boundary. For an already-published API version that publishes `snake_case` on the wire, additions to that same version must preserve the version's published wire casing until the resource is version-bumped; do not perform partial casing migrations within a version (see §Casing rules at a glance and the [identifier-naming migration plan](docs/identifier-naming-migration.md)).
 - ID-suffix fields: `lowerCamelCase` + `Id` (`modelId`, `registrantId`)
 - New enum values: lowercase words (`enabled`, `ignored`, `duplicate`); preserve published enum literals as-is within the same API version
 - Object names: singular nouns (`model`, `component`, `design`)
@@ -148,9 +148,9 @@ Before opening a PR, verify:
 
 ## Casing rules at a glance
 
-Within a given API version / resource version, every element has exactly one correct casing. The table below is the single authoritative reference for **Option B–compliant (new) versions.** Already-published legacy API versions retain their published wire casing until the resource receives its next Option B API-version bump — do not recase their fields in-place.
+Within a given API version / resource version, every element has exactly one correct casing. The table below is the single authoritative reference for **newly authored (canonical-casing) API versions.** Already-published legacy API versions retain their published wire casing until the resource receives its next canonical-casing version bump — do not recase their fields in-place.
 
-**The one-sentence rule (Option B target state):** *Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.*
+**The one-sentence rule (target state):** *Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.*
 
 | Layer / element | Casing | Example | Counter-example |
 |---|---|---|---|
@@ -169,13 +169,13 @@ Within a given API version / resource version, every element has exactly one cor
 | Go type names | PascalCase (generated) | `Connection`, `KeychainPayload` | — |
 | TypeScript type names | PascalCase (generated) | `Connection`, `KeychainPayload` | — |
 
-**The database naming is the ORM boundary, not a wire-format dictator.** In Option B–compliant API versions, every JSON tag / schema property name — DB-backed or not — is camelCase. For legacy published API versions that publish snake_case on the wire, retain the published wire casing until that resource receives its next API-version bump; do not "fix" snake_case wire properties in-place. In Option B–compliant versions, when a property is DB-backed, the snake_case DB column name lives *only* in `x-oapi-codegen-extra-tags.db` (and in the generated Go field's `db:` struct tag); it does not propagate to the JSON tag, the OpenAPI schema property name, URL parameters, or any other wire form. On DB-backed fields the `json:` and `db:` tags differ by design.
+**The database naming is the ORM boundary, not a wire-format dictator.** In newly authored (canonical-casing) API versions, every JSON tag / schema property name — DB-backed or not — is camelCase. For legacy published API versions that publish snake_case on the wire, retain the published wire casing until that resource receives its next API-version bump; do not "fix" snake_case wire properties in-place. In canonical-casing versions, when a property is DB-backed, the snake_case DB column name lives *only* in `x-oapi-codegen-extra-tags.db` (and in the generated Go field's `db:` struct tag); it does not propagate to the JSON tag, the OpenAPI schema property name, URL parameters, or any other wire form. On DB-backed fields the `json:` and `db:` tags differ by design.
 
-**Partial casing migrations are forbidden.** Do not rename selected fields within the same resource from snake_case to camelCase while leaving other published fields unchanged. If the wire format must change, introduce a new API version and migrate the resource consistently there. See the [Option B migration plan](docs/identifier-naming-option-b-migration.md) for the per-resource rollout.
+**Partial casing migrations are forbidden.** Do not rename selected fields within the same resource from snake_case to camelCase while leaving other published fields unchanged. If the wire format must change, introduce a new API version and migrate the resource consistently there. See the [identifier-naming migration plan](docs/identifier-naming-migration.md) for the per-resource rollout.
 
 **Existing enum wire values are compatibility-sensitive.** Use lowercase for newly introduced enum literals, but do not recase published enum values in-place within the same API version. The validator exempts legacy enum values that already exist on the baseline branch.
 
-**Pagination envelope fields (`page`, `page_size`, `total_count`) are on a deprecation path, not a perpetual exception.** Current forms remain accepted for backward compatibility within an existing API version; each resource migrates to `pageSize` / `totalCount` at its next Option B API-version bump (per the Phase 3 per-resource plan). On a freshly authored API version, use camelCase directly. The field `page` stays `page` under Option B (it's already a camelCase-compatible single-word identifier).
+**Pagination envelope fields (`page`, `page_size`, `total_count`) are on a deprecation path, not a perpetual exception.** Current forms remain accepted for backward compatibility within an existing API version; each resource migrates to `pageSize` / `totalCount` at its next canonical-casing API-version bump (per the Phase 3 per-resource plan). On a freshly authored API version, use camelCase directly. The field `page` stays `page` under the canonical contract (it's already a camelCase-compatible single-word identifier).
 
 **`pageSize` / `page_size` properties must have `minimum: 1`.** A page size of zero is never valid. The validator enforces this (Rule 41) on all properties named `page_size`, `pagesize`, or `pageSize`.
 
@@ -363,9 +363,9 @@ These patterns are deliberate. Do not suggest changes during code review:
 1. **`SqlNullTime` vs `NullTime`** — Some entities use `SqlNullTime` for backward compatibility with v1beta1 and downstream GORM/Pop consumers. Do not suggest switching unless the entire entity is being migrated.
 2. **Core Go package** — All core types (both generated scalars like `Uuid`, `Time`, `Id` and manual utilities like `Map`, `NullTime`, `MapObject`) live in a single package: `github.com/meshery/schemas/models/core`. Generator output path overrides and Go import overrides map all schema core versions (`v1alpha1/core`, `v1beta1/core`, `v1beta2/core`) to this single package. Schema `x-go-type-import` for any core type must use `models/core` with alias `core`.
 3. **`x-enum-casing-exempt: true`** — Enums with this annotation contain published values that will never be lowercased (e.g., `PlanName`, `FeatureName`). Do not suggest lowercasing.
-4. **`page_size` / `total_count` — deprecation list, not a perpetual exception.** These snake_case envelope fields remain accepted for backward compatibility within an existing API version. Each resource migrates its pagination envelope to `pageSize` / `totalCount` at its next Option B API-version bump (per the [Phase 3 plan](docs/identifier-naming-option-b-migration.md)). On a newly authored API version, use camelCase directly. `page` stays `page` (already a camelCase-compatible single-word identifier).
-5. **Deprecated v1beta1 constructs** — Files with `x-deprecated: true` are kept for backward compatibility. Known casing violations are fixed in the next Option B-compliant version. Do not flag issues in deprecated constructs.
-6. **Post-Option-B: wire form is camelCase regardless of DB backing.** Under Option B, a property like `subType` is camelCase on every wire (JSON tag, OpenAPI property name, TS field) whether or not it is DB-backed. When it is DB-backed, the snake_case column name lives only in `x-oapi-codegen-extra-tags.db` (e.g., `db: "sub_type"`); the JSON tag stays `subType`. The pre-Option-B pattern of DB-backed fields using snake_case on the wire is retired per-resource across Phase 3; legacy resources that still publish `sub_type` on the wire migrate at their next API-version bump, not in-place.
+4. **`page_size` / `total_count` — deprecation list, not a perpetual exception.** These snake_case envelope fields remain accepted for backward compatibility within an existing API version. Each resource migrates its pagination envelope to `pageSize` / `totalCount` at its next canonical-casing API-version bump (per the [Phase 3 plan](docs/identifier-naming-migration.md)). On a newly authored API version, use camelCase directly. `page` stays `page` (already a camelCase-compatible single-word identifier).
+5. **Deprecated v1beta1 constructs** — Files with `x-deprecated: true` are kept for backward compatibility. Known casing violations are fixed in the next canonical-casing version. Do not flag issues in deprecated constructs.
+6. **Target-state wire form: camelCase regardless of DB backing.** Under the canonical contract, a property like `subType` is camelCase on every wire (JSON tag, OpenAPI property name, TS field) whether or not it is DB-backed. When it is DB-backed, the snake_case column name lives only in `x-oapi-codegen-extra-tags.db` (e.g., `db: "sub_type"`); the JSON tag stays `subType`. The legacy pattern of DB-backed fields using snake_case on the wire is retired per-resource across Phase 3; legacy resources that still publish `sub_type` on the wire migrate at their next API-version bump, not in-place.
 7. **`x-id-format: external`** — ID properties annotated with this hold external system identifiers (e.g., Stripe IDs) that are not UUIDs. The validator skips `format: uuid` enforcement for these. Do not remove the annotation or add `format: uuid`.
 
 ## Common Mistakes to Avoid
@@ -395,7 +395,7 @@ These patterns are deliberate. Do not suggest changes during code review:
 23. ❌ Adding `format: uuid` to ID properties that hold external system identifiers (Stripe IDs, etc.) — use `x-id-format: external` instead
 24. ❌ Setting `minimum: 0` on page-size properties — page size must be at least 1
 25. ❌ Omitting `tags` from operations — every operation must have at least one tag for API documentation and client generation
-26. ❌ In Option B–compliant / new-version work, introducing a `json:` tag that matches the `db:` tag on a new DB-backed field — under Option B wire is camel and DB is snake, so they differ by design on DB-backed fields. `db: "user_id"` pairs with `json: "userId"`, never `json: "user_id"`. Pre–Option B / legacy constructs may intentionally retain matching `json:` and `db:` tags for wire compatibility and should not be flagged on that basis alone.
+26. ❌ In newly authored / canonical-casing API-version work, introducing a `json:` tag that matches the `db:` tag on a new DB-backed field — under the canonical contract wire is camel and DB is snake, so they differ by design on DB-backed fields. `db: "user_id"` pairs with `json: "userId"`, never `json: "user_id"`. Legacy published constructs may intentionally retain matching `json:` and `db:` tags for wire compatibility and should not be flagged on that basis alone.
 
 ## Checklist for Schema Changes
 
@@ -425,18 +425,18 @@ These patterns are deliberate. Do not suggest changes during code review:
 - [ ] (New property) ID properties have `format: uuid` (or `$ref` to UUID type), OR `x-id-format: external` if they hold non-UUID external identifiers
 - [ ] (New property) Page-size properties have `minimum: 1`
 - [ ] (New endpoint) Operation has at least one `tags` entry matching the construct's top-level tag definition
-- [ ] (New property, Option B) JSON tag and OpenAPI schema property name are camelCase **regardless of DB backing**; when DB-backed, the snake_case column name lives only in `x-oapi-codegen-extra-tags.db` (and must differ from the `json:` tag)
+- [ ] (New property, canonical-casing version) JSON tag and OpenAPI schema property name are camelCase **regardless of DB backing**; when DB-backed, the snake_case column name lives only in `x-oapi-codegen-extra-tags.db` (and must differ from the `json:` tag)
 - [ ] (New resource version) Pagination envelope uses `pageSize` / `totalCount` (not `page_size` / `total_count`) — the deprecated forms are accepted only within existing API versions until Phase 3 migrates each resource
 
-## Option B migration
+## Identifier-naming migration (in flight)
 
-This repository is mid-migration to **Option B** identifier naming. The authoritative execution plan lives at [`docs/identifier-naming-option-b-migration.md`](docs/identifier-naming-option-b-migration.md) and is the operative document for the migration — all contributors (human and AI agents) must read it before making any schema-aware change.
+This repository is mid-migration to a uniform **camelCase-on-the-wire** identifier-naming contract. The authoritative execution plan lives at [`docs/identifier-naming-migration.md`](docs/identifier-naming-migration.md) and is the operative document for the migration — all contributors (human and AI agents) must read it before making any schema-aware change.
 
 **The contract in one sentence:** *Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.*
 
 The migration is per-resource: each resource gets a new API version with fully camelCase JSON tags, and its previous version is deprecated for one release cycle before being removed. Do not recase fields in-place inside an already-published API version — introduce a new version instead. See §11 of the plan for the orchestration DAG, §9 for the per-resource inventory, and §14 for the `AGENTS.md` / `CLAUDE.md` boilerplate every downstream repo must adopt.
 
-**Validator catch-up is in flight.** This section describes the target contract. The schema validator still enforces several pre–Option B rules at `SeverityBlocking` — in particular Rule 32 requires DB-backed property names to match their snake_case `db:` tag, and Rule 33 forbids `pageSize` / `totalCount`. Phases 1.B (Rule 6 inversion / Rule 32 retirement) and 1.E (Rule 4 query-parameter extension) invert those rules so the doc and validator agree. Until those phases land, new `camelCase` wire forms on DB-backed fields will trip the validator at CI; file them under Phase 3's per-resource rollout rather than introducing them in an existing version.
+**Validator catch-up is in flight.** This section describes the target contract. The schema validator still enforces several legacy rules at `SeverityBlocking` — in particular Rule 32 requires DB-backed property names to match their snake_case `db:` tag, and Rule 33 forbids `pageSize` / `totalCount`. Phases 1.B (Rule 6 inversion / Rule 32 retirement) and 1.E (Rule 4 query-parameter extension) invert those rules so the doc and validator agree. Until those phases land, new `camelCase` wire forms on DB-backed fields will trip the validator at CI; file them under Phase 3's per-resource rollout rather than introducing them in an existing version.
 
 Baseline metrics and the per-resource consumer graph captured in Phase 0 live under [`validation/baseline/`](validation/baseline/) and can be regenerated with:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ Before opening a PR, verify:
 
 ## Naming conventions
 
-- Property names: **camelCase on the wire, uniformly.** New schema properties and their JSON tags use `camelCase`. For DB-backed fields, the `x-oapi-codegen-extra-tags.db` tag carries the snake_case DB column name separately from the wire identifier — the ORM layer is the sole translation boundary.
+- Property names: for **Option B–compliant (new) API versions**, use **camelCase on the wire, uniformly.** New schema properties and their JSON tags use `camelCase`. For DB-backed fields, the `x-oapi-codegen-extra-tags.db` tag carries the snake_case DB column name separately from the wire identifier — the ORM layer is the sole translation boundary. For an already-published API version that publishes `snake_case` on the wire, additions to that same version must preserve the version's published wire casing until the resource is version-bumped; do not perform partial casing migrations within a version (see §Casing rules at a glance and the [Option B plan](docs/identifier-naming-option-b-migration.md)).
 - ID-suffix fields: `lowerCamelCase` + `Id` (`modelId`, `registrantId`)
 - New enum values: lowercase words (`enabled`, `ignored`, `duplicate`); preserve published enum literals as-is within the same API version
 - Object names: singular nouns (`model`, `component`, `design`)
@@ -148,9 +148,9 @@ Before opening a PR, verify:
 
 ## Casing rules at a glance
 
-Every element in the API has exactly one correct casing. The table below is the single authoritative reference.
+Within a given API version / resource version, every element has exactly one correct casing. The table below is the single authoritative reference for **Option B–compliant (new) versions.** Already-published legacy API versions retain their published wire casing until the resource receives its next Option B API-version bump — do not recase their fields in-place.
 
-**The one-sentence rule:** *Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.*
+**The one-sentence rule (Option B target state):** *Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.*
 
 | Layer / element | Casing | Example | Counter-example |
 |---|---|---|---|
@@ -162,13 +162,14 @@ Every element in the API has exactly one correct casing. The table below is the 
 | `components/schemas` type names | PascalCase | `ModelDefinition`, `KeychainPayload` | ~~`modelDefinition`~~ |
 | File and folder names | lowercase | `api.yml`, `keychain.yaml` | ~~`Keychain.yaml`~~ |
 | URL path segments | kebab-case, plural nouns | `/api/role-holders`, `/api/workspaces` | ~~`/api/roleHolders`~~ |
-| URL path + query parameters | `camelCase + Id` | `{orgId}`, `?userId=…`, `?workspaceId=…` | ~~`{orgID}`~~, ~~`{org_id}`~~ |
+| URL path params + ID-like query params | `camelCase + Id` | `{orgId}`, `?userId=…`, `?workspaceId=…` | ~~`{orgID}`~~, ~~`{org_id}`~~, ~~`?workspace_id=…`~~ |
+| Shared pagination/search/sort/filter query params | preserve published parameter name | `?page=…`, `?pagesize=…`, `?search=…`, `?order=…`, `?filter=…` | ~~`?pageSize=…`~~ (until per-resource version bump) |
 | `operationId` | lower camelCase verbNoun | `getAllRoles`, `createWorkspace`, `getWorkspaces` | ~~`GetAllRoles`~~, ~~`get_all_roles`~~ |
 | TypeScript property / RTK arg | camelCase | `response.userId`, `queryArg.orgId` | ~~`response.user_id`~~, ~~`queryArg.orgID`~~ |
 | Go type names | PascalCase (generated) | `Connection`, `KeychainPayload` | — |
 | TypeScript type names | PascalCase (generated) | `Connection`, `KeychainPayload` | — |
 
-**The database naming is the ORM boundary, not a wire-format dictator.** Every JSON tag on every property — DB-backed or not — is camelCase. When a property is DB-backed, the snake_case DB column name lives *only* in `x-oapi-codegen-extra-tags.db` (and in the generated Go field's `db:` struct tag); it does not propagate to the JSON tag, the OpenAPI schema property name, URL parameters, or any other wire form. On DB-backed fields the `json:` and `db:` tags differ by design.
+**The database naming is the ORM boundary, not a wire-format dictator.** In Option B–compliant API versions, every JSON tag / schema property name — DB-backed or not — is camelCase. For legacy published API versions that publish snake_case on the wire, retain the published wire casing until that resource receives its next API-version bump; do not "fix" snake_case wire properties in-place. In Option B–compliant versions, when a property is DB-backed, the snake_case DB column name lives *only* in `x-oapi-codegen-extra-tags.db` (and in the generated Go field's `db:` struct tag); it does not propagate to the JSON tag, the OpenAPI schema property name, URL parameters, or any other wire form. On DB-backed fields the `json:` and `db:` tags differ by design.
 
 **Partial casing migrations are forbidden.** Do not rename selected fields within the same resource from snake_case to camelCase while leaving other published fields unchanged. If the wire format must change, introduce a new API version and migrate the resource consistently there. See the [Option B migration plan](docs/identifier-naming-option-b-migration.md) for the per-resource rollout.
 
@@ -394,7 +395,7 @@ These patterns are deliberate. Do not suggest changes during code review:
 23. ❌ Adding `format: uuid` to ID properties that hold external system identifiers (Stripe IDs, etc.) — use `x-id-format: external` instead
 24. ❌ Setting `minimum: 0` on page-size properties — page size must be at least 1
 25. ❌ Omitting `tags` from operations — every operation must have at least one tag for API documentation and client generation
-26. ❌ Introducing a `json:` tag that matches the `db:` tag on a new DB-backed field — under Option B, wire is camel and DB is snake; they differ by design on DB-backed fields. `db: "user_id"` pairs with `json: "userId"`, never `json: "user_id"`.
+26. ❌ In Option B–compliant / new-version work, introducing a `json:` tag that matches the `db:` tag on a new DB-backed field — under Option B wire is camel and DB is snake, so they differ by design on DB-backed fields. `db: "user_id"` pairs with `json: "userId"`, never `json: "user_id"`. Pre–Option B / legacy constructs may intentionally retain matching `json:` and `db:` tags for wire compatibility and should not be flagged on that basis alone.
 
 ## Checklist for Schema Changes
 
@@ -434,6 +435,8 @@ This repository is mid-migration to **Option B** identifier naming. The authorit
 **The contract in one sentence:** *Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary.*
 
 The migration is per-resource: each resource gets a new API version with fully camelCase JSON tags, and its previous version is deprecated for one release cycle before being removed. Do not recase fields in-place inside an already-published API version — introduce a new version instead. See §11 of the plan for the orchestration DAG, §9 for the per-resource inventory, and §14 for the `AGENTS.md` / `CLAUDE.md` boilerplate every downstream repo must adopt.
+
+**Validator catch-up is in flight.** This section describes the target contract. The schema validator still enforces several pre–Option B rules at `SeverityBlocking` — in particular Rule 32 requires DB-backed property names to match their snake_case `db:` tag, and Rule 33 forbids `pageSize` / `totalCount`. Phases 1.B (Rule 6 inversion / Rule 32 retirement) and 1.E (Rule 4 query-parameter extension) invert those rules so the doc and validator agree. Until those phases land, new `camelCase` wire forms on DB-backed fields will trip the validator at CI; file them under Phase 3's per-resource rollout rather than introducing them in an existing version.
 
 Baseline metrics and the per-resource consumer graph captured in Phase 0 live under [`validation/baseline/`](validation/baseline/) and can be regenerated with:
 

--- a/cmd/phase0-consumer-graph/main.go
+++ b/cmd/phase0-consumer-graph/main.go
@@ -2,7 +2,7 @@
 // graph across the downstream repos and produces the Phase 0 Agent 0.D
 // baseline (validation/baseline/consumer-graph.json) used by Phase 3 per-
 // resource sequencing in the Option B identifier-naming migration
-// (docs/identifier-naming-option-b-migration.md §6, §9).
+// (docs/identifier-naming-migration.md §6, §9).
 //
 // Two kinds of imports are attributed:
 //

--- a/cmd/phase0-field-count/main.go
+++ b/cmd/phase0-field-count/main.go
@@ -19,7 +19,7 @@
 //
 // The report is the input to Phase 1 rule authoring and Phase 3 sequencing in
 // the Option B identifier-naming migration
-// (docs/identifier-naming-option-b-migration.md §6).
+// (docs/identifier-naming-migration.md §6).
 package main
 
 import (

--- a/cmd/phase0-tag-divergence/main.go
+++ b/cmd/phase0-tag-divergence/main.go
@@ -2,7 +2,7 @@
 // meshery-cloud server/models directories and produces the Phase 0 Agent 0.B
 // tag-divergence baseline (validation/baseline/tag-divergence.json) used by
 // the Option B identifier-naming migration
-// (docs/identifier-naming-option-b-migration.md §6).
+// (docs/identifier-naming-migration.md §6).
 //
 // Each scanned field is evaluated against three criteria from Agent 0.B's
 // charter:

--- a/docs/identifier-naming-migration.md
+++ b/docs/identifier-naming-migration.md
@@ -145,7 +145,7 @@ Every PR must include:
 - 1–3 bullets describing the change.
 
 ## Why
-- The governance rationale, linked to §<section> of identifier-naming-option-b-migration.md
+- The governance rationale, linked to §<section> of identifier-naming-migration.md
 
 ## Changes
 - File-level diff summary.
@@ -232,7 +232,7 @@ Serial execution; each depends on the prior landing. All work in `meshery/schema
 **Specific changes:**
 1. In `§ Casing rules at a glance`, replace the "DB-backed / DB-mirrored fields | exact snake_case db column name" row with: "JSON tag on DB-backed fields | **camelCase**; `db:` tag in `x-oapi-codegen-extra-tags` carries the snake_case DB column name separately".
 2. In `§ Intentional Design Decisions (Do Not Flag)`, convert `page_size`/`total_count` from a perpetual exception to a **deprecation list** — current forms accepted; migrates to `pageSize`/`totalCount` at the next API-version bump per resource.
-3. Add a new `§ Option B migration` section linking to this plan at `docs/identifier-naming-option-b-migration.md` within the same repo as the operative execution document.
+3. Add a new `§ Option B migration` section linking to this plan at `docs/identifier-naming-migration.md` within the same repo as the operative execution document.
 4. Add to `§ Common Mistakes to Avoid`: "❌ Introducing a `json:` tag that matches the `db:` tag on a new field — wire is camel, DB is snake; they differ by design on DB-backed fields."
 5. Update `§ Checklist for Schema Changes` to reflect the inverted rule.
 
@@ -441,7 +441,7 @@ All agents in this phase pin their target repo's `@meshery/schemas` dependency t
 
 ### Agent 2.E — Meshery-cloud `ContentID` JSON tag alignment
 **Repo:** `layer5io/meshery-cloud`  
-**Branch:** `fix/content-id-json-tag-option-b`  
+**Branch:** `fix/content-id-json-tag-alignment`  
 **Charter:** `CatalogRequest.ContentID` at `server/models/users.go:246` currently declares `json:"contentId" db:"content_id"`. Under Option B: `ContentID` Go field + `json:"contentId"` + `db:"content_id"` — this is actually **already correct** under Option B. Agent's task is to verify, and if correct, mark the previously-flagged finding as resolved.
 
 **Testing:** `go test ./...` green; search schemas consumer-audit output for `CatalogRequest`/`ContentID` — no findings.
@@ -468,7 +468,7 @@ All agents in this phase pin their target repo's `@meshery/schemas` dependency t
 
 ### Agent 2.G — Kanvas `catalog.ts` RTK case-flip removal + `designs.ts` wrapper alignment
 **Repo:** `layer5labs/meshery-extensions`  
-**Branch:** `fix/kanvas-rtk-option-b-alignment`  
+**Branch:** `fix/kanvas-rtk-camelcase-alignment`  
 **Charter:** Two related Kanvas fixes that go together:
 1. `meshmap/src/rtk-query/catalog.ts:110` `getWorkspaceForCatalog` — remove the `orgID: queryArg.orgId` transform; emit `orgId` in the URL directly.
 2. `meshmap/src/rtk-query/catalog.ts:58-59` `getPatternsPerUser` — unify to Option B canonical names.
@@ -716,7 +716,7 @@ The remaining 21 agents follow the template in §9.2 with per-resource file path
 ### Agent 4.E — Before/after impact report publication
 **Charter:** Re-run the baseline agents (0.A–0.D) to produce "after" numbers. Publish the before/after report per §15 of this plan; commit to `meshery/schemas/docs/` as the governance artifact.
 
-**Files:** `meshery/schemas/docs/option-b-impact-report.md`.
+**Files:** `meshery/schemas/docs/identifier-naming-impact-report.md`.
 
 **Acceptance:** Report published; metrics confirm §2 objectives met.
 
@@ -868,7 +868,7 @@ discrepancies as issues against `meshery/schemas`, not locally.
 ### Migration
 
 The Option B migration is tracked at
-`meshery/schemas/docs/identifier-naming-option-b-migration.md`. All
+`meshery/schemas/docs/identifier-naming-migration.md`. All
 contributors — human and AI agents — MUST read this plan before making
 any schema-aware change.
 ```
@@ -985,7 +985,7 @@ You are Phase 3.{Resource} agent.
 CHARTER
 Migrate the {resource} resource from {old-version} to {new-version}
 under the Option B contract defined in
-meshery/schemas/docs/identifier-naming-option-b-migration.md §1.
+meshery/schemas/docs/identifier-naming-migration.md §1.
 
 STEPS
 1. In /Users/l/code/schemas, create schemas/constructs/{new-version}/{resource}/
@@ -1061,7 +1061,7 @@ ACCEPTANCE
 | — SDK (cross-boundary) | `meshmap/src/globals/mesherySdk.ts` | Event-type ↔ dispatcher boundary |
 | — GraphQL plugin | `meshmap/graphql/` | Go side; `schema.graphql` |
 | — CLAUDE.md | `CLAUDE.md` | Project instructions |
-| — Plan (this file) | `docs/identifier-naming-option-b-migration.md` | Canonical execution reference |
+| — Plan (this file) | `docs/identifier-naming-migration.md` | Canonical execution reference |
 
 ---
 

--- a/docs/identifier-naming-plan-meshery-cloud.md
+++ b/docs/identifier-naming-plan-meshery-cloud.md
@@ -131,7 +131,7 @@
 
 ## 10. Reference
 
-- Full detailed plan draft (for reference; not operative): `schemas/docs/identifier-naming-option-b-migration.md`
+- Full detailed plan draft (for reference; not operative): `schemas/docs/identifier-naming-migration.md`
 - Source of truth: `schemas/AGENTS.md § Casing rules at a glance` (post Phase 1.A amendment)
 - Cloud consumer-audit input: `schemas/validation/consumer_echo.go` (parses `server/router/router.go`)
 - Related prior PRs: #18856 (patternData wrapper), #18858 (JSON error body — sets precedent for wire-error-shape normalization).

--- a/docs/identifier-naming-plan-meshery-extensions.md
+++ b/docs/identifier-naming-plan-meshery-extensions.md
@@ -122,7 +122,7 @@
 
 ## 10. Reference
 
-- Full detailed plan draft (for reference; not operative): `schemas/docs/identifier-naming-option-b-migration.md`
+- Full detailed plan draft (for reference; not operative): `schemas/docs/identifier-naming-migration.md`
 - Source of truth: `schemas/AGENTS.md § Casing rules at a glance` (post Phase 1.A amendment)
 - Kanvas Redux store setup (correctly uses schemas slices): `meshmap/src/redux/store.ts`
 - Prior PRs: #18856 (patternData wrapper precedent — sets the `designs.ts` target shape), #18857 (merged k8s panic fix — unrelated), #18858 (JSON error body — Meshery Server side).

--- a/docs/identifier-naming-plan-meshery.md
+++ b/docs/identifier-naming-plan-meshery.md
@@ -111,7 +111,7 @@
 
 ## 10. Reference
 
-- Full detailed plan draft (for reference; not the operative document): `schemas/docs/identifier-naming-option-b-migration.md`
+- Full detailed plan draft (for reference; not the operative document): `schemas/docs/identifier-naming-migration.md`
 - Source of truth: `schemas/AGENTS.md § Casing rules at a glance` (post Phase 1.A amendment)
 - Prior audit sub-reports in this session's transcript (meshery-cloud, meshery, meshery-extensions audits)
 - PR #18856 (patternData wrapper precedent), PR #18857 (merged k8s panic fix — unrelated), PR #18858 (JSON error body — Option B-adjacent)

--- a/docs/identifier-naming-session-kickoff.md
+++ b/docs/identifier-naming-session-kickoff.md
@@ -31,16 +31,16 @@ Sibling repos (for read/write during agent execution):
 
 Read these in order. Do not skip. Do not skim.
 
-1. `docs/identifier-naming-option-b-migration.md` — master plan. §1 defines the contract; §5 defines the Common Agent Protocol every sub-agent follows; §11 is the orchestration DAG; §14 is the per-repo AGENTS.md boilerplate to paste; §17 is the sign-off gate you check your work against.
-2. `docs/option-b-plan-meshery.md` — high-level handoff scoped to `meshery/meshery`.
-3. `docs/option-b-plan-meshery-cloud.md` — high-level handoff scoped to `layer5io/meshery-cloud`.
-4. `docs/option-b-plan-meshery-extensions.md` — high-level handoff scoped to `layer5labs/meshery-extensions`.
+1. `docs/identifier-naming-migration.md` — master plan. §1 defines the contract; §5 defines the Common Agent Protocol every sub-agent follows; §11 is the orchestration DAG; §14 is the per-repo AGENTS.md boilerplate to paste; §17 is the sign-off gate you check your work against.
+2. `docs/identifier-naming-plan-meshery.md` — high-level handoff scoped to `meshery/meshery`.
+3. `docs/identifier-naming-plan-meshery-cloud.md` — high-level handoff scoped to `layer5io/meshery-cloud`.
+4. `docs/identifier-naming-plan-meshery-extensions.md` — high-level handoff scoped to `layer5labs/meshery-extensions`.
 
 After reading, you understand: the contract, the phase DAG, the Common Agent Protocol, the divergences in each downstream repo, the dependency ordering.
 
 ## 4. State of record (cross-session)
 
-Persistent execution state lives in GitHub issues on `meshery/schemas`, labeled `option-b-migration`. Each issue is a phase with a checklist of sub-agents. Issue URLs:
+Persistent execution state lives in GitHub issues on `meshery/schemas`, labeled `identifier-naming-migration`. Each issue is a phase with a checklist of sub-agents. Issue URLs:
 
 - Phase 0 — Baseline metrics: https://github.com/meshery/schemas/issues/776
 - Phase 1 — Schemas governance + validator hardening: https://github.com/meshery/schemas/issues/777
@@ -59,7 +59,7 @@ Do not rely on Claude Code's in-session `TaskList` for cross-session state. The 
 
 ## 5. Bootstrap action (what to do after you've read §3)
 
-1. Run `gh issue list --repo meshery/schemas --label option-b-migration --state open`.
+1. Run `gh issue list --repo meshery/schemas --label identifier-naming-migration --state open`.
 2. Identify the lowest-priority-number phase that is not yet `completed`.
 3. Within that phase issue, identify the first unchecked sub-agent whose dependencies (per §11 of master plan's DAG) are satisfied.
 4. Claim it by posting a comment: `Claimed by session <short-session-id> at <ISO timestamp>.`
@@ -87,7 +87,7 @@ You do the task yourself when:
 - It requires cross-referencing multiple in-flight PRs.
 - It's an orchestration step (claiming issues, updating checkpoints).
 
-Sub-agents you spawn follow the same Common Agent Protocol. You give them the exact charter from the master plan (e.g., "Execute Agent 2.A as defined in §8 of `/Users/l/code/schemas/docs/identifier-naming-option-b-migration.md`") plus the acceptance criteria. You do not re-author their prompts from scratch.
+Sub-agents you spawn follow the same Common Agent Protocol. You give them the exact charter from the master plan (e.g., "Execute Agent 2.A as defined in §8 of `/Users/l/code/schemas/docs/identifier-naming-migration.md`") plus the acceptance criteria. You do not re-author their prompts from scratch.
 
 ## 7. Stop conditions — when to checkpoint and exit
 
@@ -107,9 +107,9 @@ Before exit, every in-flight PR must be pushed with current state. Leave nothing
 Before exiting any session:
 
 1. All local changes pushed; no uncommitted files except session scratch (`state.json`, `.claude/`).
-2. Every open PR labeled `option-b-migration` and with the phase label.
+2. Every open PR labeled `identifier-naming-migration` and with the phase label.
 3. Progress comment posted on the active phase issue: what landed (SHAs), what's in flight, what the next session should claim first.
-4. If a new risk or gap surfaced, update the relevant per-repo handoff doc (`docs/option-b-plan-*.md`) in a follow-up commit.
+4. If a new risk or gap surfaced, update the relevant per-repo handoff doc (`docs/identifier-naming-plan-*.md`) in a follow-up commit.
 
 ## 9. Do-not-do list
 
@@ -127,7 +127,7 @@ Before exiting any session:
 The first session after the governance PR merges has a one-time setup:
 
 1. Confirm the governance PR is merged on `meshery/schemas`.
-2. Confirm the 5 phase-tracking issues exist on `meshery/schemas` with the `option-b-migration` label.
+2. Confirm the 5 phase-tracking issues exist on `meshery/schemas` with the `identifier-naming-migration` label.
 3. Back-fill the governance PR URL in §4 above (this doc) via a follow-up commit.
 4. Then proceed per §5 — starting with Phase 0 baseline agents.
 
@@ -136,7 +136,7 @@ The first session after the governance PR merges has a one-time setup:
 In a fresh Claude Code session opened at `/Users/l/code/schemas`, paste:
 
 ```
-Read docs/option-b-session-kickoff.md and execute per §5 of the master plan it references.
+Read docs/identifier-naming-session-kickoff.md and execute per §5 of the master plan it references.
 ```
 
 No additional context required. The kickoff doc and master plan carry everything.


### PR DESCRIPTION
> ⚠️ **Human review required** — This PR amends the canonical governance doc (AGENTS.md / CLAUDE.md). Per master plan §5.3 and kickoff §9, auto-merge is disabled; a maintainer must review before merge.

## Summary
Implements Phase 1 Agent 1.A of the [Option B identifier-naming migration](../blob/master/docs/identifier-naming-option-b-migration.md). Doc-only change — validator rule behaviour does not move yet (Agent 1.B inverts `checkRule6ForAPI` next).

## Why
AGENTS.md is the authoritative convention doc consumed by every contributor (human and AI). Option B retires the "DB-backed → snake_case on wire" conditional in favour of uniform camelCase on the wire, with the `db:` tag as the only snake_case carrier. This PR aligns the doc with that contract so downstream PRs have a clear source of truth; the per-resource wire migration itself lives in Phase 3.

## Changes
Per the charter in master plan §7 Agent 1.A:

1. **§Casing rules at a glance** — rewritten as a per-layer canonical-form table led by the one-sentence rule *"Wire is camelCase everywhere; DB is snake_case; Go fields follow Go idiom; the ORM layer is the sole translation boundary."* The former "DB-backed → snake_case db column name" row is split into three explicit rows for DB column / Go field / JSON tag so the split is unambiguous.
2. **§Intentional Design Decisions item 4** — `page_size` / `total_count` is no longer a perpetual exception; it is a deprecation list. Existing API versions keep the snake forms; each resource migrates to `pageSize` / `totalCount` at its next API-version bump per Phase 3. `page` stays `page`.
3. **§Option B migration** — new top-level section linking the operative plan, stating the one-sentence contract, noting per-resource rollout, and listing the Phase 0 baseline `make baseline-*` reproduction commands.
4. **§Common Mistakes to Avoid item 26** — added "Introducing a `json:` tag that matches the `db:` tag on a new DB-backed field — wire is camel and DB is snake; they differ by design."
5. **§Checklist for Schema Changes** — added two Option-B-specific items (new-property camelCase regardless of DB backing; new-version pagination uses camelCase).

Adjacent clean-ups that fall out of the rewrite:
- **§Naming conventions** (property-names bullet) — now the camelCase-uniform rule.
- **§Intentional Design Decisions item 6** — the "same field name, different casing across constructs" rule is retired under Option B; text rewritten to describe the per-resource migration path instead.
- **§Intentional Design Decisions item 5** — "fixed in v1beta2" generalised to "fixed in the next Option B-compliant version" because several resources now target v1beta3+.

## Tests
- [x] Doc-only change; no test to add.
- [x] `make validate-schemas` — PASS (no blocking changes; doc change does not trip any rule).
- [x] `make audit-schemas` — shows only the pre-existing `MesheryViewPage` / `MesheryViewWithLocation` duplicate-structure advisories that were present on master before this PR.
- [x] `go test ./...` — PASS.
- [x] `go build ./...` — PASS.

## Docs
The PR IS the doc. No additional docs/ touch required; the new §Option B migration section explicitly points readers at `docs/identifier-naming-option-b-migration.md`.

## Migration impact
- Breaking: no (doc-only).
- API-version bump required: no.
- Consumer repos that must be updated: none (downstream AGENTS.md boilerplate adoption lives in Phase 4.C per master plan §14).

## Rollback
Revert the commit; AGENTS.md returns to its pre-amendment form. No downstream dependency.

## Acceptance (per charter)
- [x] Amendment merged — **awaiting human-review gate**.
- [x] Validator rules not yet changed but run green.