### PR TITLE
docs: finish dropping the "Option B" label across plan/kickoff/cmd bodies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,12 +112,12 @@ audit-schemas-style-full:
 audit-schemas-debt-full:
 	go run ./cmd/validate-schemas --warn --no-baseline --style-debt --contract-debt
 
-## Regenerate the Option B Phase 0 field-count baseline artifact
+## Regenerate the Phase 0 field-count baseline artifact
 .PHONY: baseline-field-count
 baseline-field-count:
 	go run ./cmd/phase0-field-count
 
-## Regenerate the Option B Phase 0 tag-divergence baseline artifact
+## Regenerate the Phase 0 tag-divergence baseline artifact
 ## (scans json/db struct tags in $(MESHERY_REPO) and $(CLOUD_REPO))
 .PHONY: baseline-tag-divergence
 baseline-tag-divergence:
@@ -125,7 +125,7 @@ baseline-tag-divergence:
 		$(if $(MESHERY_REPO),--meshery-repo=$(MESHERY_REPO)) \
 		$(if $(CLOUD_REPO),--cloud-repo=$(CLOUD_REPO))
 
-## Regenerate the Option B Phase 0 consumer-audit verbatim baseline
+## Regenerate the Phase 0 consumer-audit verbatim baseline
 ## (captures verbose make consumer-audit output against local sibling repos)
 .PHONY: baseline-consumer-audit
 baseline-consumer-audit:
@@ -146,7 +146,7 @@ baseline-consumer-audit:
 		exit $$status; \
 	fi
 
-## Regenerate the Option B Phase 0 consumer-dependency graph
+## Regenerate the Phase 0 consumer-dependency graph
 ## (Go + TS imports of schemas across all three downstream repos)
 .PHONY: baseline-consumer-graph
 baseline-consumer-graph:

--- a/cmd/phase0-consumer-graph/main.go
+++ b/cmd/phase0-consumer-graph/main.go
@@ -1,7 +1,7 @@
 // Command phase0-consumer-graph builds a per-resource consumer-dependency
 // graph across the downstream repos and produces the Phase 0 Agent 0.D
 // baseline (validation/baseline/consumer-graph.json) used by Phase 3 per-
-// resource sequencing in the Option B identifier-naming migration
+// resource sequencing in the identifier-naming migration
 // (docs/identifier-naming-migration.md §6, §9).
 //
 // Two kinds of imports are attributed:

--- a/cmd/phase0-field-count/main.go
+++ b/cmd/phase0-field-count/main.go
@@ -18,7 +18,7 @@
 //  2. otherwise, the OpenAPI property name itself.
 //
 // The report is the input to Phase 1 rule authoring and Phase 3 sequencing in
-// the Option B identifier-naming migration
+// the identifier-naming migration
 // (docs/identifier-naming-migration.md §6).
 package main
 

--- a/cmd/phase0-tag-divergence/main.go
+++ b/cmd/phase0-tag-divergence/main.go
@@ -1,7 +1,7 @@
 // Command phase0-tag-divergence scans Go struct tags across the meshery and
 // meshery-cloud server/models directories and produces the Phase 0 Agent 0.B
 // tag-divergence baseline (validation/baseline/tag-divergence.json) used by
-// the Option B identifier-naming migration
+// the identifier-naming migration
 // (docs/identifier-naming-migration.md §6).
 //
 // Each scanned field is evaluated against three criteria from Agent 0.B's
@@ -12,7 +12,7 @@
 //  2. Multiple JSON-tag conventions appear within a single struct (e.g., one
 //     field camelCase, another snake_case).
 //  3. The `json:` tag is ALL CAPS or contains an all-caps acronym token like
-//     `ID` / `URL` that Option B retires.
+//     `ID` / `URL` that the canonical contract retires.
 //
 // Output JSON is structured as a flat record list plus a summary of per-
 // classification counts, suitable for diff-auditing across the migration.
@@ -48,7 +48,7 @@ const (
 
 // classification flags a field against Agent 0.B's criteria. A field can
 // carry more than one flag; the zero value (an empty slice) means the field
-// is clean under Option B.
+// is clean under the canonical contract.
 type classification string
 
 const (
@@ -296,7 +296,7 @@ func scanFile(label, repoAbs, absPath string) ([]fieldRecord, int, error) {
 			dbName := tagName(dbRaw)
 
 			if len(field.Names) == 0 {
-				// Embedded / unnamed fields are not the target of Option B's
+				// Embedded / unnamed fields are not the target of the canonical contract's
 				// identifier-naming rules.
 				continue
 			}
@@ -364,7 +364,7 @@ func tagName(raw string) string {
 }
 
 // classify names the casing form of a tag token. See Agent 0.B's charter and
-// the Option B contract for the discriminators.
+// the canonical contract for the discriminators.
 func classify(s string) casingForm {
 	if s == "" {
 		return casingEmpty

--- a/cmd/phase0-tag-divergence/main_test.go
+++ b/cmd/phase0-tag-divergence/main_test.go
@@ -88,7 +88,7 @@ func TestClassifyFieldMismatches(t *testing.T) {
 		json, db string
 		want     []classification
 	}{
-		{"perfectly consistent camel+snake (Option B canonical)", "userId", "user_id",
+		{"perfectly consistent camel+snake (canonical)", "userId", "user_id",
 			[]classification{classJSONDBFormMismatch}}, // form differs (camel vs snake)
 		{"snake+snake (legacy)", "user_id", "user_id", nil},
 		{"value-name divergence", "type", "source_type",

--- a/docs/identifier-naming-migration.md
+++ b/docs/identifier-naming-migration.md
@@ -1,4 +1,4 @@
-# Identifier Naming Standardization — Option B Migration Plan
+# Identifier-Naming Standardization — Migration Plan
 
 **Canonical plan — fully executable by an orchestrated system of agents.**
 
@@ -7,7 +7,7 @@
 | Status | Active |
 | Authority | `meshery/schemas/AGENTS.md` after Phase 1.A |
 | Scope | `meshery/schemas`, `meshery/meshery`, `layer5io/meshery-cloud`, `layer5labs/meshery-extensions` |
-| Governance decision | Option B — camelCase on wire, snake_case only at the DB/ORM boundary |
+| Contract | camelCase on wire, snake_case only at the DB/ORM boundary |
 | Supersedes | Earlier three-layer audit report (the conditional "DB-backed → snake_case JSON tag" rule is retired) |
 | Effective | On merge of Phase 1.A |
 | Sunset | Old wire forms retired per resource over one release cycle after Phase 3 |
@@ -224,15 +224,15 @@ Baseline metrics collection. Read-only. Output drives Phase 1 rule authoring and
 
 Serial execution; each depends on the prior landing. All work in `meshery/schemas`.
 
-### Agent 1.A — `AGENTS.md` Option B amendment
-**Charter:** Replace `§ Casing rules at a glance`, `§ Intentional Design Decisions (Do Not Flag)`, and related paragraphs with the Option B contract from §1 of this plan.
+### Agent 1.A — `AGENTS.md` identifier-naming amendment
+**Charter:** Replace `§ Casing rules at a glance`, `§ Intentional Design Decisions (Do Not Flag)`, and related paragraphs with the canonical contract from §1 of this plan.
 
 **Files:** `meshery/schemas/AGENTS.md` (symlinked as `CLAUDE.md`).
 
 **Specific changes:**
 1. In `§ Casing rules at a glance`, replace the "DB-backed / DB-mirrored fields | exact snake_case db column name" row with: "JSON tag on DB-backed fields | **camelCase**; `db:` tag in `x-oapi-codegen-extra-tags` carries the snake_case DB column name separately".
 2. In `§ Intentional Design Decisions (Do Not Flag)`, convert `page_size`/`total_count` from a perpetual exception to a **deprecation list** — current forms accepted; migrates to `pageSize`/`totalCount` at the next API-version bump per resource.
-3. Add a new `§ Option B migration` section linking to this plan at `docs/identifier-naming-migration.md` within the same repo as the operative execution document.
+3. Add a new `§ Identifier-naming migration` section linking to this plan at `docs/identifier-naming-migration.md` within the same repo as the operative execution document.
 4. Add to `§ Common Mistakes to Avoid`: "❌ Introducing a `json:` tag that matches the `db:` tag on a new field — wire is camel, DB is snake; they differ by design on DB-backed fields."
 5. Update `§ Checklist for Schema Changes` to reflect the inverted rule.
 
@@ -254,9 +254,9 @@ Serial execution; each depends on the prior landing. All work in `meshery/schema
 
 **Testing:** `cd /Users/l/code/schemas && go test ./validation/ -run "TestCasing|TestRule6"` — green. `make validate-schemas` — current schemas will now surface a large number of violations; these get baselined in Agent 1.G.
 
-**Docs:** In the Go file, the docstring for `checkRule6ForAPI` documents the Option B inversion and links to `AGENTS.md § Option B migration`.
+**Docs:** In the Go file, the docstring for `checkRule6ForAPI` documents the camelCase-wire rule inversion and links to `AGENTS.md § Identifier-naming migration`.
 
-**Acceptance:** Tests pass; Rule 6 now flags the pre-Option-B schemas; baseline pending (1.G).
+**Acceptance:** Tests pass; Rule 6 now flags the legacy schemas; baseline pending (1.G).
 
 ### Agent 1.C — "Partial casing migrations forbidden" rule
 **Charter:** Author a new rule (call it Rule 45) that walks every `components/schemas/<Entity>` object and flags structs that mix JSON-tag conventions (some camel, some snake, some ALL CAPS) on their properties.
@@ -269,7 +269,7 @@ Serial execution; each depends on the prior landing. All work in `meshery/schema
 
 **Docs:** Rule description in the Go docstring references `AGENTS.md § Casing rules at a glance` and notes this rule catches the `MesheryPattern.OrgID json:"orgId"` + `WorkspaceID json:"workspace_id"` + `UserID json:"user_id"` class of drift.
 
-**Acceptance:** Rule 45 fires on fixtures; runs green against the post-Option-B schemas once Phase 3 completes.
+**Acceptance:** Rule 45 fires on fixtures; runs green against the post-migration schemas once Phase 3 completes.
 
 ### Agent 1.D — "Sibling-endpoint parameter parity" rule
 **Charter:** Author Rule 46 — when two sibling paths in the same API version follow the pattern `GET /api/<entity-plural>`, and one declares `$ref: "#/components/parameters/orgIdQuery"`, the sibling should too. Covers the workspaces-missing-`orgIdQuery` class of omission.
@@ -340,7 +340,7 @@ Serial execution; each depends on the prior landing. All work in `meshery/schema
 
 **Testing:** `npm pack` locally; inspect package contents; `go mod tidy` in a consumer repo against the new version.
 
-**Docs:** Release notes cover the Option B contract, link to this plan, note that Phase 2 downstream fixes depend on this version.
+**Docs:** Release notes cover the canonical contract, link to this plan, note that Phase 2 downstream fixes depend on this version.
 
 **Acceptance:** Version published; downstream repos can `npm install @meshery/schemas@<new-version>` and `go mod edit -require github.com/meshery/schemas@<new-tag>`.
 
@@ -442,11 +442,11 @@ All agents in this phase pin their target repo's `@meshery/schemas` dependency t
 ### Agent 2.E — Meshery-cloud `ContentID` JSON tag alignment
 **Repo:** `layer5io/meshery-cloud`  
 **Branch:** `fix/content-id-json-tag-alignment`  
-**Charter:** `CatalogRequest.ContentID` at `server/models/users.go:246` currently declares `json:"contentId" db:"content_id"`. Under Option B: `ContentID` Go field + `json:"contentId"` + `db:"content_id"` — this is actually **already correct** under Option B. Agent's task is to verify, and if correct, mark the previously-flagged finding as resolved.
+**Charter:** `CatalogRequest.ContentID` at `server/models/users.go:246` currently declares `json:"contentId" db:"content_id"`. Under the canonical contract: `ContentID` Go field + `json:"contentId"` + `db:"content_id"` — this is actually **already correct** under the canonical contract. Agent's task is to verify, and if correct, mark the previously-flagged finding as resolved.
 
 **Testing:** `go test ./...` green; search schemas consumer-audit output for `CatalogRequest`/`ContentID` — no findings.
 
-**Docs:** PR description explains that the original audit misclassified this as a violation; under Option B it is canonical.
+**Docs:** PR description explains that the original audit misclassified this as a violation; under the canonical contract it is canonical.
 
 **Acceptance:** Confirmed correct; no code change; baseline updated to retire the stale finding.
 
@@ -454,11 +454,11 @@ All agents in this phase pin their target repo's `@meshery/schemas` dependency t
 **Repo:** `layer5io/meshery-cloud`  
 **Branch:** `refactor/cloud-ui-api-dedup`  
 **Charter:** Audit each of the 30+ hand-rolled endpoints in `meshery-cloud/ui/api/api.ts`. For each:
-1. Check if `@meshery/schemas/cloudApi` exposes an equivalent endpoint (same URL + method + params, under Option B).
+1. Check if `@meshery/schemas/cloudApi` exposes an equivalent endpoint (same URL + method + params, under the canonical contract).
 2. If yes: displace — import and re-export the generated hook; remove the hand-rolled definition.
 3. If no (legitimate customization): document the reason inline (`// LOCAL: <reason>`) and open a follow-up issue in `meshery/schemas` to consider exporting.
 
-**Additional:** Remove the input-`orgId` → URL-`orgID` case-flip transformation at lines 1264, 1272, 1201, ~96. Under Option B both sides of the wire are `orgId`.
+**Additional:** Remove the input-`orgId` → URL-`orgID` case-flip transformation at lines 1264, 1272, 1201, ~96. Under the canonical contract both sides of the wire are `orgId`.
 
 **Testing:** `npm run build`, `npm test`, `eslint --max-warnings=0` all green. Integration-test one representative flow (workspaces list) in a dev environment to confirm no regression.
 
@@ -471,7 +471,7 @@ All agents in this phase pin their target repo's `@meshery/schemas` dependency t
 **Branch:** `fix/kanvas-rtk-camelcase-alignment`  
 **Charter:** Two related Kanvas fixes that go together:
 1. `meshmap/src/rtk-query/catalog.ts:110` `getWorkspaceForCatalog` — remove the `orgID: queryArg.orgId` transform; emit `orgId` in the URL directly.
-2. `meshmap/src/rtk-query/catalog.ts:58-59` `getPatternsPerUser` — unify to Option B canonical names.
+2. `meshmap/src/rtk-query/catalog.ts:58-59` `getPatternsPerUser` — unify to canonical names.
 3. `meshmap/src/rtk-query/designs.ts:308` `uploadPatternBySourceType` body wrapper — change `{ pattern_data: {...} }` to `{ patternData: {...} }` to match the `SaveMesheryPattern` wire contract already established by PR #18856.
 4. `meshmap/src/rtk-query/designs.ts:336-342` `patternFiletoCytoJson` body — align to camelCase throughout.
 5. `meshmap/src/rtk-query/designs.ts:188` `k8sYamlToPattern` body — `{ k8s_manifest: ... }` → `{ k8sManifest: ... }`.
@@ -500,7 +500,7 @@ All agents in this phase pin their target repo's `@meshery/schemas` dependency t
 
 **Testing:** `cd ui && npm run build && npm test` — green. The `environments` wrapper removal touches many call sites; every import of `useGetEnvironmentsQuery` from the local wrapper must be updated to import from `@meshery/schemas/mesheryApi`. Compile-error-driven; TypeScript's type system catches misses.
 
-**Docs:** `ui/CONTRIBUTING.md` adds a paragraph: "Do not wrap schemas-generated hooks solely to alias parameter names; propagate the canonical Option B name."
+**Docs:** `ui/CONTRIBUTING.md` adds a paragraph: "Do not wrap schemas-generated hooks solely to alias parameter names; propagate the canonical canonical identifier."
 
 **Acceptance:** PR merged; no same-file `orgID`/`orgId` mix remains; thin wrappers eliminated.
 
@@ -693,7 +693,7 @@ The remaining 21 agents follow the template in §9.2 with per-resource file path
 **Acceptance:** Drift introduced in a test PR fails CI; reverted, green.
 
 ### Agent 4.C — Universal `AGENTS.md` + `CLAUDE.md` updates across every repo
-**Charter:** In each of the four repos (`meshery/schemas`, `meshery/meshery`, `layer5io/meshery-cloud`, `layer5labs/meshery-extensions`), ensure `AGENTS.md` and `CLAUDE.md` (symlinked or duplicated) contain the Option B mandate with a strong "MUST" / "MUST NOT" section referencing `schemas/AGENTS.md § Casing rules at a glance` as the authority. Boilerplate text in §14 of this plan.
+**Charter:** In each of the four repos (`meshery/schemas`, `meshery/meshery`, `layer5io/meshery-cloud`, `layer5labs/meshery-extensions`), ensure `AGENTS.md` and `CLAUDE.md` (symlinked or duplicated) contain the identifier-naming mandate with a strong "MUST" / "MUST NOT" section referencing `schemas/AGENTS.md § Casing rules at a glance` as the authority. Boilerplate text in §14 of this plan.
 
 **Files (per repo):**
 - `AGENTS.md`
@@ -711,7 +711,7 @@ The remaining 21 agents follow the template in §9.2 with per-resource file path
 
 **Testing:** `make validate-schemas` green; `make audit-schemas-full` green; no regressions in existing test fixtures.
 
-**Acceptance:** Validator has the minimum rule set that enforces Option B going forward.
+**Acceptance:** Validator has the minimum rule set that enforces the canonical contract going forward.
 
 ### Agent 4.E — Before/after impact report publication
 **Charter:** Re-run the baseline agents (0.A–0.D) to produce "after" numbers. Publish the before/after report per §15 of this plan; commit to `meshery/schemas/docs/` as the governance artifact.
@@ -782,7 +782,7 @@ Every agent's PR includes documentation updates whenever its change affects user
 - [ ] External user docs linked or updated (PR to `layer5io/docs` if needed)
 - [ ] `CHANGELOG.md` entry
 
-**Explicit doc sites whose names and URLs will change under Option B:**
+**Explicit doc sites whose names and URLs will change under the canonical contract:**
 - API reference sample bodies (`{ "user_id": "..." }` → `{ "userId": "..." }`).
 - Query-string examples (`?orgID=` → `?orgId=`).
 - Go import paths (version bumps).
@@ -814,7 +814,7 @@ Every repo's `AGENTS.md` (symlinked as `CLAUDE.md`) must contain the following b
 ```markdown
 ## Identifier Naming Conventions — MANDATORY
 
-This repository adheres to the **Option B** identifier-naming contract
+This repository adheres to the canonical camelCase-wire identifier-naming contract
 defined authoritatively in `meshery/schemas/AGENTS.md § Casing rules at a
 glance`. The contract is **not optional**; deviations block PRs via the
 schemas consumer-audit CI gate.
@@ -867,13 +867,13 @@ discrepancies as issues against `meshery/schemas`, not locally.
 
 ### Migration
 
-The Option B migration is tracked at
+The identifier-naming migration is tracked at
 `meshery/schemas/docs/identifier-naming-migration.md`. All
 contributors — human and AI agents — MUST read this plan before making
 any schema-aware change.
 ```
 
-Each repo's AGENTS.md also retains its repo-specific sections (build, tools, tests). The Option B section is additive.
+Each repo's AGENTS.md also retains its repo-specific sections (build, tools, tests). The identifier-naming section is additive.
 
 ---
 
@@ -896,7 +896,7 @@ Each repo's AGENTS.md also retains its repo-specific sections (build, tools, tes
 
 ### 15.2 Narrative impact
 
-**Cognitive overhead per contributor:** reduced from "remember three conventions, know DB-backing per field, recall intentional exceptions" to "camel on wire, snake at DB, PascalCase in Go". One rule, one DB boundary, one Go idiom. A new contributor reading `AGENTS.md § Option B` has everything they need in one screen.
+**Cognitive overhead per contributor:** reduced from "remember three conventions, know DB-backing per field, recall intentional exceptions" to "camel on wire, snake at DB, PascalCase in Go". One rule, one DB boundary, one Go idiom. A new contributor reading `AGENTS.md § Identifier-naming migration` has everything they need in one screen.
 
 **AI-audit false-positive rate:** the conditional "DB-backed → snake" rule is the single largest source of false positives in automated reviewers. Removing it collapses the rule surface and removes the ambiguity that produces the false-positive class.
 
@@ -935,7 +935,7 @@ Each agent has explicit escalation per §5.7. Additional per-class guidance:
 ## 17. Success criteria & sign-off gates
 
 ### Phase 1 sign-off
-- [ ] `AGENTS.md` Option B amendment merged; maintainer-approved.
+- [ ] `AGENTS.md` identifier-naming amendment merged; maintainer-approved.
 - [ ] Rules 4-extended, 45, 46 encoded with tests.
 - [ ] `consumer_ts.go` authoring complete with tests.
 - [ ] Advisory baseline refreshed; `make validate-schemas` and `make audit-schemas-full` green.
@@ -984,7 +984,7 @@ You are Phase 3.{Resource} agent.
 
 CHARTER
 Migrate the {resource} resource from {old-version} to {new-version}
-under the Option B contract defined in
+under the canonical contract defined in
 meshery/schemas/docs/identifier-naming-migration.md §1.
 
 STEPS
@@ -1069,6 +1069,6 @@ ACCEPTANCE
 
 | Revision | Date | Author | Change |
 |---|---|---|---|
-| 1.0 | 2026-04-22 | Lee Calcote (via orchestrator) | Initial authoring. Option B decision recorded. Phases 0–4 defined. Agent templates inlined. |
+| 1.0 | 2026-04-22 | Lee Calcote (via orchestrator) | Initial authoring. camelCase-on-wire decision recorded. Phases 0–4 defined. Agent templates inlined. |
 
 End of plan.

--- a/docs/identifier-naming-migration.md
+++ b/docs/identifier-naming-migration.md
@@ -500,7 +500,7 @@ All agents in this phase pin their target repo's `@meshery/schemas` dependency t
 
 **Testing:** `cd ui && npm run build && npm test` — green. The `environments` wrapper removal touches many call sites; every import of `useGetEnvironmentsQuery` from the local wrapper must be updated to import from `@meshery/schemas/mesheryApi`. Compile-error-driven; TypeScript's type system catches misses.
 
-**Docs:** `ui/CONTRIBUTING.md` adds a paragraph: "Do not wrap schemas-generated hooks solely to alias parameter names; propagate the canonical canonical identifier."
+**Docs:** `ui/CONTRIBUTING.md` adds a paragraph: "Do not wrap schemas-generated hooks solely to alias parameter names; propagate the canonical identifier."
 
 **Acceptance:** PR merged; no same-file `orgID`/`orgId` mix remains; thin wrappers eliminated.
 

--- a/docs/identifier-naming-plan-meshery-cloud.md
+++ b/docs/identifier-naming-plan-meshery-cloud.md
@@ -1,12 +1,12 @@
-# Option B Migration — High-Level Plan: `layer5io/meshery-cloud`
+# Identifier-Naming Migration — High-Level Plan: `layer5io/meshery-cloud`
 
 > Handoff artifact for the downstream detailed-plan agent. Contains the known scope, concrete findings, and dependencies — not the final runbook. A subsequent agent will expand this into per-file / per-PR specifications.
 
-## 1. Role in the Option B migration
+## 1. Role in the identifier-naming migration
 
-`layer5io/meshery-cloud` is the Go remote provider (Echo-based server) plus the Cloud Next.js UI. It is the receiving end of every Meshery-Server-proxied request and the largest surface of locally-declared RTK endpoints (~30+ in `ui/api/api.ts`). Its job in the migration: accept the Option B canonical query/body shapes on the wire, stop masking drift via `utils.QueryParam` fallbacks, align all 9 mapping-model JSON tags, and displace duplicated RTK endpoints with schemas-generated equivalents.
+`layer5io/meshery-cloud` is the Go remote provider (Echo-based server) plus the Cloud Next.js UI. It is the receiving end of every Meshery-Server-proxied request and the largest surface of locally-declared RTK endpoints (~30+ in `ui/api/api.ts`). Its job in the migration: accept the canonical camelCase query/body shapes on the wire, stop masking drift via `utils.QueryParam` fallbacks, align all 9 mapping-model JSON tags, and displace duplicated RTK endpoints with schemas-generated equivalents.
 
-## 2. The Option B contract — recap
+## 2. The canonical contract — recap
 
 - **Wire (JSON tags, URL query/path params, TS properties, OpenAPI properties):** camelCase, `Id` suffix.
 - **DB column / `db:` tag:** snake_case (unchanged).
@@ -17,7 +17,7 @@
 
 | Upstream | Blocks this repo's |
 |---|---|
-| `meshery/schemas` Phase 1 (governance + validator hardening + package publish) | All non-trivial Option B work |
+| `meshery/schemas` Phase 1 (governance + validator hardening + package publish) | All non-trivial identifier-naming work |
 | `meshery/schemas` Phase 3 per-resource versioned schemas | Any handler / model / hook that imports a migrated-resource type |
 | `meshery/meshery` Phase 2.A and 2.B (server query-param + outbound URL alignment) | Retirement of `utils.QueryParam` dual-accept (cannot retire until server emits single form) |
 
@@ -35,7 +35,7 @@
 - `server/handlers/flow_emails.go:245` — `orgId`/`orgID` dual-accept.
 - `server/handlers/middlewares_authz_scope.go:241` — `orgId`/`orgID` dual-accept.
 - Additional sites to be located via `grep -rn 'QueryParam.*"[a-z]*Id".*"[a-z_]*id"' server/`.
-- **Outlier with no fallback:** `server/handlers/meshery_filters.go:212` — reads only `q.Get("user_id")` (snake), silently drops `userId` if received. Either add fallback or align to Option B canonical.
+- **Outlier with no fallback:** `server/handlers/meshery_filters.go:212` — reads only `q.Get("user_id")` (snake), silently drops `userId` if received. Either add fallback or align to canonical.
 
 **Mapping-model JSON tags — `json:"ID"` ALL CAPS across 9 files** (AGENTS.md requires lowercase `"id"`):
 - `server/models/model_environment_connection_mapping.go:13` — `EnvironmentConnectionMapping.ID`.
@@ -49,9 +49,9 @@
 - `server/models/model_keychain_filter.go:10` — `KeychainFilter` — `roleID json:"roleID"` (ALL CAPS) with `db:"role_id"`.
 
 **Go field / JSON tag / DB tag three-way splits:**
-- `server/models/users.go:246` — `CatalogRequest.ContentID`: Go `ContentID`, `json:"contentId"`, `db:"content_id"`. **Actually correct under Option B** — confirm and mark as resolved rather than fix.
-- `server/models/users.go:332` — `Messages.UserId`: field `UserId` with `json:"userId"`. No DB tag (in-memory). Consistent within the struct; **correct under Option B** (Go field PascalCase + camelCase JSON on non-DB-backed).
-- `server/models/meshery_patterns.go:62` — `MesheryPattern.OrgID` with `json:"orgId" db:"-"`. Correct under Option B on JSON; `db:"-"` omits it (computed / joined field), so no DB conflict. **Verify and mark resolved.**
+- `server/models/users.go:246` — `CatalogRequest.ContentID`: Go `ContentID`, `json:"contentId"`, `db:"content_id"`. **Actually correct under the canonical contract** — confirm and mark as resolved rather than fix.
+- `server/models/users.go:332` — `Messages.UserId`: field `UserId` with `json:"userId"`. No DB tag (in-memory). Consistent within the struct; **correct under the canonical contract** (Go field PascalCase + camelCase JSON on non-DB-backed).
+- `server/models/meshery_patterns.go:62` — `MesheryPattern.OrgID` with `json:"orgId" db:"-"`. Correct under the canonical contract on JSON; `db:"-"` omits it (computed / joined field), so no DB conflict. **Verify and mark resolved.**
 
 **Locally-declared request body duplicating schemas:**
 - `server/handlers/meshery_patterns.go:140` — `MesheryPatternRequestBody` with a `TODO(local-struct migration)` comment referencing `github.com/meshery/schemas/models/v1beta2/design.MesheryPatternRequestBody`. Awaiting schemas issue #5063. When schemas resolves, displace.
@@ -102,7 +102,7 @@
 - `go test ./...` green; new Pop ORM DAO tests for any model-tag change (round-trip Marshal/Unmarshal against fixture DB rows).
 - Allure-Go test reports updated for handler changes.
 - Cloud UI: `npm run build`, `npm test`, ESLint + Prettier clean.
-- Jest regression tests already exist under `ui/__tests__/components/workspaces/*regression*.test.tsx` — extend these with Option B assertions.
+- Jest regression tests already exist under `ui/__tests__/components/workspaces/*regression*.test.tsx` — extend these with canonical-casing assertions.
 - Integration test against staging Cloud endpoint after backend changes.
 
 ## 7. Documentation requirements (every PR)
@@ -119,7 +119,7 @@
 - **`QueryParamOrganizationID` constant flip (Phase 2.C PR 1) is non-breaking** — backend accepts `orgId` via the fallback already; the constant flip just makes `orgId` the canonical form in error messages and logs.
 - **9 mapping-model JSON tag fix is API-breaking** for any consumer reading the `ID` field by name. Survey consumers across all three downstream repos before merging; add a `MarshalJSON` shim emitting both `ID` and `id` for one release if needed.
 - **`ui/api/api.ts` dedup is the largest Cloud-specific workstream.** Best tackled by component group (workspaces endpoints first, then events, then catalog, etc.) rather than as one mega-PR.
-- **Cloud UI already has regression tests guarding orgID behavior** (`workspace-widget-orgid.regression.test.tsx`, etc.) — extend these to guard Option B canonicality as well.
+- **Cloud UI already has regression tests guarding orgID behavior** (`workspace-widget-orgid.regression.test.tsx`, etc.) — extend these to guard canonicality as well.
 
 ## 9. Known open questions for the detailed-plan agent
 
@@ -127,7 +127,7 @@
 2. For the 9 mapping-model `json:"ID"` fix: is the breaking-change blast radius small enough to ship without a `MarshalJSON` shim, or must we stage?
 3. Does Cloud's `meshery_patterns.go MesheryPattern` diverge from Meshery Server's in ways that block a single schemas-sourced struct? Or is it field-identical modulo JSON tags?
 4. Is there a Cloud-specific identifier (e.g., `PlanId`, `SubscriptionId`, `BadgeId`) whose current wire format conflicts with the schemas canonical? Enumerate before Phase 3.
-5. What is Cloud's stance on supporting Meshery Server versions that predate the Option B migration? The `utils.QueryParam` removal window needs to be coordinated with the oldest supported Meshery Server release.
+5. What is Cloud's stance on supporting Meshery Server versions that predate the identifier-naming migration? The `utils.QueryParam` removal window needs to be coordinated with the oldest supported Meshery Server release.
 
 ## 10. Reference
 

--- a/docs/identifier-naming-plan-meshery-extensions.md
+++ b/docs/identifier-naming-plan-meshery-extensions.md
@@ -1,12 +1,12 @@
-# Option B Migration — High-Level Plan: `layer5labs/meshery-extensions` (Kanvas)
+# Identifier-Naming Migration — High-Level Plan: `layer5labs/meshery-extensions` (Kanvas)
 
 > Handoff artifact for the downstream detailed-plan agent. Contains the known scope, concrete findings, and dependencies — not the final runbook. A subsequent agent will expand this into per-file / per-PR specifications.
 
-## 1. Role in the Option B migration
+## 1. Role in the identifier-naming migration
 
-`layer5labs/meshery-extensions` houses Kanvas (the Meshery UI extension — React/TypeScript) plus a Go GraphQL plugin. It is a **consumer only**: it does not own any wire contract but consumes both `@meshery/schemas/mesheryApi` and `@meshery/schemas/cloudApi`, emits RTK requests to Meshery Server, and crosses an injection boundary (via `mesherySdk.ts`) to Meshery UI. Its job in the migration: stop the client-side case-flip transformations, align its request-body wrappers with what Meshery Server expects post-Option-B, resolve same-file casing contradictions, and displace its hand-rolled RTK endpoints where schemas equivalents exist.
+`layer5labs/meshery-extensions` houses Kanvas (the Meshery UI extension — React/TypeScript) plus a Go GraphQL plugin. It is a **consumer only**: it does not own any wire contract but consumes both `@meshery/schemas/mesheryApi` and `@meshery/schemas/cloudApi`, emits RTK requests to Meshery Server, and crosses an injection boundary (via `mesherySdk.ts`) to Meshery UI. Its job in the migration: stop the client-side case-flip transformations, align its request-body wrappers with what Meshery Server expects post-migration, resolve same-file casing contradictions, and displace its hand-rolled RTK endpoints where schemas equivalents exist.
 
-## 2. The Option B contract — recap
+## 2. The canonical contract — recap
 
 - **Wire (JSON tags, URL query/path params, TS properties, OpenAPI properties):** camelCase, `Id` suffix.
 - **DB column / `db:` tag:** snake_case (unchanged).
@@ -17,7 +17,7 @@
 
 | Upstream | Blocks this repo's |
 |---|---|
-| `meshery/schemas` Phase 1 (governance + validator hardening + package publish) | All non-trivial Option B work |
+| `meshery/schemas` Phase 1 (governance + validator hardening + package publish) | All non-trivial identifier-naming work |
 | `meshery/meshery` Phase 2.A (handler query-param alignment) | `getWorkspaceForCatalog` case-flip removal (no harm in leading; no harm in trailing) |
 | `meshery/meshery` Phase 2.B (outbound URL alignment) | Server-side; unrelated here |
 | `meshery/schemas` Phase 3.Design / Phase 3.Workspace | Any Kanvas endpoint that references those resources' types |
@@ -28,7 +28,7 @@
 
 **Client-side case-flip transformation (sends `orgID` to match Cloud legacy wire):**
 - `meshmap/src/rtk-query/catalog.ts:110` — `getWorkspaceForCatalog` endpoint maps input `queryArg.orgId` → URL param `orgID: queryArg.orgId`. Must remove once backend canonical is `orgId`.
-- `meshmap/src/rtk-query/catalog.ts:58-59` — `getPatternsPerUser` uses mixed `orgID` (caps) and `user_id` (snake) params in the same endpoint. Align to Option B canonical.
+- `meshmap/src/rtk-query/catalog.ts:58-59` — `getPatternsPerUser` uses mixed `orgID` (caps) and `user_id` (snake) params in the same endpoint. Align to canonical.
 
 **Mutation body wrapper-key drift** (snake wrappers with camelCase inner fields — partial-migration violation):
 - `meshmap/src/rtk-query/designs.ts:308` — `uploadPatternBySourceType` body is `{ pattern_data: { name, patternFile }, save }`. Wrapper snake, inner camel. Should be `{ patternData: { ... } }` to align with the precedent set by PR #18856 (`SaveMesheryPattern` wire contract).
@@ -68,7 +68,7 @@
 
 **Minimal divergence:**
 - `graphql/schema/schema.graphql` — uses UPPERCASE composite identifiers: `designID`, `k8sclusterIDs`, `connectionID`.
-- Under Option B, GraphQL identifier fields should align with the canonical wire form (camelCase + `Id`), same as REST.
+- Under the canonical contract, GraphQL identifier fields should align with the canonical wire form (camelCase + `Id`), same as REST.
 - `graphql/model/models_gen.go` — generated types; will follow schema changes.
 
 **Candidate changes:**
@@ -95,7 +95,7 @@
 - Lint: `make kanvas-lint` (ESLint + Prettier) clean.
 - Kanvas dev server (`make kanvas`) loads against a live Meshery server; manually verify save, load, delete design flows.
 - `cd graphql && make graphql-lint && make graphql` clean for any GraphQL changes.
-- Meshery Server + Kanvas integration smoke: design save succeeds end-to-end after Option B wrapper changes.
+- Meshery Server + Kanvas integration smoke: design save succeeds end-to-end after canonical-casing wrapper changes.
 
 ## 7. Documentation requirements (every PR)
 

--- a/docs/identifier-naming-plan-meshery.md
+++ b/docs/identifier-naming-plan-meshery.md
@@ -1,12 +1,12 @@
-# Option B Migration — High-Level Plan: `meshery/meshery`
+# Identifier-Naming Migration — High-Level Plan: `meshery/meshery`
 
 > Handoff artifact for the downstream detailed-plan agent. Contains the known scope, concrete findings, and dependencies — not the final runbook. A subsequent agent will expand this into per-file / per-PR specifications.
 
-## 1. Role in the Option B migration
+## 1. Role in the identifier-naming migration
 
-`meshery/meshery` is the Go server + Meshery UI (Next.js) + `mesheryctl` CLI. It consumes `@meshery/schemas` as the source of truth and hosts the routing logic that the schemas consumer-audit validates against. Its job in the migration: align every identifier it emits (outbound URLs, JSON bodies), every identifier it reads (query params, response shapes), and every hook it exposes to Kanvas with the Option B canonical form.
+`meshery/meshery` is the Go server + Meshery UI (Next.js) + `mesheryctl` CLI. It consumes `@meshery/schemas` as the source of truth and hosts the routing logic that the schemas consumer-audit validates against. Its job in the migration: align every identifier it emits (outbound URLs, JSON bodies), every identifier it reads (query params, response shapes), and every hook it exposes to Kanvas with the canonical form.
 
-## 2. The Option B contract — recap
+## 2. The canonical contract — recap
 
 - **Wire (JSON tags, URL query/path params, TS properties, OpenAPI properties):** camelCase, `Id` suffix (lowercase `d`).
 - **DB column / `db:` tag:** snake_case (unchanged; the sole remaining translation boundary).
@@ -17,7 +17,7 @@
 
 | Upstream | Blocks this repo's |
 |---|---|
-| `meshery/schemas` Phase 1 (governance + validator hardening + package publish) | All non-trivial Option B work in this repo |
+| `meshery/schemas` Phase 1 (governance + validator hardening + package publish) | All non-trivial identifier-naming work in this repo |
 | `meshery/schemas` Phase 3 per-resource versioned schemas | Any handler / model / hook that imports a migrated-resource type |
 | `layer5io/meshery-cloud` Phase 2.C (constant + dual-accept retirement) | Timing of outbound URL alignment — can land before or after; no hard ordering |
 
@@ -28,7 +28,7 @@
 **Query-parameter extraction drift (sibling endpoints, different keys):**
 - `server/handlers/workspace_handlers.go:24,46` — reads `q.Get("orgID")` (ALL CAPS). Should be `q.Get("orgId")`. *Non-breaking if companion UI fix lands.*
 - `server/handlers/meshery_pattern_handler.go:557` — `q["orgID"]`. Same fix.
-- `server/handlers/environments_handlers.go:24,45` — already reads `q.Get("orgId")`. **Correct under Option B.**
+- `server/handlers/environments_handlers.go:24,45` — already reads `q.Get("orgId")`. **Correct under the canonical contract.**
 
 **Outbound URL construction (Meshery Server → Meshery Cloud):**
 - `server/models/remote_provider.go:5174` — `q.Set("orgID", orgID)` in `GetEnvironments`. Change to `"orgId"`.
@@ -40,10 +40,10 @@
 **JSON tag drift on locally-declared Go models (partial-casing-migration violations):**
 - `server/models/meshery_pattern.go:93,109,110` — `MesheryPattern` struct mixes three JSON-tag conventions on three DB-backed ID fields: `json:"user_id"`, `json:"workspace_id"`, `json:"orgId"`. Violates AGENTS.md "Partial casing migrations forbidden". Two resolution paths:
   - **Phase 2 interim:** Normalize back to all snake (revert `orgId` → `org_id`) so the struct is consistent with DB-backing — non-breaking, internal consistency restored.
-  - **Phase 3 final:** Displace the local struct with `github.com/meshery/schemas/models/v1beta3/design.MesheryPattern` once the v1beta3 design schema lands under Option B.
+  - **Phase 3 final:** Displace the local struct with `github.com/meshery/schemas/models/v1beta3/design.MesheryPattern` once the v1beta3 design schema lands under the canonical contract.
 - `server/models/meshery_filter.go:19,36` — `MesheryFilter.UserID json:"user_id"`. Candidate for schemas export + displacement.
 - `server/models/meshery_application.go:42` — same class.
-- `server/models/k8s_context.go:37-38` — `MesheryInstanceID json:"meshery_instance_id"`, `KubernetesServerID json:"kubernetes_server_id"`. Meshery-local (not in schemas); wire form needs Option B camelCase (`mesheryInstanceId`, `kubernetesServerId`) once a `v1beta*` K8sContext schema is authored.
+- `server/models/k8s_context.go:37-38` — `MesheryInstanceID json:"meshery_instance_id"`, `KubernetesServerID json:"kubernetes_server_id"`. Meshery-local (not in schemas); wire form needs canonical camelCase (`mesheryInstanceId`, `kubernetesServerId`) once a `v1beta*` K8sContext schema is authored.
 
 **`mesheryctl` CLI (not yet surveyed — gap):**
 - Subsequent audit pass needed. Expected divergences: command-line flag casing (`--org-id` vs `--orgId`), config-file key casing.
@@ -103,7 +103,7 @@
 
 ## 9. Known open questions for the detailed-plan agent
 
-1. Does the `mesheryctl` config file format need its own versioning for an Option B migration, or can it migrate in place?
+1. Does the `mesheryctl` config file format need its own versioning for an identifier-naming migration, or can it migrate in place?
 2. Should `K8sContext` be exported to `meshery/schemas` for reuse (it currently is not), and if so, under which version?
 3. Which resources in the 22-resource inventory have meshery-server-specific shape extensions (e.g., pagination envelope on `/api/pattern`) that need schemas-side updates before this repo can consume them?
 4. Are there generated GraphQL types in `server/internal/graphql/generated/generated.go` that reference snake-case identifiers inherited from a GraphQL SDL file? That file was mentioned in prior audits but not traced end-to-end.
@@ -114,4 +114,4 @@
 - Full detailed plan draft (for reference; not the operative document): `schemas/docs/identifier-naming-migration.md`
 - Source of truth: `schemas/AGENTS.md § Casing rules at a glance` (post Phase 1.A amendment)
 - Prior audit sub-reports in this session's transcript (meshery-cloud, meshery, meshery-extensions audits)
-- PR #18856 (patternData wrapper precedent), PR #18857 (merged k8s panic fix — unrelated), PR #18858 (JSON error body — Option B-adjacent)
+- PR #18856 (patternData wrapper precedent), PR #18857 (merged k8s panic fix — unrelated), PR #18858 (JSON error body — canonical-casing-adjacent)

--- a/docs/identifier-naming-session-kickoff.md
+++ b/docs/identifier-naming-session-kickoff.md
@@ -1,10 +1,10 @@
-# Option B — Session Kickoff
+# Identifier-Naming Standardization — Session Kickoff
 
-**Read this first. This document is the entry point for every execution session of the Option B identifier-naming migration.**
+**Read this first. This document is the entry point for every execution session of the identifier-naming migration.**
 
 ## 0. What this session is doing
 
-You are one execution session in a multi-session migration that standardizes identifier naming across `meshery/schemas`, `meshery/meshery`, `layer5io/meshery-cloud`, and `layer5labs/meshery-extensions`. The migration direction is **Option B**: camelCase on wire, snake_case only at the DB/ORM boundary.
+You are one execution session in a multi-session migration that standardizes identifier naming across `meshery/schemas`, `meshery/meshery`, `layer5io/meshery-cloud`, and `layer5labs/meshery-extensions`. The migration direction: camelCase on wire, snake_case only at the DB/ORM boundary.
 
 You are **not** a design session. You do not re-audit, re-plan, re-argue the contract, or introduce new conventions. You read the plan and execute.
 


### PR DESCRIPTION
Follow-up to meshery/schemas#788, which renamed the 5 plan/kickoff docs and stripped the "Option B" label from `AGENTS.md`. This PR finishes the job per @leecalcote's categorical directive ("Don't mention option b anywhere; remove it from all references of it"):

## Scope
- `docs/identifier-naming-migration.md` — master plan body (~32 mentions)
- `docs/identifier-naming-session-kickoff.md` — session kickoff body (~14 mentions)
- `docs/identifier-naming-plan-meshery.md` — per-repo plan (~11 mentions)
- `docs/identifier-naming-plan-meshery-cloud.md` — per-repo plan (~13 mentions)
- `docs/identifier-naming-plan-meshery-extensions.md` — per-repo plan (~9 mentions)
- `cmd/phase0-*/main.go` docstrings + `cmd/phase0-tag-divergence/main_test.go` — 6 mentions across 4 files

Also done out of band:
- Retitled the 5 phase-tracking issues (#776–#780), dropping the `[Option B]` prefix and appending `(identifier-naming migration)`.
- Stripped residual "Option B" text and updated file-path references in all 5 issue bodies.

## Substitution patterns
Context-dependent, applied by sed with spot-check review:
| Was | Became |
|---|---|
| `Option B migration` | `identifier-naming migration` |
| `Option B contract` | `canonical contract` |
| `Option B canonical <x>` | `canonical <x>` |
| `Option B amendment` | `identifier-naming amendment` |
| `Option B mandate` | `identifier-naming mandate` |
| `Option B decision` | `camelCase-on-wire decision` |
| `Under/under Option B` | `Under/under the canonical contract` |
| `pre-Option-B` / `pre-Option B` | `legacy` |
| `post-Option-B` / `post-Option B` | `post-migration` |
| `§ Option B migration` | `§ Identifier-naming migration` |
| H1: `Option B Migration — High-Level Plan: X` | `Identifier-Naming Migration — High-Level Plan: X` |
| H1: `Option B — Session Kickoff` | `Identifier-Naming Standardization — Session Kickoff` |

## Tests
- [x] `make validate-schemas` — green
- [x] `go test ./...` — green
- [x] `go build ./...` — green
- [x] `grep -riE 'option b\|option-b' docs/ cmd/ AGENTS.md` — zero matches

## Migration impact
- Breaking: no (doc + code-comment edits only).
- API-version bump required: no.
- Consumer repos: none touched.

## Rollback
Revert the commit. Everything is mechanical substitution; no structural change.