### PR TITLE
docs(agents): fix inverted pagination-row example in Casing-rules table

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,7 +163,7 @@ Within a given API version / resource version, every element has exactly one cor
 | File and folder names | lowercase | `api.yml`, `keychain.yaml` | ~~`Keychain.yaml`~~ |
 | URL path segments | kebab-case, plural nouns | `/api/role-holders`, `/api/workspaces` | ~~`/api/roleHolders`~~ |
 | URL path params + ID-like query params | `camelCase + Id` | `{orgId}`, `?userId=…`, `?workspaceId=…` | ~~`{orgID}`~~, ~~`{org_id}`~~, ~~`?workspace_id=…`~~ |
-| Shared pagination/search/sort/filter query params | preserve published parameter name | `?page=…`, `?pagesize=…`, `?search=…`, `?order=…`, `?filter=…` | ~~`?pageSize=…`~~ (until per-resource version bump) |
+| Shared pagination/search/sort/filter query params | `camelCase` | `?page=…`, `?pageSize=…`, `?search=…`, `?order=…`, `?filter=…` | ~~`?pagesize=…`~~, ~~`?page_size=…`~~ |
 | `operationId` | lower camelCase verbNoun | `getAllRoles`, `createWorkspace`, `getWorkspaces` | ~~`GetAllRoles`~~, ~~`get_all_roles`~~ |
 | TypeScript property / RTK arg | camelCase | `response.userId`, `queryArg.orgId` | ~~`response.user_id`~~, ~~`queryArg.orgID`~~ |
 | Go type names | PascalCase (generated) | `Connection`, `KeychainPayload` | — |


### PR DESCRIPTION
Accepts @gemini-code-assist's open review thread on PR #788 (https://github.com/meshery/schemas/pull/788#discussion_r3127990410).

## Problem
The Casing-rules table preamble says it is the authoritative reference for **newly authored (canonical-casing) API versions**, but the "Shared pagination/search/sort/filter query params" row listed:
- Example: `?pagesize=…` (legacy)
- Counter-example: `?pageSize=…` (target)

That inverts what every other row in the table does and contradicts:
- The preamble that says the table describes the target state.
- The standalone "Pagination envelope" paragraph that explicitly says newly authored versions use `pageSize` / `totalCount`.
- The Schema Changes checklist item mandating `pageSize` / `totalCount` on new resource versions.

## Fix
Applied Gemini's suggested diff verbatim so the row aligns with the rest of the table:

```diff
-| Shared pagination/search/sort/filter query params | preserve published parameter name | `?page=…`, `?pagesize=…`, `?search=…`, `?order=…`, `?filter=…` | ~~`?pageSize=…`~~ (until per-resource version bump) |
+| Shared pagination/search/sort/filter query params | `camelCase` | `?page=…`, `?pageSize=…`, `?search=…`, `?order=…`, `?filter=…` | ~~`?pagesize=…`~~, ~~`?page_size=…`~~ |
```

Legacy-version preservation for these shared query params is already covered by the table preamble ("Already-published legacy API versions retain their published wire casing…") and by the standalone pagination paragraph further down — the row itself should describe the target state like every other row.

## Tests
- [x] `make validate-schemas` — green (doc-only change)

## Migration impact
None.

## Rollback
Revert the commit.