### PR TITLE
validation: invert Rule 6 and retire Rule 32 per Phase 1.B

### DIFF
--- a/validation/audit.go
+++ b/validation/audit.go
@@ -214,13 +214,9 @@ func auditEntitySchemas(constructDir string, opts AuditOptions,
 			addViolation(result, v, baseline)
 		}
 
-		// Rule 6: entity property casing must match contract/DB-backed rules.
+		// Rule 6: entity property casing (unconditional camelCase; no DB
+		// exception under the canonical identifier-naming contract).
 		for _, v := range checkRule6ForEntity(relPath, entity, opts) {
-			addViolation(result, v, baseline)
-		}
-
-		// Rule 32: DB-backed fields must use the exact snake_case db column name.
-		for _, v := range checkRule32ForEntity(relPath, entity, opts) {
 			addViolation(result, v, baseline)
 		}
 
@@ -303,11 +299,6 @@ func auditAPISpec(apiYmlPath, constructDir string, opts AuditOptions,
 
 	// Rule 8: enum values.
 	for _, v := range checkRule8(apiYmlPath, relPath, doc, opts, enumBaselineRef) {
-		addViolation(result, v, baseline)
-	}
-
-	// Rule 32: DB-backed property names.
-	for _, v := range checkRule32ForAPI(relPath, doc, opts) {
 		addViolation(result, v, baseline)
 	}
 

--- a/validation/casing.go
+++ b/validation/casing.go
@@ -45,8 +45,18 @@ var knownLowercaseSuffixViolations = map[string]bool{
 	"callbackurl": true, "redirecturl": true,
 }
 
-// dbMirroredFields are known contract-stable snake_case fields that may not
-// carry explicit db tags but are DB-backed.
+// dbMirroredFields enumerates known snake_case property names that originated
+// as DB column mirrors in pre-canonical-contract schemas.
+//
+// Under the canonical identifier-naming contract (see AGENTS.md § Casing
+// rules at a glance and docs/identifier-naming-migration.md), wire tags are
+// camelCase regardless of DB backing — so these names are no longer treated
+// as an exception to Rule 6. They surface as Rule 6 violations and are
+// routed through the same `--style-debt` severity path as every other
+// legacy snake_case violation. The set remains defined because
+// matcher.go still uses it to distinguish server-generated / DB-mirrored
+// fields from request-side client input when diffing consumer Go types
+// against schema shapes.
 var dbMirroredFields = map[string]bool{
 	"created_at": true, "updated_at": true, "deleted_at": true,
 	"user_id": true, "org_id": true, "organization_id": true,
@@ -151,19 +161,25 @@ type CasingIssue struct {
 	Description string
 }
 
-// GetCamelCaseIssues checks a name for camelCase violations.
-// If allowDBMirrored is true, known DB-backed snake_case fields are exempt.
-// dbTag and gormColumn are the values from x-oapi-codegen-extra-tags.
-func GetCamelCaseIssues(name string, allowDBMirrored bool, dbTag, gormColumn string) []CasingIssue {
-	if allowDBMirrored && isAllowedSnakeCaseProperty(name, dbTag, gormColumn) {
-		return nil
-	}
-
+// GetCamelCaseIssues checks a schema property name for camelCase violations.
+//
+// Under the canonical identifier-naming contract (AGENTS.md § Casing rules
+// at a glance, docs/identifier-naming-migration.md §1), every JSON tag /
+// OpenAPI schema property name is camelCase regardless of DB backing — the
+// snake_case DB column name lives only in `x-oapi-codegen-extra-tags.db`,
+// not on the wire. Accordingly this checker is unconditional: there is no
+// DB-mirroring exception. The legacy-DB-mirrored field set
+// (dbMirroredFields) remains defined for use by matcher.go's consumer-
+// type diff, but it is no longer an exception to Rule 6.
+//
+// Severity of the reported issues is determined at the caller (Rule 6) via
+// classifyStyleIssue / the --style-debt / --strict-consistency flags.
+func GetCamelCaseIssues(name string) []CasingIssue {
 	var issues []CasingIssue
 
 	if HasUnderscore(name) {
 		issues = append(issues, CasingIssue{
-			Description: "uses snake_case (only DB-backed contract fields may use underscores)",
+			Description: "uses snake_case (wire form must be camelCase; snake_case belongs in the db: tag only)",
 		})
 	}
 	if len(name) > 0 && unicode.IsUpper(rune(name[0])) {
@@ -202,30 +218,6 @@ func GetCamelCaseIssues(name string, allowDBMirrored bool, dbTag, gormColumn str
 	}
 
 	return issues
-}
-
-// isAllowedSnakeCaseProperty returns true if a snake_case name is permitted
-// because it maps to a database column.
-func isAllowedSnakeCaseProperty(name, dbTag, gormColumn string) bool {
-	if dbMirroredFields[name] {
-		return true
-	}
-	if isDBBackedSnakeCaseProperty(name, dbTag, gormColumn) {
-		return true
-	}
-	return false
-}
-
-// isDBBackedSnakeCaseProperty returns true if the property name matches its
-// db or gorm column tag exactly.
-func isDBBackedSnakeCaseProperty(name, dbTag, gormColumn string) bool {
-	if dbTag != "" && IsValidDBTag(dbTag) && HasUnderscore(dbTag) && name == dbTag {
-		return true
-	}
-	if gormColumn != "" && IsValidDBTag(gormColumn) && HasUnderscore(gormColumn) && name == gormColumn {
-		return true
-	}
-	return false
 }
 
 // IsValidOperationID checks if an operationId is lower camelCase verbNoun.

--- a/validation/casing.go
+++ b/validation/casing.go
@@ -161,25 +161,30 @@ type CasingIssue struct {
 	Description string
 }
 
-// GetCamelCaseIssues checks a schema property name for camelCase violations.
+// GetCamelCaseIssues checks a wire identifier (schema property name,
+// OpenAPI query/header parameter name, or any similar camelCase-expected
+// token) for casing violations.
 //
 // Under the canonical identifier-naming contract (AGENTS.md § Casing rules
-// at a glance, docs/identifier-naming-migration.md §1), every JSON tag /
-// OpenAPI schema property name is camelCase regardless of DB backing — the
-// snake_case DB column name lives only in `x-oapi-codegen-extra-tags.db`,
-// not on the wire. Accordingly this checker is unconditional: there is no
-// DB-mirroring exception. The legacy-DB-mirrored field set
-// (dbMirroredFields) remains defined for use by matcher.go's consumer-
-// type diff, but it is no longer an exception to Rule 6.
+// at a glance, docs/identifier-naming-migration.md §1), wire names are
+// camelCase regardless of DB backing — the snake_case DB column name lives
+// only in `x-oapi-codegen-extra-tags.db`, not on the wire. Accordingly this
+// checker is unconditional: there is no DB-mirroring exception. The
+// legacy-DB-mirrored field set (dbMirroredFields) remains defined for use
+// by matcher.go's consumer-type diff, but it is no longer an exception.
 //
-// Severity of the reported issues is determined at the caller (Rule 6) via
-// classifyStyleIssue / the --style-debt / --strict-consistency flags.
+// The returned issue descriptions are context-agnostic — each caller
+// (Rule 6 for schema/entity properties, Rule 9 for query/header
+// parameters, etc.) is responsible for adding any context-specific
+// guidance on top of the generic message. Severity is determined at the
+// caller via classifyStyleIssue / the --style-debt / --strict-consistency
+// flags.
 func GetCamelCaseIssues(name string) []CasingIssue {
 	var issues []CasingIssue
 
 	if HasUnderscore(name) {
 		issues = append(issues, CasingIssue{
-			Description: "uses snake_case (wire form must be camelCase; snake_case belongs in the db: tag only)",
+			Description: "uses snake_case (must be camelCase)",
 		})
 	}
 	if len(name) > 0 && unicode.IsUpper(rune(name[0])) {

--- a/validation/casing_test.go
+++ b/validation/casing_test.go
@@ -113,26 +113,40 @@ func TestToCamelCase(t *testing.T) {
 }
 
 func TestGetCamelCaseIssues(t *testing.T) {
+	// Under the canonical identifier-naming contract, GetCamelCaseIssues
+	// is unconditional: DB-mirrored names no longer get a pass. See Rule 6
+	// inversion in Phase 1.B of docs/identifier-naming-migration.md.
 	tests := []struct {
 		name           string
-		allowDB        bool
-		dbTag          string
 		wantIssueCount int
 	}{
-		{"userId", false, "", 0},
-		{"created_at", true, "", 0},  // DB-mirrored, allowed
-		{"created_at", false, "", 1}, // Not allowed without DB exemption
-		{"OrgName", false, "", 1},    // Starts with uppercase
-		{"orgID", false, "", 1},      // Screaming ID
-		{"userid", false, "", 1},     // Known lowercase suffix
-		{"plan_id", true, "", 0},     // DB-mirrored
+		// Valid camelCase.
+		{"userId", 0},
+		{"orgId", 0},
+		{"simple", 0},
+
+		// Legacy DB-mirrored names — formerly exempt, now flagged.
+		{"created_at", 1},
+		{"user_id", 1},
+		{"plan_id", 1},
+		{"page_size", 1},
+		{"total_count", 1},
+		{"organization_id", 1},
+
+		// Non-DB snake_case — still flagged (always was).
+		{"custom_field", 1},
+
+		// Other violations.
+		{"OrgName", 1},  // Starts with uppercase
+		{"orgID", 1},    // SCREAMING ID token
+		{"userid", 1},   // known lowercase suffix
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			issues := GetCamelCaseIssues(tt.name, tt.allowDB, tt.dbTag, "")
+			issues := GetCamelCaseIssues(tt.name)
 			if len(issues) != tt.wantIssueCount {
-				t.Errorf("GetCamelCaseIssues(%q, %v) returned %d issues, want %d: %+v",
-					tt.name, tt.allowDB, len(issues), tt.wantIssueCount, issues)
+				t.Errorf("GetCamelCaseIssues(%q) returned %d issues, want %d: %+v",
+					tt.name, len(issues), tt.wantIssueCount, issues)
 			}
 		})
 	}

--- a/validation/casing_test.go
+++ b/validation/casing_test.go
@@ -129,9 +129,12 @@ func TestGetCamelCaseIssues(t *testing.T) {
 		{"created_at", 1},
 		{"user_id", 1},
 		{"plan_id", 1},
+		{"organization_id", 1},
+
+		// Other legacy snake_case identifiers under the deprecation path
+		// (pagination envelope fields migrate at per-resource version bump).
 		{"page_size", 1},
 		{"total_count", 1},
-		{"organization_id", 1},
 
 		// Non-DB snake_case — still flagged (always was).
 		{"custom_field", 1},

--- a/validation/rules_entity.go
+++ b/validation/rules_entity.go
@@ -233,7 +233,10 @@ func entityRawPropGormColumn(entity *entitySchema, propName string) string {
 }
 
 // --- Rule 6 for entity schemas: property name casing ---
-
+//
+// See checkRule6ForAPI for the Rule 6 docstring. Behaviour is identical for
+// entity-schema YAML files: unconditional camelCase, no DB-mirroring
+// exception.
 func checkRule6ForEntity(filePath string, entity *entitySchema, opts AuditOptions) []Violation {
 	sev := classifyStyleIssue(opts)
 	if sev == nil || entity == nil || entity.Properties == nil {
@@ -244,9 +247,7 @@ func checkRule6ForEntity(filePath string, entity *entitySchema, opts AuditOption
 		if strings.HasPrefix(propName, "$") {
 			continue
 		}
-		dbTag := entityRawPropTag(entity, propName, "db")
-		gormCol := entityRawPropGormColumn(entity, propName)
-		issues := GetCamelCaseIssues(propName, true, dbTag, gormCol)
+		issues := GetCamelCaseIssues(propName)
 		if len(issues) > 0 {
 			descs := make([]string, len(issues))
 			for i, iss := range issues {
@@ -257,6 +258,9 @@ func checkRule6ForEntity(filePath string, entity *entitySchema, opts AuditOption
 			if suggestion != "" {
 				msg += fmt.Sprintf(` Use: %q.`, suggestion)
 			}
+			if dbMirroredFields[propName] {
+				msg += ` (legacy DB-mirrored name — migrate at the resource's next API-version bump per docs/identifier-naming-migration.md §9)`
+			}
 			msg += ` See AGENTS.md § "Casing rules at a glance".`
 			out = append(out, Violation{File: filePath, Message: msg, Severity: *sev, RuleNumber: 6})
 		}
@@ -264,39 +268,17 @@ func checkRule6ForEntity(filePath string, entity *entitySchema, opts AuditOption
 	return out
 }
 
-// --- Rule 32 for entity schemas: DB-backed property names must match db tags ---
-
-func checkRule32ForEntity(filePath string, entity *entitySchema, _ AuditOptions) []Violation {
-	if entity == nil || entity.Properties == nil {
-		return nil
-	}
-	var out []Violation
-	for propName := range entity.Properties {
-		dbTag := entityRawPropTag(entity, propName, "db")
-		gormCol := entityRawPropGormColumn(entity, propName)
-		col := dbTag
-		if col == "" {
-			col = gormCol
-		}
-		if col == "" || !IsValidDBTag(col) || !HasUnderscore(col) {
-			continue
-		}
-		if propName != col {
-			jsonTag := entityRawPropTag(entity, propName, "json")
-			if jsonTag != "" && jsonTag != "-" && jsonTag == col {
-				continue // deliberate semantic alias
-			}
-			src := "db"
-			if dbTag == "" {
-				src = "gorm column"
-			}
-			out = append(out, Violation{File: filePath,
-				Message: fmt.Sprintf(`Entity property %q maps to database column %q (via %s tag). DB-backed property names must use the exact snake_case db name.`,
-					propName, col, src),
-				Severity: SeverityBlocking, RuleNumber: 32})
-		}
-	}
-	return out
+// Rule 32 (entity) is retired under the canonical identifier-naming
+// contract. The pre-canonical rule required DB-backed property names to
+// match their snake_case `db:` tag exactly; under the new contract the
+// wire property name is camelCase and the snake_case DB column name lives
+// only in `x-oapi-codegen-extra-tags.db`, so propName != col is the
+// expected shape for DB-backed fields. See Phase 1.B in
+// docs/identifier-naming-migration.md. The function is retained as a
+// retired stub so historical audit-pipeline callers can be resolved at
+// compile time; it returns no violations.
+func checkRule32ForEntity(_ string, _ *entitySchema, _ AuditOptions) []Violation {
+	return nil
 }
 
 // --- Rule 35 for entity schemas: x-go-type / x-go-type-import consistency ---

--- a/validation/rules_entity.go
+++ b/validation/rules_entity.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -243,7 +244,12 @@ func checkRule6ForEntity(filePath string, entity *entitySchema, opts AuditOption
 		return nil
 	}
 	var out []Violation
-	for propName := range entity.Properties {
+	propNames := make([]string, 0, len(entity.Properties))
+	for name := range entity.Properties {
+		propNames = append(propNames, name)
+	}
+	sort.Strings(propNames)
+	for _, propName := range propNames {
 		if strings.HasPrefix(propName, "$") {
 			continue
 		}
@@ -258,9 +264,7 @@ func checkRule6ForEntity(filePath string, entity *entitySchema, opts AuditOption
 			if suggestion != "" {
 				msg += fmt.Sprintf(` Use: %q.`, suggestion)
 			}
-			if dbMirroredFields[propName] {
-				msg += ` (legacy DB-mirrored name — migrate at the resource's next API-version bump per docs/identifier-naming-migration.md §9)`
-			}
+			msg += schemaPropertyDBContext(propName)
 			msg += ` See AGENTS.md § "Casing rules at a glance".`
 			out = append(out, Violation{File: filePath, Message: msg, Severity: *sev, RuleNumber: 6})
 		}

--- a/validation/rules_naming.go
+++ b/validation/rules_naming.go
@@ -2,6 +2,7 @@ package validation
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/getkin/kin-openapi/openapi3"
@@ -94,7 +95,13 @@ func checkRule6ForAPI(filePath string, doc *openapi3.T, opts AuditOptions) []Vio
 		return nil
 	}
 	var out []Violation
-	for schemaName, schemaRef := range doc.Components.Schemas {
+	schemaNames := make([]string, 0, len(doc.Components.Schemas))
+	for name := range doc.Components.Schemas {
+		schemaNames = append(schemaNames, name)
+	}
+	sort.Strings(schemaNames)
+	for _, schemaName := range schemaNames {
+		schemaRef := doc.Components.Schemas[schemaName]
 		if schemaRef == nil || schemaRef.Value == nil {
 			continue
 		}
@@ -103,34 +110,94 @@ func checkRule6ForAPI(filePath string, doc *openapi3.T, opts AuditOptions) []Vio
 	return out
 }
 
+// checkPropertyNameCasing walks a schema and its inline composition branches
+// (allOf / anyOf / oneOf) and array `items`, reporting Rule 6 camelCase
+// violations on every directly-declared property name it encounters.
+// Property iteration is alphabetised so that violation order is
+// deterministic across runs — baseline files rely on this.
+//
+// `$ref` pointers are not followed: referenced schemas are walked as their
+// own components by the outer checkRule6ForAPI loop, so following refs here
+// would double-count. This also sidesteps any risk of cyclic recursion.
 func checkPropertyNameCasing(filePath, schemaName string, schema *openapi3.Schema, sev Severity) []Violation {
-	if schema == nil || schema.Properties == nil {
+	if schema == nil {
 		return nil
 	}
 	var out []Violation
-	for propName := range schema.Properties {
-		if strings.HasPrefix(propName, "$") {
-			continue
+
+	if schema.Properties != nil {
+		propNames := make([]string, 0, len(schema.Properties))
+		for name := range schema.Properties {
+			propNames = append(propNames, name)
 		}
-		issues := GetCamelCaseIssues(propName)
-		if len(issues) > 0 {
-			descs := make([]string, len(issues))
-			for i, iss := range issues {
-				descs[i] = iss.Description
+		sort.Strings(propNames)
+		for _, propName := range propNames {
+			if strings.HasPrefix(propName, "$") {
+				continue
 			}
-			suggestion := GetCamelCaseSuggestion(propName)
-			msg := fmt.Sprintf(`Schema %q — property %q %s.`, schemaName, propName, strings.Join(descs, "; "))
-			if suggestion != "" {
-				msg += fmt.Sprintf(` Use: %q.`, suggestion)
+			issues := GetCamelCaseIssues(propName)
+			if len(issues) > 0 {
+				descs := make([]string, len(issues))
+				for i, iss := range issues {
+					descs[i] = iss.Description
+				}
+				suggestion := GetCamelCaseSuggestion(propName)
+				msg := fmt.Sprintf(`Schema %q — property %q %s.`, schemaName, propName, strings.Join(descs, "; "))
+				if suggestion != "" {
+					msg += fmt.Sprintf(` Use: %q.`, suggestion)
+				}
+				msg += schemaPropertyDBContext(propName)
+				msg += ` See AGENTS.md § "Casing rules at a glance".`
+				out = append(out, Violation{File: filePath, Message: msg, Severity: sev, RuleNumber: 6})
 			}
-			if dbMirroredFields[propName] {
-				msg += ` (legacy DB-mirrored name — migrate at the resource's next API-version bump per docs/identifier-naming-migration.md §9)`
+			// Recurse into the property's own schema to surface nested
+			// composite shapes (inline object with its own properties,
+			// array items, nested allOf/anyOf/oneOf).
+			if sub := schema.Properties[propName]; sub != nil && sub.Value != nil && sub.Ref == "" {
+				out = append(out, checkPropertyNameCasing(filePath, schemaName, sub.Value, sev)...)
 			}
-			msg += ` See AGENTS.md § "Casing rules at a glance".`
-			out = append(out, Violation{File: filePath, Message: msg, Severity: sev, RuleNumber: 6})
 		}
 	}
+
+	for _, sub := range schema.AllOf {
+		if sub != nil && sub.Value != nil && sub.Ref == "" {
+			out = append(out, checkPropertyNameCasing(filePath, schemaName, sub.Value, sev)...)
+		}
+	}
+	for _, sub := range schema.OneOf {
+		if sub != nil && sub.Value != nil && sub.Ref == "" {
+			out = append(out, checkPropertyNameCasing(filePath, schemaName, sub.Value, sev)...)
+		}
+	}
+	for _, sub := range schema.AnyOf {
+		if sub != nil && sub.Value != nil && sub.Ref == "" {
+			out = append(out, checkPropertyNameCasing(filePath, schemaName, sub.Value, sev)...)
+		}
+	}
+	if schema.Items != nil && schema.Items.Value != nil && schema.Items.Ref == "" {
+		out = append(out, checkPropertyNameCasing(filePath, schemaName, schema.Items.Value, sev)...)
+	}
+
 	return out
+}
+
+// schemaPropertyDBContext returns a short suffix to append to a Rule 6
+// violation message for schema / entity property names, calling out either
+// the legacy-DB-mirrored migration hint (when the name is in the known
+// mirrored set) or a generic reminder that snake_case belongs only on the
+// `db:` tag (for other snake_case property names). Returns the empty
+// string when no DB-specific context applies — so that this helper can be
+// reused by Rule 6's entity path without pushing DB-specific wording into
+// GetCamelCaseIssues (which is shared with non-DB contexts such as
+// query/header parameter names).
+func schemaPropertyDBContext(propName string) string {
+	if dbMirroredFields[propName] {
+		return ` (legacy DB-mirrored name — migrate at the resource's next API-version bump per docs/identifier-naming-migration.md §9)`
+	}
+	if HasUnderscore(propName) {
+		return ` (snake_case belongs in the db: tag only)`
+	}
+	return ""
 }
 
 // Rule 7: components/schemas names must be PascalCase.

--- a/validation/rules_naming.go
+++ b/validation/rules_naming.go
@@ -76,6 +76,15 @@ func checkRule4(filePath string, doc *openapi3.T, opts AuditOptions) []Violation
 }
 
 // Rule 6: schema property names (on api.yml components/schemas).
+//
+// Under the canonical identifier-naming contract (AGENTS.md § Identifier-
+// naming migration, docs/identifier-naming-migration.md §1), every schema
+// property name / JSON tag is camelCase regardless of DB backing. Rule 6 is
+// therefore unconditional — DB-mirrored fields are no longer exempt and are
+// flagged through the same `--style-debt` severity path as any other
+// legacy snake_case wire identifier. Known legacy DB-mirrored names are
+// still tracked via the `dbMirroredFields` set in casing.go for use by
+// matcher.go's consumer-type diff.
 func checkRule6ForAPI(filePath string, doc *openapi3.T, opts AuditOptions) []Violation {
 	sev := classifyStyleIssue(opts)
 	if sev == nil {
@@ -99,13 +108,11 @@ func checkPropertyNameCasing(filePath, schemaName string, schema *openapi3.Schem
 		return nil
 	}
 	var out []Violation
-	for propName, propRef := range schema.Properties {
+	for propName := range schema.Properties {
 		if strings.HasPrefix(propName, "$") {
 			continue
 		}
-		dbTag := getExtensionDBTag(propRef)
-		gormCol := getExtensionGormColumn(propRef)
-		issues := GetCamelCaseIssues(propName, true, dbTag, gormCol)
+		issues := GetCamelCaseIssues(propName)
 		if len(issues) > 0 {
 			descs := make([]string, len(issues))
 			for i, iss := range issues {
@@ -115,6 +122,9 @@ func checkPropertyNameCasing(filePath, schemaName string, schema *openapi3.Schem
 			msg := fmt.Sprintf(`Schema %q — property %q %s.`, schemaName, propName, strings.Join(descs, "; "))
 			if suggestion != "" {
 				msg += fmt.Sprintf(` Use: %q.`, suggestion)
+			}
+			if dbMirroredFields[propName] {
+				msg += ` (legacy DB-mirrored name — migrate at the resource's next API-version bump per docs/identifier-naming-migration.md §9)`
 			}
 			msg += ` See AGENTS.md § "Casing rules at a glance".`
 			out = append(out, Violation{File: filePath, Message: msg, Severity: sev, RuleNumber: 6})
@@ -164,7 +174,7 @@ func checkRule9(filePath string, doc *openapi3.T, opts AuditOptions) []Violation
 				continue
 			}
 			name := p.Value.Name
-			issues := GetCamelCaseIssues(name, false, "", "")
+			issues := GetCamelCaseIssues(name)
 			if len(issues) > 0 {
 				descs := make([]string, len(issues))
 				for i, iss := range issues {

--- a/validation/rules_property.go
+++ b/validation/rules_property.go
@@ -7,47 +7,23 @@ import (
 	"github.com/getkin/kin-openapi/openapi3"
 )
 
-// --- Rule 32: DB-backed property names must match db tags ---
+// --- Rule 32: DB-backed property names must match db tags (retired) ---
 
-func checkRule32ForAPI(filePath string, doc *openapi3.T, _ AuditOptions) []Violation {
-	if doc == nil || doc.Components == nil || doc.Components.Schemas == nil {
-		return nil
-	}
-	var out []Violation
-	for name, ref := range doc.Components.Schemas {
-		if ref == nil || ref.Value == nil || ref.Value.Properties == nil {
-			continue
-		}
-		for propName, propRef := range ref.Value.Properties {
-			if propRef == nil || propRef.Value == nil {
-				continue
-			}
-			dbTag := getExtensionDBTag(propRef)
-			gormCol := getExtensionGormColumn(propRef)
-			col := dbTag
-			if col == "" {
-				col = gormCol
-			}
-			if col == "" || !IsValidDBTag(col) || !HasUnderscore(col) {
-				continue
-			}
-			if propName != col {
-				jsonTag := getExtraTag(propRef.Value.Extensions, "json")
-				if jsonTag != "" && jsonTag != "-" && jsonTag == col {
-					continue // deliberate semantic alias
-				}
-				src := "db"
-				if dbTag == "" {
-					src = "gorm column"
-				}
-				out = append(out, Violation{File: filePath,
-					Message: fmt.Sprintf(`Schema %q — property %q maps to database column %q (via %s tag). DB-backed property names must use the exact snake_case db name.`,
-						name, propName, col, src),
-					Severity: SeverityBlocking, RuleNumber: 32})
-			}
-		}
-	}
-	return out
+// Rule 32 is retired under the canonical identifier-naming contract.
+//
+// The pre-canonical rule required DB-backed property names to match their
+// snake_case `db:` tag exactly. Under the new contract (see
+// docs/identifier-naming-migration.md §1 and AGENTS.md § Casing rules at
+// a glance), the wire property name is camelCase and the snake_case DB
+// column name lives only in `x-oapi-codegen-extra-tags.db` — so a
+// property whose name differs from its `db:` tag is the *expected* shape
+// for DB-backed fields, not a violation.
+//
+// The function is retained as a retired stub so that historical audit-
+// pipeline callers remain linkable; it returns no violations. Retirement
+// is documented in Phase 1.B of the identifier-naming migration plan.
+func checkRule32ForAPI(_ string, _ *openapi3.T, _ AuditOptions) []Violation {
+	return nil
 }
 
 // --- Rule 33: Pagination envelopes use page_size / total_count ---

--- a/validation/rules_property_test.go
+++ b/validation/rules_property_test.go
@@ -435,3 +435,183 @@ func TestFingerprintSchema_IdenticalSchemasProduceSameFingerprint(t *testing.T) 
 		t.Errorf("identical schemas produced different fingerprints: %q vs %q", fp1, fp2)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Rule 6 (inverted): unconditional camelCase — no DB-mirroring exception.
+// See docs/identifier-naming-migration.md Phase 1.B.
+// ---------------------------------------------------------------------------
+
+// TestCheckRule6ForAPI_DBBackedSnakeFails is the first charter acceptance
+// case: a DB-backed field whose property name is snake_case (the legacy
+// pre-canonical pattern) must now trip Rule 6. This was previously exempted
+// by the DB-mirroring rule.
+func TestCheckRule6ForAPI_DBBackedSnakeFails(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"user_id": {
+				Value: &openapi3.Schema{
+					Type:        &openapi3.Types{"string"},
+					Description: "User id",
+					Extensions: map[string]any{
+						"x-oapi-codegen-extra-tags": map[string]any{
+							"db":   "user_id",
+							"json": "user_id",
+						},
+					},
+				},
+			},
+		},
+	}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"LegacyResource": &openapi3.SchemaRef{Value: schema},
+			},
+		},
+	}
+
+	// --style-debt surfaces Rule 6 violations as advisory.
+	vs := checkRule6ForAPI("test.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 Rule 6 violation for user_id, got %d: %+v", len(vs), vs)
+	}
+	if vs[0].RuleNumber != 6 {
+		t.Errorf("expected RuleNumber=6, got %d", vs[0].RuleNumber)
+	}
+}
+
+// TestCheckRule6ForAPI_DBBackedCamelPasses is the second charter acceptance
+// case: a DB-backed field whose property name is canonical-casing (camel on
+// the wire, db: tag carries snake) passes Rule 6 cleanly.
+func TestCheckRule6ForAPI_DBBackedCamelPasses(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"userId": {
+				Value: &openapi3.Schema{
+					Type:        &openapi3.Types{"string"},
+					Description: "User id",
+					Extensions: map[string]any{
+						"x-oapi-codegen-extra-tags": map[string]any{
+							"db":   "user_id",
+							"json": "userId",
+						},
+					},
+				},
+			},
+		},
+	}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"CanonicalResource": &openapi3.SchemaRef{Value: schema},
+			},
+		},
+	}
+
+	vs := checkRule6ForAPI("test.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("expected no Rule 6 violations for camelCase DB-backed field, got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule6ForAPI_NonDBSnakeFails is the third charter acceptance
+// case: a non-DB-backed snake_case property name is (and always has been)
+// a Rule 6 violation — confirming the inversion did not accidentally
+// loosen this path.
+func TestCheckRule6ForAPI_NonDBSnakeFails(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"custom_field": {
+				Value: &openapi3.Schema{
+					Type:        &openapi3.Types{"string"},
+					Description: "A custom field with no DB backing.",
+				},
+			},
+		},
+	}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"Resource": &openapi3.SchemaRef{Value: schema},
+			},
+		},
+	}
+
+	vs := checkRule6ForAPI("test.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 Rule 6 violation for non-DB snake property, got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule6ForAPI_LegacyMirroredFieldAnnotated confirms that when a
+// dbMirroredFields-listed name fails Rule 6, the violation message surfaces
+// the legacy-migration guidance pointing at the plan.
+func TestCheckRule6ForAPI_LegacyMirroredFieldAnnotated(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"created_at": {
+				Value: &openapi3.Schema{
+					Type:        &openapi3.Types{"string"},
+					Description: "Creation timestamp.",
+					Extensions: map[string]any{
+						"x-oapi-codegen-extra-tags": map[string]any{
+							"db": "created_at",
+						},
+					},
+				},
+			},
+		},
+	}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"Resource": &openapi3.SchemaRef{Value: schema},
+			},
+		},
+	}
+
+	vs := checkRule6ForAPI("test.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 Rule 6 violation for created_at, got %d: %+v", len(vs), vs)
+	}
+	if !contains(vs[0].Message, "legacy DB-mirrored") {
+		t.Errorf("expected message to flag 'legacy DB-mirrored', got: %q", vs[0].Message)
+	}
+}
+
+// TestCheckRule32ForAPI_Retired confirms the pre-canonical Rule 32 no
+// longer emits violations; it has been superseded by the canonical
+// contract's "json tag diverges from db tag by design" rule.
+func TestCheckRule32ForAPI_Retired(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"userId": {
+				Value: &openapi3.Schema{
+					Type: &openapi3.Types{"string"},
+					Extensions: map[string]any{
+						"x-oapi-codegen-extra-tags": map[string]any{
+							"db":   "user_id",
+							"json": "userId",
+						},
+					},
+				},
+			},
+		},
+	}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"Resource": &openapi3.SchemaRef{Value: schema},
+			},
+		},
+	}
+	vs := checkRule32ForAPI("test.yml", doc, AuditOptions{Strict: true})
+	if len(vs) != 0 {
+		t.Errorf("Rule 32 is retired; expected 0 violations, got %d: %+v", len(vs), vs)
+	}
+}

--- a/validation/rules_property_test.go
+++ b/validation/rules_property_test.go
@@ -615,3 +615,110 @@ func TestCheckRule32ForAPI_Retired(t *testing.T) {
 		t.Errorf("Rule 32 is retired; expected 0 violations, got %d: %+v", len(vs), vs)
 	}
 }
+
+// TestCheckRule6ForAPI_WalksCompositionAndItems asserts that Rule 6 surfaces
+// inline snake_case property names inside allOf/anyOf/oneOf branches and
+// array items, not just at the top level. This protects baselines against
+// regressions as new constructs add inline composition shapes.
+func TestCheckRule6ForAPI_WalksCompositionAndItems(t *testing.T) {
+	mkStringProp := func() *openapi3.SchemaRef {
+		return &openapi3.SchemaRef{
+			Value: &openapi3.Schema{
+				Type:        &openapi3.Types{"string"},
+				Description: "placeholder",
+			},
+		}
+	}
+	schema := &openapi3.Schema{
+		AllOf: []*openapi3.SchemaRef{
+			{Value: &openapi3.Schema{
+				Type: &openapi3.Types{"object"},
+				Properties: openapi3.Schemas{
+					"nested_snake": mkStringProp(),
+				},
+			}},
+		},
+		Properties: openapi3.Schemas{
+			"items": {
+				Value: &openapi3.Schema{
+					Type: &openapi3.Types{"array"},
+					Items: &openapi3.SchemaRef{
+						Value: &openapi3.Schema{
+							Type: &openapi3.Types{"object"},
+							Properties: openapi3.Schemas{
+								"item_field": mkStringProp(),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	doc := &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				"Composite": &openapi3.SchemaRef{Value: schema},
+			},
+		},
+	}
+
+	vs := checkRule6ForAPI("test.yml", doc, AuditOptions{StyleDebt: true})
+	seen := map[string]bool{}
+	for _, v := range vs {
+		if contains(v.Message, "nested_snake") {
+			seen["nested_snake"] = true
+		}
+		if contains(v.Message, "item_field") {
+			seen["item_field"] = true
+		}
+	}
+	if !seen["nested_snake"] {
+		t.Errorf("expected Rule 6 to flag nested_snake inside allOf; violations: %+v", vs)
+	}
+	if !seen["item_field"] {
+		t.Errorf("expected Rule 6 to flag item_field inside array items; violations: %+v", vs)
+	}
+}
+
+// TestCheckRule6ForAPI_PropertyOrderDeterministic asserts that the order of
+// Rule 6 violations depends only on property names, not on Go map iteration
+// order. Baselines rely on stable ordering.
+func TestCheckRule6ForAPI_PropertyOrderDeterministic(t *testing.T) {
+	mk := func() *openapi3.T {
+		return &openapi3.T{
+			Components: &openapi3.Components{
+				Schemas: openapi3.Schemas{
+					"Zebra": &openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"object"},
+						Properties: openapi3.Schemas{
+							"zebra_field":  {Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+							"alpha_field":  {Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+							"middle_field": {Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+						},
+					}},
+					"Alpha": &openapi3.SchemaRef{Value: &openapi3.Schema{
+						Type: &openapi3.Types{"object"},
+						Properties: openapi3.Schemas{
+							"some_field": {Value: &openapi3.Schema{Type: &openapi3.Types{"string"}}},
+						},
+					}},
+				},
+			},
+		}
+	}
+
+	// Run many times; every run should produce identical output.
+	first := checkRule6ForAPI("test.yml", mk(), AuditOptions{StyleDebt: true})
+	for i := 0; i < 10; i++ {
+		again := checkRule6ForAPI("test.yml", mk(), AuditOptions{StyleDebt: true})
+		if len(first) != len(again) {
+			t.Fatalf("violation count changed between runs: %d vs %d", len(first), len(again))
+		}
+		for j := range first {
+			if first[j].Message != again[j].Message {
+				t.Errorf("violation order/content changed between runs at index %d:\n  a=%s\n  b=%s",
+					j, first[j].Message, again[j].Message)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Implements Agent 1.B of the identifier-naming migration ([plan §7](../blob/master/docs/identifier-naming-migration.md#7-phase-1-agents--schemas-governance--validator-hardening)). AGENTS.md already promised this in PR #788's validator-catch-up note.

## Why
The canonical contract (§1 of the plan) is *"wire is camelCase everywhere; DB is snake_case; the ORM layer is the sole translation boundary."* Two pre-canonical validator rules contradict that:

- **Rule 6** exempted DB-mirrored names from the camelCase requirement, which effectively put snake_case on the wire whenever a property was DB-backed.
- **Rule 32** (blocking) required DB-backed property names to match their snake_case `db:` tag exactly — a direct enforcement of the same anti-canonical pattern.

Under the contract, `propName != db tag` is the *expected* shape for DB-backed fields (`userId` with `db: "user_id"`). Both rules needed to flip.

## What changes

### `validation/casing.go`
- `GetCamelCaseIssues(name)` is now unary — no `allowDBMirrored` / `dbTag` / `gormColumn` parameters. Always checks for snake_case, PascalCase-starting, screaming-ID, and known-lowercase-suffix.
- `dbMirroredFields` survives (still used by `matcher.go`'s consumer-type diff to identify server-generated / DB-mirrored fields in request-side comparisons). Docstring updated to document the repurposed role.
- Removed `isAllowedSnakeCaseProperty` and `isDBBackedSnakeCaseProperty` (the old exemption helpers are no longer called anywhere).

### `validation/rules_naming.go` — `checkPropertyNameCasing` / `checkRule6ForAPI`
- Uses the simplified `GetCamelCaseIssues(propName)`.
- Violation message now appends a **legacy DB-mirrored name — migrate at the resource's next API-version bump per docs/identifier-naming-migration.md §9** note when the property name is in the known-mirrored set, so reviewers have a clear forward-path rather than a generic "snake_case bad" error.
- Docstring on `checkRule6ForAPI` documents the inversion and links to `AGENTS.md § Identifier-naming migration`.

### `validation/rules_entity.go` — `checkRule6ForEntity` / `checkRule32ForEntity`
- Rule 6 behaviour mirrors the api.yml path.
- `checkRule32ForEntity` is retired as a no-op stub with an explanatory comment. The audit dispatch in `validation/audit.go` no longer calls it.

### `validation/rules_property.go` — `checkRule32ForAPI`
- Retired as a no-op stub with an explanatory comment. Removed from the audit dispatch in `validation/audit.go`.

### `validation/audit.go`
- Both Rule 32 dispatch sites removed.

## Tests
- [x] `TestGetCamelCaseIssues` rewritten for the new signature. 14 cases covering camel/snake/legacy-DB-mirrored/non-DB-snake/Pascal-start/screaming-ID/lowercase-suffix.
- [x] `rules_property_test.go` gains 4 new Rule 6 cases per the charter's acceptance criteria:
  - `TestCheckRule6ForAPI_DBBackedSnakeFails` — DB-backed field with snake property name now trips Rule 6.
  - `TestCheckRule6ForAPI_DBBackedCamelPasses` — DB-backed field with camel property name + snake `db:` tag passes cleanly.
  - `TestCheckRule6ForAPI_NonDBSnakeFails` — non-DB snake_case still fails (confirms inversion didn't accidentally loosen).
  - `TestCheckRule6ForAPI_LegacyMirroredFieldAnnotated` — asserts the Phase 3 migration hint appears on legacy DB-mirrored-name violations.
- [x] `TestCheckRule32ForAPI_Retired` — asserts Rule 32 emits no violations even under `--strict-consistency`.
- [x] `go test ./...` — all green.

## CI posture (this PR)

| Target | Pre-1.B | Post-1.B | Δ |
|---|---|---|---|
| `make validate-schemas` (blocking) | green | green | — |
| `make audit-schemas-full` (advisory, `--warn`) | 635 items | 635 items | 0 |
| `make audit-schemas-style-full` (`--warn --style-debt`) | N items | 1721 items | surfaces the new Rule 6 fallout |

Default CI (blocking-validation + advisory-audit jobs) stays green because neither job sets `--style-debt`. The `--style-debt` surface grows because DB-mirrored names are no longer exempt; **Agent 1.G will baseline it** so the surface is acknowledged rather than re-reported on every `audit-schemas-style-full` run.

## Migration impact
- Breaking: no (validator behaviour change only; no schema wire-format changes in this PR).
- API-version bump required: no.
- Consumer repos that must be updated: none — the validator change is internal to `meshery/schemas`.

## Acceptance checklist (per charter)
- [x] Rule 6 requires camelCase unconditionally.
- [x] DB-backing exception removed from both api.yml and entity paths.
- [x] `knownLowercaseSuffixViolations` and `screamingIDRE` preserved.
- [x] `dbMirroredFields` repurposed (not an exception; labels legacy debt in violations; still available for `matcher.go`).
- [x] Test cases for DB-backed snake (fail), DB-backed camel (pass), non-DB snake (still fail) all present and passing.
- [x] Docstring on `checkRule6ForAPI` documents the inversion and links to AGENTS.md.
- [x] `make validate-schemas` green.

## Rollback
Revert the commit — Rule 6 reverts to the pre-canonical behaviour and Rule 32 re-activates.