### PR TITLE
validation: add Rule 45 (partial casing migrations forbidden) per Phase 1.C

### DIFF
--- a/validation/audit.go
+++ b/validation/audit.go
@@ -284,6 +284,7 @@ func auditAPISpec(apiYmlPath, constructDir string, opts AuditOptions,
 		checkRule28, checkRule30, checkRule31, checkRule35,
 		checkRule36,
 		checkRule42, checkRule43, checkRule44,
+		checkRule45ForAPI,
 	}
 
 	for _, check := range ruleChecks {

--- a/validation/rules_naming.go
+++ b/validation/rules_naming.go
@@ -407,15 +407,24 @@ func getExtraTag(extensions map[string]any, tagName string) string {
 // `MesheryPattern` struct's `OrgID json:"orgId"` + `WorkspaceID
 // json:"workspace_id"` + `UserID json:"user_id"`).
 //
-// Casing families:
-//   - camel     — camelCase or lowercase single word (`userId`, `name`).
+// Casing families (see classifyCasingFamily for the full taxonomy):
+//   - camel     — starts lowercase, contains at least one uppercase, no
+//                 consecutive-uppercase acronym run (`userId`, `orgId`).
 //   - snake     — contains an underscore (`user_id`, `created_at`).
-//   - screaming — all-uppercase token, or contains a SCREAMING-ID /
-//                 SCREAMING-URL token (`ID`, `URL`, `orgID`, `pageURL`).
+//   - screaming — all-uppercase, or contains a 2+ consecutive-uppercase
+//                 acronym token (`ID`, `URL`, `orgID`, `pageURL`).
+//   - lowercase — single-word all-lowercase, no underscore, no uppercase
+//                 (`id`, `name`, `metadata`). Agnostic bucket: does NOT
+//                 count toward the mixed-family trigger.
 //
 // Pure-camel and pure-snake structs both pass — a fully-legacy-snake
-// struct is caught by Rule 6 independently. Only the mixed case fails
-// Rule 45.
+// struct is caught by Rule 6 independently. The rule fires only when
+// two or more of {camel, snake, screaming} appear in the same struct;
+// a mix with only the agnostic `lowercase` bucket is not a drift.
+//
+// Properties with `json:"-"` are excluded from the wire-name set
+// (they don't reach the wire), so DB-only fields like `model_id` with
+// `json:"-"` do not contribute a snake-family member.
 //
 // Composition: inline `allOf`/`anyOf`/`oneOf` branches and array `items`
 // are walked as part of the *same* struct (their properties contribute to
@@ -480,7 +489,8 @@ func isMixedForRule45(families map[string][]string) bool {
 
 // rule45Message renders the violation text for a schema that mixes casing
 // families. Families are listed in deterministic order with their members
-// sorted, so violation text is stable run-to-run.
+// sorted and deduplicated (composition can visit the same wire name more
+// than once), so violation text is stable run-to-run and readable.
 func rule45Message(schemaName string, families map[string][]string) string {
 	familyNames := make([]string, 0, len(families))
 	for f := range families {
@@ -492,7 +502,14 @@ func rule45Message(schemaName string, families map[string][]string) string {
 	for _, f := range familyNames {
 		members := append([]string(nil), families[f]...)
 		sort.Strings(members)
-		parts = append(parts, fmt.Sprintf("%s: [%s]", f, strings.Join(members, ", ")))
+		// Deduplicate adjacent entries (list is sorted).
+		out := members[:0]
+		for i, m := range members {
+			if i == 0 || m != members[i-1] {
+				out = append(out, m)
+			}
+		}
+		parts = append(parts, fmt.Sprintf("%s: [%s]", f, strings.Join(out, ", ")))
 	}
 	return fmt.Sprintf(
 		`Schema %q mixes JSON-tag casing conventions across its properties — %s. Partial casing migrations are forbidden under the canonical identifier-naming contract. If the wire format must change, introduce a new API version and migrate every property consistently. See AGENTS.md § "Casing rules at a glance" and docs/identifier-naming-migration.md §9.`,
@@ -520,8 +537,13 @@ func collectCasingFamilies(schema *openapi3.Schema, families map[string][]string
 			}
 			propRef := schema.Properties[propName]
 			effective := effectiveWireName(propRef, propName)
-			family := classifyCasingFamily(effective)
-			families[family] = append(families[family], effective)
+			if effective != "" {
+				// `json:"-"` properties return "" from effectiveWireName
+				// and are excluded from the wire-name set — they are
+				// DB-only / internal and must not trigger Rule 45.
+				family := classifyCasingFamily(effective)
+				families[family] = append(families[family], effective)
+			}
 			// Recurse into the property's own schema (nested objects,
 			// array items, composition) so inline composite shapes
 			// contribute to the same family set.
@@ -619,18 +641,39 @@ func hasConsecutiveUppercase(name string) bool {
 	return false
 }
 
-// effectiveWireName returns the JSON-tag override from
-// `x-oapi-codegen-extra-tags.json` if present and non-empty (minus any
-// `,omitempty` modifier), otherwise the OpenAPI property key itself.
-// Rule 45 cares about what reaches the wire, not what the source file
-// calls the property.
+// effectiveWireName returns the wire-visible name of a property, or the
+// empty string when the property is not on the wire at all
+// (`x-oapi-codegen-extra-tags.json: "-"`). Callers treat the empty return
+// as "exclude from the wire-name set" — a `json:"-"` field must not
+// contribute to Rule 45's family set because it is DB-only / internal,
+// not part of the wire contract. The usual resolution is:
+//
+//   - If `json:"-"` is set, return "" (not on the wire).
+//   - Otherwise if `x-oapi-codegen-extra-tags.json` names the wire form,
+//     return that name (minus any `,omitempty` modifier — that's
+//     stripped by getExtraTag).
+//   - Otherwise fall back to the OpenAPI property key, which is the
+//     JSON tag by default.
 func effectiveWireName(propRef *openapi3.SchemaRef, propName string) string {
 	if propRef == nil || propRef.Value == nil {
 		return propName
 	}
-	js := getExtraTag(propRef.Value.Extensions, "json")
-	if js == "" || js == "-" {
-		return propName
+	// getExtraTag strips any `,omitempty` after the first comma, but does
+	// not distinguish "no override" from "override is `-`". Consult the
+	// raw extension map for the dash case.
+	if raw, ok := propRef.Value.Extensions["x-oapi-codegen-extra-tags"].(map[string]any); ok {
+		if js, ok := raw["json"].(string); ok {
+			head := js
+			if idx := strings.Index(js, ","); idx >= 0 {
+				head = js[:idx]
+			}
+			if head == "-" {
+				return ""
+			}
+			if head != "" {
+				return head
+			}
+		}
 	}
-	return js
+	return propName
 }

--- a/validation/rules_naming.go
+++ b/validation/rules_naming.go
@@ -391,3 +391,246 @@ func getExtraTag(extensions map[string]any, tagName string) string {
 	}
 	return s
 }
+
+// --- Rule 45: Partial casing migrations forbidden ---
+
+// Rule 45 flags `components/schemas/<Entity>` objects whose effective
+// wire-form property names (schema-property key, or the
+// `x-oapi-codegen-extra-tags.json` override when present) mix two or more
+// casing families — camel / snake / screaming. Under the canonical
+// identifier-naming contract (AGENTS.md § Casing rules at a glance,
+// docs/identifier-naming-migration.md §1), when a resource's wire format
+// changes, the change must land on a new API version and migrate *every*
+// property consistently. A struct that publishes `userId` + `user_id` +
+// `orgId` is the symptom of a partial migration that forgot some fields
+// — exactly the class of drift this rule catches (e.g., meshery/server
+// `MesheryPattern` struct's `OrgID json:"orgId"` + `WorkspaceID
+// json:"workspace_id"` + `UserID json:"user_id"`).
+//
+// Casing families:
+//   - camel     — camelCase or lowercase single word (`userId`, `name`).
+//   - snake     — contains an underscore (`user_id`, `created_at`).
+//   - screaming — all-uppercase token, or contains a SCREAMING-ID /
+//                 SCREAMING-URL token (`ID`, `URL`, `orgID`, `pageURL`).
+//
+// Pure-camel and pure-snake structs both pass — a fully-legacy-snake
+// struct is caught by Rule 6 independently. Only the mixed case fails
+// Rule 45.
+//
+// Composition: inline `allOf`/`anyOf`/`oneOf` branches and array `items`
+// are walked as part of the *same* struct (their properties contribute to
+// the same family set). `$ref` pointers are not followed — referenced
+// components are walked as their own schemas by the outer loop.
+//
+// Severity is flag-gated via classifyStyleIssue — advisory under
+// `--style-debt`, blocking under `--strict-consistency`, suppressed
+// otherwise. The current repo has many legacy mixed structs; Agent 1.G
+// will baseline them. Post-Phase-3, the rule should run clean.
+func checkRule45ForAPI(filePath string, doc *openapi3.T, opts AuditOptions) []Violation {
+	sev := classifyStyleIssue(opts)
+	if sev == nil {
+		return nil
+	}
+	if doc == nil || doc.Components == nil || doc.Components.Schemas == nil {
+		return nil
+	}
+	var out []Violation
+	schemaNames := make([]string, 0, len(doc.Components.Schemas))
+	for name := range doc.Components.Schemas {
+		schemaNames = append(schemaNames, name)
+	}
+	sort.Strings(schemaNames)
+
+	for _, schemaName := range schemaNames {
+		schemaRef := doc.Components.Schemas[schemaName]
+		if schemaRef == nil || schemaRef.Value == nil {
+			continue
+		}
+		families := map[string][]string{}
+		collectCasingFamilies(schemaRef.Value, families)
+		if !isMixedForRule45(families) {
+			continue
+		}
+		out = append(out, Violation{
+			File:       filePath,
+			Message:    rule45Message(schemaName, families),
+			Severity:   *sev,
+			RuleNumber: 45,
+		})
+	}
+	return out
+}
+
+// isMixedForRule45 returns true when the family set constitutes a
+// partial-migration drift: at least two *distinct* casing conventions
+// appear (camel / snake / screaming), ignoring the agnostic "lowercase"
+// single-word bucket and the "other" catch-all. A struct with only
+// lowercase single-word keys plus snake keys is not a partial migration;
+// it's plain legacy, and Rule 6 already flags the snake keys.
+func isMixedForRule45(families map[string][]string) bool {
+	distinct := 0
+	for f := range families {
+		switch f {
+		case "camel", "snake", "screaming":
+			distinct++
+		}
+	}
+	return distinct >= 2
+}
+
+// rule45Message renders the violation text for a schema that mixes casing
+// families. Families are listed in deterministic order with their members
+// sorted, so violation text is stable run-to-run.
+func rule45Message(schemaName string, families map[string][]string) string {
+	familyNames := make([]string, 0, len(families))
+	for f := range families {
+		familyNames = append(familyNames, f)
+	}
+	sort.Strings(familyNames)
+
+	var parts []string
+	for _, f := range familyNames {
+		members := append([]string(nil), families[f]...)
+		sort.Strings(members)
+		parts = append(parts, fmt.Sprintf("%s: [%s]", f, strings.Join(members, ", ")))
+	}
+	return fmt.Sprintf(
+		`Schema %q mixes JSON-tag casing conventions across its properties — %s. Partial casing migrations are forbidden under the canonical identifier-naming contract. If the wire format must change, introduce a new API version and migrate every property consistently. See AGENTS.md § "Casing rules at a glance" and docs/identifier-naming-migration.md §9.`,
+		schemaName, strings.Join(parts, "; "))
+}
+
+// collectCasingFamilies accumulates every property's effective wire name
+// into the families map, grouped by casing family. Recurses into inline
+// composition (allOf/anyOf/oneOf) and array items so a schema assembled
+// from composition is evaluated as one unit. Does not follow $ref.
+func collectCasingFamilies(schema *openapi3.Schema, families map[string][]string) {
+	if schema == nil {
+		return
+	}
+
+	if schema.Properties != nil {
+		propNames := make([]string, 0, len(schema.Properties))
+		for name := range schema.Properties {
+			propNames = append(propNames, name)
+		}
+		sort.Strings(propNames)
+		for _, propName := range propNames {
+			if strings.HasPrefix(propName, "$") {
+				continue
+			}
+			propRef := schema.Properties[propName]
+			effective := effectiveWireName(propRef, propName)
+			family := classifyCasingFamily(effective)
+			families[family] = append(families[family], effective)
+			// Recurse into the property's own schema (nested objects,
+			// array items, composition) so inline composite shapes
+			// contribute to the same family set.
+			if propRef != nil && propRef.Value != nil && propRef.Ref == "" {
+				collectCasingFamilies(propRef.Value, families)
+			}
+		}
+	}
+
+	for _, sub := range schema.AllOf {
+		if sub != nil && sub.Value != nil && sub.Ref == "" {
+			collectCasingFamilies(sub.Value, families)
+		}
+	}
+	for _, sub := range schema.OneOf {
+		if sub != nil && sub.Value != nil && sub.Ref == "" {
+			collectCasingFamilies(sub.Value, families)
+		}
+	}
+	for _, sub := range schema.AnyOf {
+		if sub != nil && sub.Value != nil && sub.Ref == "" {
+			collectCasingFamilies(sub.Value, families)
+		}
+	}
+	if schema.Items != nil && schema.Items.Value != nil && schema.Items.Ref == "" {
+		collectCasingFamilies(schema.Items.Value, families)
+	}
+}
+
+// classifyCasingFamily returns the casing family for a wire-form
+// identifier. The buckets used by Rule 45 are:
+//
+//   - "camel"     — camelCase (starts lowercase, at least one uppercase,
+//                   no consecutive uppercase acronym). Example: "userId".
+//   - "snake"     — contains an underscore. Example: "user_id".
+//   - "screaming" — entirely uppercase, OR contains a 2+ consecutive-
+//                   uppercase acronym token (e.g. "ID" in "orgID",
+//                   "URL" in "pageURL", "HPA" in "HPAReplicas").
+//   - "lowercase" — all-lowercase single word with no underscore. This
+//                   is an agnostic bucket: `id`, `name`, `owner`,
+//                   `metadata`, `status` — identifiers that are the
+//                   canonical single-word form for both camel and snake
+//                   traditions. Rule 45 treats this bucket as
+//                   non-conflicting: it does not count as "the camel
+//                   half of a snake/camel mix", because a legacy-snake
+//                   struct that uses `id` alongside `user_id` is not a
+//                   partial migration.
+//   - "other"     — empty input or a form that doesn't fit any bucket.
+func classifyCasingFamily(name string) string {
+	if name == "" {
+		return "other"
+	}
+	if HasUnderscore(name) {
+		return "snake"
+	}
+	hasUpper := false
+	hasLower := false
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if c >= 'A' && c <= 'Z' {
+			hasUpper = true
+		}
+		if c >= 'a' && c <= 'z' {
+			hasLower = true
+		}
+	}
+	if hasUpper && !hasLower {
+		return "screaming"
+	}
+	if hasConsecutiveUppercase(name) {
+		return "screaming"
+	}
+	if !hasUpper {
+		return "lowercase"
+	}
+	return "camel"
+}
+
+// hasConsecutiveUppercase reports whether name contains a run of two or
+// more consecutive ASCII uppercase letters — a SCREAMING-acronym token
+// such as "ID" in "orgID", "URL" in "pageURL", or "HPA" in "HPAReplicas".
+func hasConsecutiveUppercase(name string) bool {
+	run := 0
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if c >= 'A' && c <= 'Z' {
+			run++
+			if run >= 2 {
+				return true
+			}
+			continue
+		}
+		run = 0
+	}
+	return false
+}
+
+// effectiveWireName returns the JSON-tag override from
+// `x-oapi-codegen-extra-tags.json` if present and non-empty (minus any
+// `,omitempty` modifier), otherwise the OpenAPI property key itself.
+// Rule 45 cares about what reaches the wire, not what the source file
+// calls the property.
+func effectiveWireName(propRef *openapi3.SchemaRef, propName string) string {
+	if propRef == nil || propRef.Value == nil {
+		return propName
+	}
+	js := getExtraTag(propRef.Value.Extensions, "json")
+	if js == "" || js == "-" {
+		return propName
+	}
+	return js
+}

--- a/validation/rules_naming_test.go
+++ b/validation/rules_naming_test.go
@@ -1,0 +1,332 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Helpers for Rule 45 tests.
+func mkStringPropWithJSON(jsonTag string) *openapi3.SchemaRef {
+	var ext map[string]any
+	if jsonTag != "" {
+		ext = map[string]any{
+			"x-oapi-codegen-extra-tags": map[string]any{
+				"json": jsonTag,
+			},
+		}
+	}
+	return &openapi3.SchemaRef{
+		Value: &openapi3.Schema{
+			Type:        &openapi3.Types{"string"},
+			Description: "placeholder",
+			Extensions:  ext,
+		},
+	}
+}
+
+func mkStringProp() *openapi3.SchemaRef {
+	return mkStringPropWithJSON("")
+}
+
+// docWithSchema returns a doc with a single component schema at the given
+// name, simplifying the boilerplate for Rule 45 tests.
+func docWithSchema(name string, schema *openapi3.Schema) *openapi3.T {
+	return &openapi3.T{
+		Components: &openapi3.Components{
+			Schemas: openapi3.Schemas{
+				name: &openapi3.SchemaRef{Value: schema},
+			},
+		},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rule 45: Partial casing migrations forbidden
+// ---------------------------------------------------------------------------
+
+// TestCheckRule45ForAPI_AllCamelPasses — the first charter acceptance case:
+// a struct whose properties are all camelCase (or single-word lowercase)
+// surfaces no Rule 45 violation.
+func TestCheckRule45ForAPI_AllCamelPasses(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"id":          mkStringProp(),
+			"userId":      mkStringProp(),
+			"orgId":       mkStringProp(),
+			"name":        mkStringProp(),
+			"patternFile": mkStringProp(),
+		},
+	}
+	vs := checkRule45ForAPI("t.yml", docWithSchema("Canonical", schema),
+		AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("all-camel struct should not trip Rule 45; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule45ForAPI_AllSnakePasses — the second charter acceptance
+// case: a pure legacy all-snake struct passes Rule 45. Lowercase
+// single-word keys like `id` are in the agnostic "lowercase" bucket —
+// they don't count as "the camel half of a snake/camel mix" because
+// they're the canonical single-word form for either tradition. Rule 6
+// flags the snake fields independently.
+func TestCheckRule45ForAPI_AllSnakePasses(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"id":         mkStringProp(),
+			"name":       mkStringProp(),
+			"user_id":    mkStringProp(),
+			"org_id":     mkStringProp(),
+			"created_at": mkStringProp(),
+		},
+	}
+	vs := checkRule45ForAPI("t.yml", docWithSchema("LegacyUniform", schema),
+		AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("all-snake legacy struct should not trip Rule 45; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule45ForAPI_LowercaseAgnostic confirms that a struct whose
+// properties are all lowercase single-words (no underscore, no
+// uppercase) does not trip Rule 45 — it's purely agnostic.
+func TestCheckRule45ForAPI_LowercaseAgnostic(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"id":       mkStringProp(),
+			"name":     mkStringProp(),
+			"owner":    mkStringProp(),
+			"metadata": mkStringProp(),
+		},
+	}
+	vs := checkRule45ForAPI("t.yml", docWithSchema("Simple", schema),
+		AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("lowercase-only struct should not trip Rule 45; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule45ForAPI_MixedFails — the third charter acceptance case:
+// the classic partial-migration drift class. The message must name each
+// non-matching field so reviewers know exactly where the mix is.
+func TestCheckRule45ForAPI_MixedFails(t *testing.T) {
+	// Model the meshery/server MesheryPattern drift:
+	//   OrgID       json:"orgId"         -> camel
+	//   WorkspaceID json:"workspace_id"  -> snake
+	//   UserID      json:"user_id"       -> snake
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"orgId":        mkStringProp(),
+			"workspace_id": mkStringProp(),
+			"user_id":      mkStringProp(),
+		},
+	}
+	vs := checkRule45ForAPI("t.yml", docWithSchema("MesheryPattern", schema),
+		AuditOptions{StyleDebt: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 Rule 45 violation, got %d: %+v", len(vs), vs)
+	}
+	msg := vs[0].Message
+	for _, want := range []string{"MesheryPattern", "orgId", "user_id", "workspace_id", "camel", "snake"} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("message missing %q; got: %s", want, msg)
+		}
+	}
+	if vs[0].RuleNumber != 45 {
+		t.Errorf("expected RuleNumber=45, got %d", vs[0].RuleNumber)
+	}
+}
+
+// TestCheckRule45ForAPI_ScreamingFails — a struct mixing camel with an
+// ALL-CAPS ID/URL token fails Rule 45 (classic `orgID` drift).
+func TestCheckRule45ForAPI_ScreamingFails(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"orgID":  mkStringProp(), // screaming ID
+			"userId": mkStringProp(), // camel
+		},
+	}
+	vs := checkRule45ForAPI("t.yml", docWithSchema("Mixed", schema),
+		AuditOptions{StyleDebt: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 Rule 45 violation for camel+screaming mix; got %d: %+v", len(vs), vs)
+	}
+	if !strings.Contains(vs[0].Message, "camel") || !strings.Contains(vs[0].Message, "screaming") {
+		t.Errorf("message should name both families; got: %s", vs[0].Message)
+	}
+}
+
+// TestCheckRule45ForAPI_JSONTagOverrideWins — when a property's effective
+// wire name comes from `x-oapi-codegen-extra-tags.json`, Rule 45 classifies
+// on that override, not the OpenAPI property key. A schema that keeps
+// snake_case property keys while overriding the wire form to camelCase on
+// every field should pass.
+func TestCheckRule45ForAPI_JSONTagOverrideWins(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"user_id": mkStringPropWithJSON("userId"),
+			"org_id":  mkStringPropWithJSON("orgId"),
+			"name":    mkStringProp(),
+		},
+	}
+	vs := checkRule45ForAPI("t.yml", docWithSchema("OverrideConsistent", schema),
+		AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("JSON-tag override should set the effective wire name; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule45ForAPI_WalksComposition — inline allOf/anyOf/oneOf branches
+// and array items contribute properties to the same family set, because
+// they're part of the same struct's wire shape.
+func TestCheckRule45ForAPI_WalksComposition(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"userId": mkStringProp(),
+		},
+		AllOf: []*openapi3.SchemaRef{
+			{Value: &openapi3.Schema{
+				Properties: openapi3.Schemas{
+					"user_id": mkStringProp(), // snake nested in allOf
+				},
+			}},
+		},
+	}
+	vs := checkRule45ForAPI("t.yml", docWithSchema("CompositeDrift", schema),
+		AuditOptions{StyleDebt: true})
+	if len(vs) != 1 {
+		t.Fatalf("composition should contribute to the same family set; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule45ForAPI_SuppressedWhenNotStyleDebt — the rule is gated by
+// classifyStyleIssue, so a plain AuditOptions (no --style-debt) returns
+// nothing.
+func TestCheckRule45ForAPI_SuppressedWhenNotStyleDebt(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"orgId":   mkStringProp(),
+			"user_id": mkStringProp(),
+		},
+	}
+	vs := checkRule45ForAPI("t.yml", docWithSchema("Mixed", schema),
+		AuditOptions{})
+	if len(vs) != 0 {
+		t.Errorf("expected Rule 45 suppressed without --style-debt; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule45ForAPI_StrictBlocks — under --strict-consistency Rule 45
+// fires at SeverityBlocking (same path as every other style rule).
+func TestCheckRule45ForAPI_StrictBlocks(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"orgId":   mkStringProp(),
+			"user_id": mkStringProp(),
+		},
+	}
+	vs := checkRule45ForAPI("t.yml", docWithSchema("Mixed", schema),
+		AuditOptions{Strict: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 Rule 45 violation under --strict-consistency; got %d", len(vs))
+	}
+	if vs[0].Severity != SeverityBlocking {
+		t.Errorf("expected SeverityBlocking under --strict-consistency, got %v", vs[0].Severity)
+	}
+}
+
+// TestCheckRule45ForAPI_Deterministic — violation message content must be
+// stable across runs so the advisory baseline file doesn't diff from
+// map-iteration order.
+func TestCheckRule45ForAPI_Deterministic(t *testing.T) {
+	mk := func() *openapi3.T {
+		return docWithSchema("Drift", &openapi3.Schema{
+			Type: &openapi3.Types{"object"},
+			Properties: openapi3.Schemas{
+				"zField":       mkStringProp(),
+				"a_field":      mkStringProp(),
+				"middleField":  mkStringProp(),
+				"another_snake": mkStringProp(),
+			},
+		})
+	}
+	first := checkRule45ForAPI("t.yml", mk(), AuditOptions{StyleDebt: true})
+	for i := 0; i < 10; i++ {
+		again := checkRule45ForAPI("t.yml", mk(), AuditOptions{StyleDebt: true})
+		if len(first) != len(again) {
+			t.Fatalf("violation count changed between runs: %d vs %d", len(first), len(again))
+		}
+		for j := range first {
+			if first[j].Message != again[j].Message {
+				t.Errorf("violation text changed between runs at index %d:\n  a=%s\n  b=%s",
+					j, first[j].Message, again[j].Message)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Casing-family classifier (shared helper)
+// ---------------------------------------------------------------------------
+
+func TestClassifyCasingFamily(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"userId", "camel"},
+		{"orgId", "camel"},
+		{"name", "lowercase"},     // single-word lowercase — agnostic bucket
+		{"metadata", "lowercase"},
+		{"a", "lowercase"},
+		{"id", "lowercase"},
+		{"user_id", "snake"},
+		{"created_at", "snake"},
+		{"page_size", "snake"},
+		{"ID", "screaming"},
+		{"URL", "screaming"},
+		{"orgID", "screaming"},   // contains "ID" token
+		{"pageURL", "screaming"}, // contains "URL" token
+		{"UserID", "screaming"},  // PascalCase + acronym — rule 45 treats the "ID" token as screaming
+		{"", "other"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			got := classifyCasingFamily(tc.in)
+			if got != tc.want {
+				t.Errorf("classifyCasingFamily(%q) = %q; want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEffectiveWireName(t *testing.T) {
+	cases := []struct {
+		name, override, want string
+	}{
+		{"userId", "", "userId"},
+		{"user_id", "userId", "userId"},
+		{"user_id", "userId,omitempty", "userId"},
+		{"transient", "-", "transient"}, // json:"-" falls back to property name
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+"/"+tc.override, func(t *testing.T) {
+			ref := mkStringPropWithJSON(tc.override)
+			got := effectiveWireName(ref, tc.name)
+			if got != tc.want {
+				t.Errorf("effectiveWireName(%q, override=%q) = %q; want %q",
+					tc.name, tc.override, got, tc.want)
+			}
+		})
+	}
+}

--- a/validation/rules_naming_test.go
+++ b/validation/rules_naming_test.go
@@ -317,7 +317,11 @@ func TestEffectiveWireName(t *testing.T) {
 		{"userId", "", "userId"},
 		{"user_id", "userId", "userId"},
 		{"user_id", "userId,omitempty", "userId"},
-		{"transient", "-", "transient"}, // json:"-" falls back to property name
+
+		// json:"-" means the field is not serialized — excluded from the
+		// wire-name set. effectiveWireName returns "" to signal that.
+		{"model_id", "-", ""},
+		{"model_id", "-,omitempty", ""}, // pathological form; still excluded
 	}
 	for _, tc := range cases {
 		t.Run(tc.name+"/"+tc.override, func(t *testing.T) {
@@ -328,5 +332,26 @@ func TestEffectiveWireName(t *testing.T) {
 					tc.name, tc.override, got, tc.want)
 			}
 		})
+	}
+}
+
+// TestCheckRule45ForAPI_JSONDashExcluded confirms that a DB-only
+// snake_case property with `json:"-"` does NOT contribute a snake-family
+// member to Rule 45's mixing check, because it is not on the wire.
+// Without this, DB-joined fields like `model_id json:"-"` would
+// incorrectly trigger Rule 45 on otherwise-canonical camelCase structs.
+func TestCheckRule45ForAPI_JSONDashExcluded(t *testing.T) {
+	schema := &openapi3.Schema{
+		Type: &openapi3.Types{"object"},
+		Properties: openapi3.Schemas{
+			"userId":   mkStringProp(),
+			"orgId":    mkStringProp(),
+			"model_id": mkStringPropWithJSON("-"), // DB-only, never on wire
+		},
+	}
+	vs := checkRule45ForAPI("t.yml", docWithSchema("HasDBOnly", schema),
+		AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("json:\"-\" DB-only field should be excluded from Rule 45; got %d: %+v", len(vs), vs)
 	}
 }


### PR DESCRIPTION
Implements Agent 1.C of the identifier-naming migration ([plan §7](../blob/master/docs/identifier-naming-migration.md#7-phase-1-agents--schemas-governance--validator-hardening)). The canonical contract (§1) forbids partial casing migrations within a single API version — if the wire format must change, the resource gets a new API version and every property migrates consistently. Rule 45 flags the symptom: a `components/schemas/<Entity>` object whose property names mix two or more casing families.

## Casing families (Rule 45)

| Family | Definition | Example |
|---|---|---|
| `camel` | camelCase (lowercase start, uppercase later, no acronym run) | `userId`, `orgId`, `schemaVersion` |
| `snake` | contains an underscore | `user_id`, `created_at` |
| `screaming` | all-uppercase, or contains a 2+ consecutive-uppercase acronym token | `ID`, `URL`, `orgID`, `pageURL`, `HPAReplicas` |
| `lowercase` | single-word all-lowercase, no underscore, no uppercase | `id`, `name`, `owner`, `metadata` |
| `other` | empty / doesn't fit any bucket | — |

The `lowercase` bucket is **agnostic**: `id` alongside `user_id` is not a partial migration, it's plain legacy. Rule 45 fires only when at least two of {`camel`, `snake`, `screaming`} appear together in the same struct's effective wire-name set.

## Effective wire name

Rule 45 classifies on what reaches the wire, not the OpenAPI property key itself. `x-oapi-codegen-extra-tags.json` overrides (minus `,omitempty`) take precedence. A schema that keeps snake_case keys internally but overrides every JSON tag to camelCase passes the rule.

## Composition

Inline `allOf`/`anyOf`/`oneOf` branches and array `items` contribute to the same family set (same struct's wire shape). `$ref` is not followed — referenced schemas are walked as their own components by the outer loop.

## Determinism

Schema and property iteration is sorted; families are emitted alphabetically with members also sorted. Covered by `TestCheckRule45ForAPI_Deterministic` running the check 10× and asserting identical output — baseline files depend on this.

## Severity

Flag-gated via `classifyStyleIssue` — advisory under `--style-debt`, blocking under `--strict-consistency`, suppressed otherwise (same path as Rule 6). Default CI stays green.

## Tests (per charter acceptance)
- [x] **(i)** all-camel struct → pass (`TestCheckRule45ForAPI_AllCamelPasses`)
- [x] **(ii)** all-snake legacy → pass (`TestCheckRule45ForAPI_AllSnakePasses` — includes `id`/`name` in the lowercase bucket + snake fields, expects no fire)
- [x] **(iii)** mixed camel+snake → fail with message citing each field (`TestCheckRule45ForAPI_MixedFails`, models the MesheryPattern drift from the charter: `orgId` + `workspace_id` + `user_id`)

Plus 6 additional cases: screaming drift, JSON-tag-override wins, composition walking, suppression without `--style-debt`, blocking under `--strict-consistency`, determinism, agnostic-lowercase struct passes. Also unit coverage for `classifyCasingFamily` and `effectiveWireName`.

## CI posture
| Target | Pre-1.C | Post-1.C | Δ |
|---|---|---|---|
| `make validate-schemas` | green | green | — |
| `make audit-schemas` (`--warn`) | 635 advisory | 635 advisory | 0 |
| `make audit-schemas-style-full` | — | +29 Rule 45 firings | +29 |

The 29 firings cover the expected real-world drift (Environment, ModelDefinition, *Page envelopes, UserRoleUpdateRequest, etc.). **Agent 1.G baselines this surface.**

## Human-review required per master plan §5.3
This PR adds a new rule in `schemas/validation/` that is blocking under `--strict-consistency`. Per §5.3 ("Any change to schemas/validation/ that adds or inverts a blocking rule") auto-merge is NOT armed; leaving the merge to a maintainer.

## Rollback
Revert the commit; Rule 45 disappears from the dispatch.