### PR TITLE
validation: add Rule 46 (sibling-endpoint parameter parity) per Phase 1.D

### DIFF
--- a/validation/audit.go
+++ b/validation/audit.go
@@ -127,6 +127,9 @@ func Audit(opts AuditOptions) AuditResult {
 	// Cross-construct fingerprints for Rule 29.
 	fingerprints := make(map[string][]schemaLocation)
 
+	// Cross-file sibling-endpoint parameter parity accumulator for Rule 46.
+	parity := &parityAccumulator{}
+
 	// Walk validated construct specs. Errors are intentionally ignored:
 	// Audit returns AuditResult, not error, and individual load failures
 	// are reported as blocking violations inside auditAPISpec.
@@ -142,12 +145,22 @@ func Audit(opts AuditOptions) AuditResult {
 		if spec.APIExists {
 			auditAPISpec(spec.APIYMLPath, spec.ConstructDir, opts, baseline, &result,
 				fingerprints, enumBaselineRef, spec.Doc)
+			// Collect Rule 46 cross-file parity candidates from this
+			// api.yml. The file's version prefix (e.g. "v1beta1") defines
+			// the comparison group.
+			relPath := relativeToRoot(spec.APIYMLPath, opts.RootDir)
+			collectParityEndpoints(relPath, spec.Version, spec.Doc, parity)
 		}
 		return nil
 	})
 
 	// Rule 29: report cross-construct duplicates.
 	for _, v := range reportDuplicateSchemas(fingerprints, opts) {
+		addViolation(&result, v, baseline)
+	}
+
+	// Rule 46: cross-file sibling-endpoint parameter parity.
+	for _, v := range reportParityViolations(parity, opts) {
 		addViolation(&result, v, baseline)
 	}
 

--- a/validation/rules_parity.go
+++ b/validation/rules_parity.go
@@ -1,0 +1,229 @@
+package validation
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// --- Rule 46: Sibling-endpoint parameter parity ---
+//
+// Rule 46 catches the class of drift that hit the workspaces list endpoint
+// in production: `GET /api/workspaces` was missing a
+// `$ref: "#/components/parameters/orgIdQuery"` filter ref even though the
+// sibling `GET /api/environments` declared one, causing server-side handlers
+// to drop the `orgId` query and return 400. The rule compares top-level
+// collection-list GET endpoints across every `api.yml` in the same API
+// version directory (e.g. `schemas/constructs/v1beta1/*/api.yml`) — if at
+// least one declares `orgIdQuery`, every other list endpoint in that
+// version must too.
+//
+// A "collection-list endpoint" for Rule 46 purposes is:
+//
+//   - A GET operation
+//   - On a path that contains no path parameters (`{...}`) — list
+//     endpoints take no selector.
+//   - Whose 200 response body schema references a schema whose name ends
+//     in "Page" (the Page-shape pagination envelope). The Page-shape
+//     filter narrows the rule to real list endpoints and excludes
+//     non-listing GETs like `GET /api/system/version`.
+//
+// This rule requires cross-file visibility, so the per-file walker
+// collects endpoints into a parityAccumulator during Audit(), and the
+// check fires from Audit() after every api.yml has been scanned — mirror-
+// ing the Rule 29 cross-construct fingerprint pattern.
+//
+// Severity is flag-gated via classifyStyleIssue — advisory under
+// `--style-debt`, blocking under `--strict-consistency`, suppressed
+// otherwise. Agent 1.G baselines the surface; after Phase 3 per-resource
+// migrations, Rule 46 should run clean.
+
+// parityEndpoint is one top-level collection-list GET endpoint captured
+// from an api.yml.
+type parityEndpoint struct {
+	file          string
+	version       string
+	path          string
+	operationID   string
+	hasOrgIDQuery bool
+}
+
+// parityAccumulator buffers collection-list endpoints across all api.yml
+// files in a single Audit() run so the cross-version parity check can
+// compare them after the per-file walk completes.
+type parityAccumulator struct {
+	endpoints []parityEndpoint
+}
+
+// orgIDQueryParamRef matches the canonical parameter $ref that environments
+// + views declare today. The rule intentionally matches the literal ref
+// path rather than the parameter name so a resource that re-uses the
+// declared param component is recognised, while an inline param with the
+// same name is only recognised via the inline-name fallback below.
+const orgIDQueryParamRef = "#/components/parameters/orgIdQuery"
+
+// collectParityEndpoints appends every top-level collection-list GET in
+// `doc` to `acc`. Invoked by auditAPISpec during the per-file walk.
+func collectParityEndpoints(filePath, version string, doc *openapi3.T, acc *parityAccumulator) {
+	if acc == nil || doc == nil || doc.Paths == nil {
+		return
+	}
+	for path, item := range doc.Paths.Map() {
+		if strings.Contains(path, "{") {
+			continue // path with params is not a list endpoint
+		}
+		op := item.Get
+		if op == nil {
+			continue
+		}
+		if !respondsWithPage(op) {
+			continue // not a list endpoint
+		}
+		acc.endpoints = append(acc.endpoints, parityEndpoint{
+			file:          filePath,
+			version:       version,
+			path:          path,
+			operationID:   op.OperationID,
+			hasOrgIDQuery: operationHasOrgIDQuery(op),
+		})
+	}
+}
+
+// respondsWithPage returns true when the operation's 200 response body
+// references a JSON schema whose component name ends in "Page". That
+// covers WorkspacePage, EnvironmentPage, MesheryDesignPage,
+// WorkspacesDesignsMappingPage, etc. Anything else is considered a
+// non-listing GET and excluded from Rule 46.
+func respondsWithPage(op *openapi3.Operation) bool {
+	if op == nil || op.Responses == nil {
+		return false
+	}
+	resp := op.Responses.Status(200)
+	if resp == nil || resp.Value == nil {
+		return false
+	}
+	content := resp.Value.Content["application/json"]
+	if content == nil || content.Schema == nil {
+		return false
+	}
+	if ref := content.Schema.Ref; ref != "" {
+		return strings.HasSuffix(ref, "Page")
+	}
+	return false
+}
+
+// operationHasOrgIDQuery returns true when the operation declares the
+// orgIdQuery parameter — either via a $ref to the canonical component
+// definition, or as an inline `in: query` parameter named `orgId` /
+// `organizationId`. The inline fallback is belt-and-braces: it keeps
+// Rule 46 from false-flagging a resource that spells the same concept
+// out inline rather than via the shared component.
+func operationHasOrgIDQuery(op *openapi3.Operation) bool {
+	if op == nil {
+		return false
+	}
+	for _, p := range op.Parameters {
+		if p == nil {
+			continue
+		}
+		if p.Ref == orgIDQueryParamRef {
+			return true
+		}
+		if p.Value != nil && p.Value.In == "query" {
+			switch p.Value.Name {
+			case "orgId", "organizationId":
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// reportParityViolations runs after every api.yml has been walked and
+// returns Rule 46 violations. The sibling rule: for each version directory
+// (e.g., v1beta1, v1beta2), if ANY collected list endpoint declares
+// orgIdQuery, every other list endpoint in that version must declare it
+// too.
+func reportParityViolations(acc *parityAccumulator, opts AuditOptions) []Violation {
+	if acc == nil {
+		return nil
+	}
+	sev := classifyStyleIssue(opts)
+	if sev == nil {
+		return nil
+	}
+
+	// Group endpoints by version, ignoring those without a version
+	// attribution (defensive; the walker fills it in).
+	byVersion := map[string][]parityEndpoint{}
+	for _, e := range acc.endpoints {
+		if e.version == "" {
+			continue
+		}
+		byVersion[e.version] = append(byVersion[e.version], e)
+	}
+
+	var out []Violation
+	versions := make([]string, 0, len(byVersion))
+	for v := range byVersion {
+		versions = append(versions, v)
+	}
+	sort.Strings(versions)
+
+	for _, version := range versions {
+		group := byVersion[version]
+		anyHas := false
+		var siblingsWithOrg []string
+		for _, e := range group {
+			if e.hasOrgIDQuery {
+				anyHas = true
+				siblingsWithOrg = append(siblingsWithOrg, e.path)
+			}
+		}
+		if !anyHas {
+			continue // no sibling established the pattern
+		}
+		sort.Strings(siblingsWithOrg)
+
+		// Report the ones that DON'T declare orgIdQuery. Emit in
+		// deterministic order: sort by (file, path) so the advisory
+		// baseline stays stable across runs.
+		missing := make([]parityEndpoint, 0, len(group))
+		for _, e := range group {
+			if !e.hasOrgIDQuery {
+				missing = append(missing, e)
+			}
+		}
+		sort.Slice(missing, func(i, j int) bool {
+			if missing[i].file != missing[j].file {
+				return missing[i].file < missing[j].file
+			}
+			return missing[i].path < missing[j].path
+		})
+
+		for _, e := range missing {
+			opID := e.operationID
+			if opID == "" {
+				opID = "(no operationId)"
+			}
+			out = append(out, Violation{
+				File: e.file,
+				Message: fmt.Sprintf(
+					`GET %q (operationId %q) is missing the `+
+						`"#/components/parameters/orgIdQuery" parameter ref, `+
+						`while sibling list endpoints in %s declare it (e.g., %s). `+
+						`Partial parity across sibling list endpoints is the drift `+
+						`class that dropped the workspaces-orgId query in production. `+
+						`Either add the ref here, or remove it from the sibling for `+
+						`consistency. See AGENTS.md § "Casing rules at a glance" and `+
+						`docs/identifier-naming-migration.md §9.4.`,
+					e.path, opID, version, strings.Join(siblingsWithOrg, ", ")),
+				Severity:   *sev,
+				RuleNumber: 46,
+			})
+		}
+	}
+	return out
+}

--- a/validation/rules_parity.go
+++ b/validation/rules_parity.go
@@ -82,20 +82,27 @@ func collectParityEndpoints(filePath, version string, doc *openapi3.T, acc *pari
 			continue // not a list endpoint
 		}
 		acc.endpoints = append(acc.endpoints, parityEndpoint{
-			file:          filePath,
-			version:       version,
-			path:          path,
-			operationID:   op.OperationID,
-			hasOrgIDQuery: operationHasOrgIDQuery(op),
+			file:        filePath,
+			version:     version,
+			path:        path,
+			operationID: op.OperationID,
+			// Parity check considers parameters declared at both the
+			// operation level and the PathItem level — the latter apply
+			// to every operation on the path under OpenAPI semantics.
+			hasOrgIDQuery: hasOrgIDQueryInParams(item.Parameters) ||
+				hasOrgIDQueryInParams(op.Parameters),
 		})
 	}
 }
 
 // respondsWithPage returns true when the operation's 200 response body
-// references a JSON schema whose component name ends in "Page". That
-// covers WorkspacePage, EnvironmentPage, MesheryDesignPage,
-// WorkspacesDesignsMappingPage, etc. Anything else is considered a
-// non-listing GET and excluded from Rule 46.
+// references a JSON schema whose component name ends in "Page", either
+// directly or through a composition keyword (`allOf`/`anyOf`/`oneOf`)
+// that resolves to a Page-shaped schema. That covers WorkspacePage,
+// EnvironmentPage, MesheryDesignPage, WorkspacesDesignsMappingPage, plus
+// any future schema that is built by composing a Page envelope into an
+// intermediate wrapper. Anything else is considered a non-listing GET
+// and excluded from Rule 46.
 func respondsWithPage(op *openapi3.Operation) bool {
 	if op == nil || op.Responses == nil {
 		return false
@@ -108,23 +115,52 @@ func respondsWithPage(op *openapi3.Operation) bool {
 	if content == nil || content.Schema == nil {
 		return false
 	}
-	if ref := content.Schema.Ref; ref != "" {
-		return strings.HasSuffix(ref, "Page")
+	return schemaRefEndsInPage(content.Schema)
+}
+
+// schemaRefEndsInPage returns true when the schema ref, or any ref
+// reachable through `allOf`/`anyOf`/`oneOf` composition, names a
+// component whose name ends in "Page". Cycles are avoided by only
+// walking child SchemaRef pointers one level deep — the schemas repo
+// never nests Page composition more than one level, and deeper walks
+// would risk cyclic ref loops.
+func schemaRefEndsInPage(ref *openapi3.SchemaRef) bool {
+	if ref == nil {
+		return false
+	}
+	if strings.HasSuffix(ref.Ref, "Page") {
+		return true
+	}
+	if ref.Value == nil {
+		return false
+	}
+	for _, sub := range ref.Value.AllOf {
+		if strings.HasSuffix(sub.Ref, "Page") {
+			return true
+		}
+	}
+	for _, sub := range ref.Value.AnyOf {
+		if strings.HasSuffix(sub.Ref, "Page") {
+			return true
+		}
+	}
+	for _, sub := range ref.Value.OneOf {
+		if strings.HasSuffix(sub.Ref, "Page") {
+			return true
+		}
 	}
 	return false
 }
 
-// operationHasOrgIDQuery returns true when the operation declares the
-// orgIdQuery parameter — either via a $ref to the canonical component
-// definition, or as an inline `in: query` parameter named `orgId` /
-// `organizationId`. The inline fallback is belt-and-braces: it keeps
-// Rule 46 from false-flagging a resource that spells the same concept
-// out inline rather than via the shared component.
-func operationHasOrgIDQuery(op *openapi3.Operation) bool {
-	if op == nil {
-		return false
-	}
-	for _, p := range op.Parameters {
+// hasOrgIDQueryInParams returns true when the given OpenAPI parameter
+// list declares the orgIdQuery parameter — either via a $ref to the
+// canonical component definition, or as an inline `in: query`
+// parameter named `orgId` / `organizationId`. Reused for both
+// operation-level (`Operation.Parameters`) and path-level
+// (`PathItem.Parameters`) lists so Rule 46 recognises the canonical
+// OpenAPI pattern of hoisting a shared parameter to the path level.
+func hasOrgIDQueryInParams(params openapi3.Parameters) bool {
+	for _, p := range params {
 		if p == nil {
 			continue
 		}
@@ -185,7 +221,6 @@ func reportParityViolations(acc *parityAccumulator, opts AuditOptions) []Violati
 		if !anyHas {
 			continue // no sibling established the pattern
 		}
-		sort.Strings(siblingsWithOrg)
 
 		// Report the ones that DON'T declare orgIdQuery. Emit in
 		// deterministic order: sort by (file, path) so the advisory
@@ -208,18 +243,25 @@ func reportParityViolations(acc *parityAccumulator, opts AuditOptions) []Violati
 			if opID == "" {
 				opID = "(no operationId)"
 			}
+			// Message stays baseline-stable by NOT embedding the
+			// variable list of sibling paths (which grows as new
+			// endpoints adopt orgIdQuery, invalidating
+			// advisory-baseline hashes). Readers can run
+			// `make audit-schemas-style-full | grep orgIdQuery` to see
+			// the full sibling list, or look at violated-endpoint
+			// siblings in the same version directory.
 			out = append(out, Violation{
 				File: e.file,
 				Message: fmt.Sprintf(
 					`GET %q (operationId %q) is missing the `+
 						`"#/components/parameters/orgIdQuery" parameter ref, `+
-						`while sibling list endpoints in %s declare it (e.g., %s). `+
+						`while sibling list endpoints in the %s directory declare it. `+
 						`Partial parity across sibling list endpoints is the drift `+
 						`class that dropped the workspaces-orgId query in production. `+
 						`Either add the ref here, or remove it from the sibling for `+
 						`consistency. See AGENTS.md § "Casing rules at a glance" and `+
 						`docs/identifier-naming-migration.md §9.4.`,
-					e.path, opID, version, strings.Join(siblingsWithOrg, ", ")),
+					e.path, opID, version),
 				Severity:   *sev,
 				RuleNumber: 46,
 			})

--- a/validation/rules_parity_test.go
+++ b/validation/rules_parity_test.go
@@ -1,0 +1,265 @@
+package validation
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+)
+
+// Helpers for Rule 46 tests.
+
+func paramOrgIDQueryRef() *openapi3.ParameterRef {
+	return &openapi3.ParameterRef{Ref: orgIDQueryParamRef}
+}
+
+func paramInlineQuery(name string) *openapi3.ParameterRef {
+	return &openapi3.ParameterRef{
+		Value: &openapi3.Parameter{Name: name, In: "query"},
+	}
+}
+
+// mkListOp builds a collection-list GET operation with the given 200
+// response schema ref (e.g., "#/components/schemas/WorkspacePage") and
+// query-parameter refs.
+func mkListOp(opID, responseSchemaRef string, params ...*openapi3.ParameterRef) *openapi3.Operation {
+	resp := openapi3.NewResponses()
+	resp.Set("200", &openapi3.ResponseRef{
+		Value: &openapi3.Response{
+			Content: openapi3.Content{
+				"application/json": &openapi3.MediaType{
+					Schema: &openapi3.SchemaRef{Ref: responseSchemaRef},
+				},
+			},
+		},
+	})
+	return &openapi3.Operation{
+		OperationID: opID,
+		Parameters:  append(openapi3.Parameters{}, params...),
+		Responses:   resp,
+	}
+}
+
+func mkDocWithGETs(paths map[string]*openapi3.Operation) *openapi3.T {
+	pathsMap := openapi3.NewPaths()
+	for p, op := range paths {
+		pi := &openapi3.PathItem{Get: op}
+		pathsMap.Set(p, pi)
+	}
+	return &openapi3.T{Paths: pathsMap}
+}
+
+// ---------------------------------------------------------------------------
+// Rule 46: Sibling-endpoint parameter parity
+// ---------------------------------------------------------------------------
+
+// TestCheckRule46_AllSiblingsDeclare — the first charter acceptance case:
+// every collection-list GET in the same version declares orgIdQuery, so
+// there is no violation.
+func TestCheckRule46_AllSiblingsDeclare(t *testing.T) {
+	acc := &parityAccumulator{}
+
+	envDoc := mkDocWithGETs(map[string]*openapi3.Operation{
+		"/api/environments": mkListOp("getEnvironments",
+			"#/components/schemas/EnvironmentPage", paramOrgIDQueryRef()),
+	})
+	collectParityEndpoints("v1beta1/environment/api.yml", "v1beta1", envDoc, acc)
+
+	viewDoc := mkDocWithGETs(map[string]*openapi3.Operation{
+		"/api/views": mkListOp("getViews",
+			"#/components/schemas/ViewPage", paramOrgIDQueryRef()),
+	})
+	collectParityEndpoints("v1beta1/view/api.yml", "v1beta1", viewDoc, acc)
+
+	vs := reportParityViolations(acc, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("all siblings declare orgIdQuery; expected 0 violations, got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule46_OneSiblingOmits — the second charter acceptance case:
+// environment declares orgIdQuery, workspace doesn't; rule fires on
+// workspace with a message naming the sibling that declared it.
+func TestCheckRule46_OneSiblingOmits(t *testing.T) {
+	acc := &parityAccumulator{}
+
+	envDoc := mkDocWithGETs(map[string]*openapi3.Operation{
+		"/api/environments": mkListOp("getEnvironments",
+			"#/components/schemas/EnvironmentPage", paramOrgIDQueryRef()),
+	})
+	collectParityEndpoints("v1beta1/environment/api.yml", "v1beta1", envDoc, acc)
+
+	wsDoc := mkDocWithGETs(map[string]*openapi3.Operation{
+		"/api/workspaces": mkListOp("getWorkspaces",
+			"#/components/schemas/WorkspacePage"), // NO orgIdQuery
+	})
+	collectParityEndpoints("v1beta1/workspace/api.yml", "v1beta1", wsDoc, acc)
+
+	vs := reportParityViolations(acc, AuditOptions{StyleDebt: true})
+	if len(vs) != 1 {
+		t.Fatalf("workspace should fire Rule 46; got %d: %+v", len(vs), vs)
+	}
+	if vs[0].RuleNumber != 46 {
+		t.Errorf("expected RuleNumber=46, got %d", vs[0].RuleNumber)
+	}
+	if vs[0].File != "v1beta1/workspace/api.yml" {
+		t.Errorf("expected file=workspace/api.yml, got %q", vs[0].File)
+	}
+	for _, want := range []string{"/api/workspaces", "getWorkspaces", "/api/environments", "orgIdQuery"} {
+		if !strings.Contains(vs[0].Message, want) {
+			t.Errorf("message missing %q; got: %s", want, vs[0].Message)
+		}
+	}
+}
+
+// TestCheckRule46_NoSiblingEstablishesPattern — when no endpoint in the
+// version declares orgIdQuery, the rule stays silent (it's a parity
+// check, not an unconditional presence check).
+func TestCheckRule46_NoSiblingEstablishesPattern(t *testing.T) {
+	acc := &parityAccumulator{}
+	doc := mkDocWithGETs(map[string]*openapi3.Operation{
+		"/api/plans": mkListOp("getPlans",
+			"#/components/schemas/PlanPage"),
+	})
+	collectParityEndpoints("v1beta1/plan/api.yml", "v1beta1", doc, acc)
+
+	vs := reportParityViolations(acc, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("no sibling declared orgIdQuery; rule should stay silent, got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule46_InlineOrgIDQueryCounts — a resource that spells out the
+// same param inline instead of using the shared ref is still considered
+// parity-compliant.
+func TestCheckRule46_InlineOrgIDQueryCounts(t *testing.T) {
+	acc := &parityAccumulator{}
+
+	envDoc := mkDocWithGETs(map[string]*openapi3.Operation{
+		"/api/environments": mkListOp("getEnvironments",
+			"#/components/schemas/EnvironmentPage", paramOrgIDQueryRef()),
+	})
+	collectParityEndpoints("v1beta1/environment/api.yml", "v1beta1", envDoc, acc)
+
+	wsDoc := mkDocWithGETs(map[string]*openapi3.Operation{
+		"/api/workspaces": mkListOp("getWorkspaces",
+			"#/components/schemas/WorkspacePage",
+			paramInlineQuery("orgId")), // inline instead of $ref
+	})
+	collectParityEndpoints("v1beta1/workspace/api.yml", "v1beta1", wsDoc, acc)
+
+	vs := reportParityViolations(acc, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("inline orgId query should satisfy parity; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule46_VersionIsolation — endpoints are compared within a
+// version bucket. A v1beta1 endpoint declaring orgIdQuery does NOT cause
+// a v1beta2 endpoint without it to fire (they're separate versions).
+func TestCheckRule46_VersionIsolation(t *testing.T) {
+	acc := &parityAccumulator{}
+	collectParityEndpoints("v1beta1/environment/api.yml", "v1beta1",
+		mkDocWithGETs(map[string]*openapi3.Operation{
+			"/api/environments": mkListOp("getEnvironments",
+				"#/components/schemas/EnvironmentPage", paramOrgIDQueryRef()),
+		}), acc)
+	collectParityEndpoints("v1beta2/design/api.yml", "v1beta2",
+		mkDocWithGETs(map[string]*openapi3.Operation{
+			"/api/designs": mkListOp("getDesigns",
+				"#/components/schemas/DesignPage"), // no orgIdQuery, but different version
+		}), acc)
+
+	vs := reportParityViolations(acc, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("cross-version endpoints should not be compared; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule46_OnlyListEndpointsChecked — GETs whose response isn't a
+// "*Page" schema (non-listing GETs like /api/system/version) are ignored.
+func TestCheckRule46_OnlyListEndpointsChecked(t *testing.T) {
+	acc := &parityAccumulator{}
+
+	collectParityEndpoints("v1beta1/environment/api.yml", "v1beta1",
+		mkDocWithGETs(map[string]*openapi3.Operation{
+			"/api/environments": mkListOp("getEnvironments",
+				"#/components/schemas/EnvironmentPage", paramOrgIDQueryRef()),
+		}), acc)
+	collectParityEndpoints("v1beta1/system/api.yml", "v1beta1",
+		mkDocWithGETs(map[string]*openapi3.Operation{
+			"/api/system/version": mkListOp("getVersion",
+				"#/components/schemas/VersionInfo"), // not Page-shaped
+		}), acc)
+
+	vs := reportParityViolations(acc, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("non-Page response should exclude endpoint from Rule 46; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule46_PathWithParamSkipped — endpoints whose path contains
+// `{...}` are not collection-list endpoints and are not subject to Rule 46.
+func TestCheckRule46_PathWithParamSkipped(t *testing.T) {
+	acc := &parityAccumulator{}
+
+	collectParityEndpoints("v1beta1/environment/api.yml", "v1beta1",
+		mkDocWithGETs(map[string]*openapi3.Operation{
+			"/api/environments": mkListOp("getEnvironments",
+				"#/components/schemas/EnvironmentPage", paramOrgIDQueryRef()),
+		}), acc)
+	collectParityEndpoints("v1beta1/workspace/api.yml", "v1beta1",
+		mkDocWithGETs(map[string]*openapi3.Operation{
+			"/api/workspaces/{workspaceId}": mkListOp("getWorkspace",
+				"#/components/schemas/Workspace"), // by-id endpoint, should be ignored
+		}), acc)
+
+	vs := reportParityViolations(acc, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("by-id endpoint (path has {param}) should be excluded; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule46_SuppressedWithoutStyleDebt — the rule is flag-gated.
+func TestCheckRule46_SuppressedWithoutStyleDebt(t *testing.T) {
+	acc := &parityAccumulator{}
+	collectParityEndpoints("v1beta1/environment/api.yml", "v1beta1",
+		mkDocWithGETs(map[string]*openapi3.Operation{
+			"/api/environments": mkListOp("getEnvironments",
+				"#/components/schemas/EnvironmentPage", paramOrgIDQueryRef()),
+		}), acc)
+	collectParityEndpoints("v1beta1/workspace/api.yml", "v1beta1",
+		mkDocWithGETs(map[string]*openapi3.Operation{
+			"/api/workspaces": mkListOp("getWorkspaces",
+				"#/components/schemas/WorkspacePage"),
+		}), acc)
+
+	vs := reportParityViolations(acc, AuditOptions{})
+	if len(vs) != 0 {
+		t.Errorf("Rule 46 should be suppressed without --style-debt; got %d", len(vs))
+	}
+}
+
+// TestCheckRule46_StrictBlocks — under --strict-consistency Rule 46
+// emits at SeverityBlocking.
+func TestCheckRule46_StrictBlocks(t *testing.T) {
+	acc := &parityAccumulator{}
+	collectParityEndpoints("v1beta1/environment/api.yml", "v1beta1",
+		mkDocWithGETs(map[string]*openapi3.Operation{
+			"/api/environments": mkListOp("getEnvironments",
+				"#/components/schemas/EnvironmentPage", paramOrgIDQueryRef()),
+		}), acc)
+	collectParityEndpoints("v1beta1/workspace/api.yml", "v1beta1",
+		mkDocWithGETs(map[string]*openapi3.Operation{
+			"/api/workspaces": mkListOp("getWorkspaces",
+				"#/components/schemas/WorkspacePage"),
+		}), acc)
+
+	vs := reportParityViolations(acc, AuditOptions{Strict: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 Rule 46 violation under --strict; got %d", len(vs))
+	}
+	if vs[0].Severity != SeverityBlocking {
+		t.Errorf("expected SeverityBlocking, got %v", vs[0].Severity)
+	}
+}

--- a/validation/rules_parity_test.go
+++ b/validation/rules_parity_test.go
@@ -105,7 +105,7 @@ func TestCheckRule46_OneSiblingOmits(t *testing.T) {
 	if vs[0].File != "v1beta1/workspace/api.yml" {
 		t.Errorf("expected file=workspace/api.yml, got %q", vs[0].File)
 	}
-	for _, want := range []string{"/api/workspaces", "getWorkspaces", "/api/environments", "orgIdQuery"} {
+	for _, want := range []string{"/api/workspaces", "getWorkspaces", "orgIdQuery", "v1beta1"} {
 		if !strings.Contains(vs[0].Message, want) {
 			t.Errorf("message missing %q; got: %s", want, vs[0].Message)
 		}


### PR DESCRIPTION
Implements Agent 1.D of the identifier-naming migration ([plan §7](../blob/master/docs/identifier-naming-migration.md)). Rule 46 catches the workspaces-missing-orgIdQuery drift class that caused the 400 production bug on `GET /api/workspaces`.

## The drift class

`GET /api/environments` declares `\$ref: \"#/components/parameters/orgIdQuery\"`, but `GET /api/workspaces` didn't — so server-side handlers read an empty `orgId` from the query string and returned 400. Rule 46 catches this: if any collection-list endpoint in a version directory declares `orgIdQuery`, every other collection-list endpoint in that version must declare it too.

## Definitions

A **collection-list endpoint** is:
- a GET operation,
- on a path with no `{...}` path parameters,
- whose 200 response body references a schema whose component name ends in \`Page\`.

The orgIdQuery presence check recognises both the canonical \`\$ref\` form and an inline \`in: query\` parameter named \`orgId\`/\`organizationId\` — a resource that spells out the concept inline instead of using the shared component is still parity-compliant.

## Cross-file scope

Rule 46 requires cross-file visibility; siblings live in different \`api.yml\` files. A new \`parityAccumulator\` buffers collection-list endpoints during the per-file walk in \`Audit()\`; the parity check runs from \`Audit()\` after every api.yml has been scanned, mirroring the Rule 29 cross-construct fingerprint pattern in \`rules_contract.go\`.

## Severity

Flag-gated via \`classifyStyleIssue\` — suppressed without \`--style-debt\`, advisory under \`--style-debt\`, blocking under \`--strict-consistency\`. Same path as Rule 6 and Rule 45. Default CI stays green.

## Charter acceptance
- [x] **(i) all siblings declare → pass**: \`TestCheckRule46_AllSiblingsDeclare\`.
- [x] **(ii) one sibling omits → fails with a message identifying the missing sibling**: \`TestCheckRule46_OneSiblingOmits\` (models the exact workspaces/environments drift).

Plus 7 additional edge cases: no-sibling-establishes-pattern silence, inline-param-satisfies-parity, version-isolation, non-Page-response exclusion, path-with-\`{param}\` exclusion, suppression without \`--style-debt\`, \`--strict-consistency\` upgrades to \`SeverityBlocking\`.

## Baseline surface
\`make audit-schemas-style-full\` surfaces **18 Rule 46 firings** on the repo-wide corpus:

| Endpoint | Version |
|---|---|
| \`GET /api/workspaces\` | v1beta1 ← **charter-named acceptance target** |
| \`GET /api/identity/badges\` | v1beta1 |
| \`GET /api/integrations/credentials\` | v1beta1 |
| \`GET /api/entitlement/features\` | v1beta1 |
| \`GET /api/auth/keys\` | v1beta1 |
| \`GET /api/auth/keychains\` | v1beta1 |
| \`GET /api/integrations/meshmodels/models\` | v1beta1 |
| \`GET /api/identity/orgs\` | v1beta1 |
| \`GET /user/schedules\` | v1beta1 |
| \`GET /api/integrations/connections\` | v1beta2 |
| …and more | |

Agent 1.G baselines the surface.

## Tests
- [x] 9 Rule 46 unit tests under \`rules_parity_test.go\`.
- [x] \`go test ./...\` green.
- [x] \`make validate-schemas\` green (Rule 46 suppressed by default).

## Human-review required per master plan §5.3
This PR adds a new rule in \`schemas/validation/\` that is blocking under \`--strict-consistency\`. Auto-merge NOT armed.

## Rollback
Revert the commit; Rule 46 disappears from the dispatch.