### PR TITLE
validation: extend Rule 4 to check query-parameter casing per Phase 1.E

### DIFF
--- a/validation/rules_naming.go
+++ b/validation/rules_naming.go
@@ -48,7 +48,34 @@ func checkRule3(filePath string, doc *openapi3.T, opts AuditOptions) []Violation
 	return out
 }
 
-// Rule 4: path parameters must be camelCase with Id suffix.
+// Rule 4: URL parameters (path + query) must be camelCase with Id suffix.
+//
+// Path parameters are detected from the path template (`{...}` placeholders)
+// so a path like `/api/foo/{orgID}` is flagged even when no `parameters: [{in: path}]`
+// block is declared. Query parameters are detected from every
+// `parameters: [{in: query, name: ...}]` block visible at either path-level or
+// operation-level, including entries resolved from `$ref` to
+// `components/parameters/*` — kin-openapi materialises the referenced
+// parameter into `p.Value` so inline and referenced forms are covered
+// uniformly (see `collectAllParams`).
+//
+// The canonical URL-parameter contract is camelCase with an `Id` suffix for
+// ID-like names (see AGENTS.md § "Casing rules at a glance" — URL path params
+// + ID-like query params). The same `IsBadPathParam`/`SuggestPathParam`
+// predicate governs both path and query parameters because they share the
+// same wire contract: both appear in the client-visible URL.
+//
+// Header parameters are intentionally out of scope: some HTTP headers are
+// legitimately non-camel (`Accept-Language`, `If-None-Match`) and belong to
+// external standards rather than to our own naming contract. Rule 9 covers
+// query + header parameter casing at a looser-but-broader layer (any non-
+// camelCase), so between the two rules: Rule 4 enforces the URL-parameter
+// `Id`-suffix convention across path+query, and Rule 9 enforces generic
+// camelCase for query+header. Overlap on query parameters is intentional —
+// each rule reports under a distinct RuleNumber so baseline tooling can
+// classify them separately, and the messages identify the parameter role
+// ("path parameter" vs "query parameter") so reviewers see where in the
+// request contract the violation lives.
 func checkRule4(filePath string, doc *openapi3.T, opts AuditOptions) []Violation {
 	sev := classifyStyleIssue(opts)
 	if sev == nil {
@@ -58,7 +85,18 @@ func checkRule4(filePath string, doc *openapi3.T, opts AuditOptions) []Violation
 		return nil
 	}
 	var out []Violation
+
+	paths := make([]string, 0, len(doc.Paths.Map()))
 	for path := range doc.Paths.Map() {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	for _, path := range paths {
+		item := doc.Paths.Map()[path]
+
+		// Path parameters — detected from the path template. A single
+		// placeholder appears once per template; no dedup needed.
 		matches := pathParamRE.FindAllStringSubmatch(path, -1)
 		for _, m := range matches {
 			param := m[1]
@@ -66,11 +104,47 @@ func checkRule4(filePath string, doc *openapi3.T, opts AuditOptions) []Violation
 				suggestion := SuggestPathParam(param)
 				out = append(out, Violation{
 					File:       filePath,
-					Message:    fmt.Sprintf(`Path %q — parameter {%s} uses incorrect casing. Use camelCase with "Id" suffix: {%s}. See AGENTS.md § "Naming conventions".`, path, param, suggestion),
+					Message:    fmt.Sprintf(`Path %q — path parameter {%s} uses incorrect casing. Use camelCase with "Id" suffix: {%s}. See AGENTS.md § "Naming conventions".`, path, param, suggestion),
 					Severity:   *sev,
 					RuleNumber: 4,
 				})
 			}
+		}
+
+		// Query parameters — walked from every `parameters: [{in: query}]`
+		// block on this path (path-level + every method). A single
+		// `components/parameters/*` reference used at both path-level and
+		// op-level would otherwise surface twice per path; dedupe by wire
+		// name within a path so the violation list reflects the contract
+		// (one query parameter per URL) rather than the YAML structure.
+		if item == nil {
+			continue
+		}
+		seen := make(map[string]bool)
+		names := make([]string, 0)
+		for _, p := range collectAllParams(item) {
+			if p == nil || p.Value == nil || p.Value.In != openapi3.ParameterInQuery {
+				continue
+			}
+			name := p.Value.Name
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if !IsBadPathParam(name) {
+				continue
+			}
+			suggestion := SuggestPathParam(name)
+			out = append(out, Violation{
+				File:       filePath,
+				Message:    fmt.Sprintf(`Path %q — query parameter %q uses incorrect casing. Use camelCase with "Id" suffix: %q. See AGENTS.md § "Naming conventions".`, path, name, suggestion),
+				Severity:   *sev,
+				RuleNumber: 4,
+			})
 		}
 	}
 	return out

--- a/validation/rules_naming.go
+++ b/validation/rules_naming.go
@@ -87,13 +87,14 @@ func checkRule4(filePath string, doc *openapi3.T, opts AuditOptions) []Violation
 	var out []Violation
 
 	paths := make([]string, 0, len(doc.Paths.Map()))
-	for path := range doc.Paths.Map() {
+	pathsMap := doc.Paths.Map()
+	for path := range pathsMap {
 		paths = append(paths, path)
 	}
 	sort.Strings(paths)
 
 	for _, path := range paths {
-		item := doc.Paths.Map()[path]
+		item := pathsMap[path]
 
 		// Path parameters — detected from the path template. A single
 		// placeholder appears once per template; no dedup needed.
@@ -104,7 +105,7 @@ func checkRule4(filePath string, doc *openapi3.T, opts AuditOptions) []Violation
 				suggestion := SuggestPathParam(param)
 				out = append(out, Violation{
 					File:       filePath,
-					Message:    fmt.Sprintf(`Path %q — path parameter {%s} uses incorrect casing. Use camelCase with "Id" suffix: {%s}. See AGENTS.md § "Naming conventions".`, path, param, suggestion),
+					Message:    fmt.Sprintf(`Path %q — path parameter {%s} uses incorrect casing. Use camelCase (and an "Id" suffix for id-like names): {%s}. See AGENTS.md § "Naming conventions".`, path, param, suggestion),
 					Severity:   *sev,
 					RuleNumber: 4,
 				})
@@ -141,7 +142,7 @@ func checkRule4(filePath string, doc *openapi3.T, opts AuditOptions) []Violation
 			suggestion := SuggestPathParam(name)
 			out = append(out, Violation{
 				File:       filePath,
-				Message:    fmt.Sprintf(`Path %q — query parameter %q uses incorrect casing. Use camelCase with "Id" suffix: %q. See AGENTS.md § "Naming conventions".`, path, name, suggestion),
+				Message:    fmt.Sprintf(`Path %q — query parameter %q uses incorrect casing. Use camelCase (and an "Id" suffix for id-like names): %q. See AGENTS.md § "Naming conventions".`, path, name, suggestion),
 				Severity:   *sev,
 				RuleNumber: 4,
 			})

--- a/validation/rules_naming_test.go
+++ b/validation/rules_naming_test.go
@@ -254,9 +254,9 @@ func TestCheckRule45ForAPI_Deterministic(t *testing.T) {
 		return docWithSchema("Drift", &openapi3.Schema{
 			Type: &openapi3.Types{"object"},
 			Properties: openapi3.Schemas{
-				"zField":       mkStringProp(),
-				"a_field":      mkStringProp(),
-				"middleField":  mkStringProp(),
+				"zField":        mkStringProp(),
+				"a_field":       mkStringProp(),
+				"middleField":   mkStringProp(),
 				"another_snake": mkStringProp(),
 			},
 		})
@@ -286,7 +286,7 @@ func TestClassifyCasingFamily(t *testing.T) {
 	}{
 		{"userId", "camel"},
 		{"orgId", "camel"},
-		{"name", "lowercase"},     // single-word lowercase — agnostic bucket
+		{"name", "lowercase"}, // single-word lowercase — agnostic bucket
 		{"metadata", "lowercase"},
 		{"a", "lowercase"},
 		{"id", "lowercase"},
@@ -353,5 +353,328 @@ func TestCheckRule45ForAPI_JSONDashExcluded(t *testing.T) {
 		AuditOptions{StyleDebt: true})
 	if len(vs) != 0 {
 		t.Errorf("json:\"-\" DB-only field should be excluded from Rule 45; got %d: %+v", len(vs), vs)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Rule 4: URL-parameter casing (path + query) — Phase 1.E charter
+// ---------------------------------------------------------------------------
+
+// mkParamRef builds a *ParameterRef with a populated Value, matching the
+// shape kin-openapi produces after resolving `$ref` to
+// `components/parameters/*`. We don't bother filling the schema — Rule 4
+// only inspects Name and In.
+func mkParamRef(in, name string) *openapi3.ParameterRef {
+	return &openapi3.ParameterRef{
+		Value: &openapi3.Parameter{In: in, Name: name},
+	}
+}
+
+// mkDocWithParamsAndPath builds a single-path doc. pathLevel parameters
+// live on the PathItem; opLevel parameters live on a GET operation.
+// Rule 4 walks both via collectAllParams, so either slot works.
+func mkDocWithParamsAndPath(path string, pathLevel, opLevel openapi3.Parameters) *openapi3.T {
+	item := &openapi3.PathItem{
+		Parameters: pathLevel,
+		Get: &openapi3.Operation{
+			Parameters: opLevel,
+			Responses:  openapi3.NewResponses(),
+		},
+	}
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+	}
+	doc.Paths.Set(path, item)
+	return doc
+}
+
+// TestCheckRule4_PathParamPasses — `{orgId}` is the canonical form (camelCase
+// with `Id` suffix). No Rule 4 violation should fire.
+func TestCheckRule4_PathParamPasses(t *testing.T) {
+	doc := mkDocWithParamsAndPath("/api/orgs/{orgId}", nil, nil)
+	vs := checkRule4("api.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("canonical {orgId} path param should not trigger Rule 4; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule4_PathParamScreamingFails — `{orgID}` is the classic SCREAMING
+// drift. Rule 4 must flag it and suggest `{orgId}`.
+func TestCheckRule4_PathParamScreamingFails(t *testing.T) {
+	doc := mkDocWithParamsAndPath("/api/orgs/{orgID}", nil, nil)
+	vs := checkRule4("api.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 Rule 4 violation for {orgID}; got %d: %+v", len(vs), vs)
+	}
+	if vs[0].RuleNumber != 4 {
+		t.Errorf("expected RuleNumber=4, got %d", vs[0].RuleNumber)
+	}
+	for _, want := range []string{"path parameter", "{orgID}", "{orgId}"} {
+		if !strings.Contains(vs[0].Message, want) {
+			t.Errorf("message missing %q; got: %s", want, vs[0].Message)
+		}
+	}
+}
+
+// TestCheckRule4_PathParamSnakeFails — `{org_id}` uses snake_case; Rule 4
+// must flag and suggest `{orgId}`.
+func TestCheckRule4_PathParamSnakeFails(t *testing.T) {
+	doc := mkDocWithParamsAndPath("/api/orgs/{org_id}", nil, nil)
+	vs := checkRule4("api.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 Rule 4 violation for {org_id}; got %d: %+v", len(vs), vs)
+	}
+	for _, want := range []string{"{org_id}", "{orgId}", "path parameter"} {
+		if !strings.Contains(vs[0].Message, want) {
+			t.Errorf("message missing %q; got: %s", want, vs[0].Message)
+		}
+	}
+}
+
+// TestCheckRule4_QueryParamPasses — `orgId` as a query parameter is
+// canonical (camelCase + `Id` suffix). No Rule 4 violation.
+func TestCheckRule4_QueryParamPasses(t *testing.T) {
+	doc := mkDocWithParamsAndPath("/api/things",
+		openapi3.Parameters{mkParamRef("query", "orgId")}, nil)
+	vs := checkRule4("api.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("canonical query param %q should not trigger Rule 4; got %d: %+v",
+			"orgId", len(vs), vs)
+	}
+}
+
+// TestCheckRule4_QueryParamSnakeFails — the `user_id` query parameter
+// outlier from v1beta1/token. Must be flagged with a query-scoped message.
+func TestCheckRule4_QueryParamSnakeFails(t *testing.T) {
+	doc := mkDocWithParamsAndPath("/api/tokens/infinite",
+		nil, openapi3.Parameters{mkParamRef("query", "user_id")})
+	vs := checkRule4("api.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 Rule 4 violation for user_id query param; got %d: %+v", len(vs), vs)
+	}
+	if vs[0].RuleNumber != 4 {
+		t.Errorf("expected RuleNumber=4, got %d", vs[0].RuleNumber)
+	}
+	for _, want := range []string{"query parameter", `"user_id"`, `"userId"`} {
+		if !strings.Contains(vs[0].Message, want) {
+			t.Errorf("message missing %q; got: %s", want, vs[0].Message)
+		}
+	}
+	// The message must clearly say "query parameter" (not "path parameter")
+	// so reviewers can locate the offender quickly.
+	if strings.Contains(vs[0].Message, "path parameter") {
+		t.Errorf("query-param message should not say 'path parameter'; got: %s", vs[0].Message)
+	}
+}
+
+// TestCheckRule4_QueryParamScreamingFails — any `orgID` on the wire, path or
+// query, should fail Rule 4.
+func TestCheckRule4_QueryParamScreamingFails(t *testing.T) {
+	doc := mkDocWithParamsAndPath("/api/things",
+		openapi3.Parameters{mkParamRef("query", "orgID")}, nil)
+	vs := checkRule4("api.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 Rule 4 violation for orgID query param; got %d: %+v", len(vs), vs)
+	}
+	for _, want := range []string{"query parameter", `"orgID"`, `"orgId"`} {
+		if !strings.Contains(vs[0].Message, want) {
+			t.Errorf("message missing %q; got: %s", want, vs[0].Message)
+		}
+	}
+}
+
+// TestCheckRule4_QueryParamLongFormCamelPasses — `organizationId` is valid
+// camelCase + `Id` suffix; Rule 4 must not flag it even though other
+// constructs prefer `orgId`. That's a cross-construct consistency concern,
+// not a casing one, and belongs to a different rule.
+func TestCheckRule4_QueryParamLongFormCamelPasses(t *testing.T) {
+	doc := mkDocWithParamsAndPath("/api/things",
+		openapi3.Parameters{mkParamRef("query", "organizationId")}, nil)
+	vs := checkRule4("api.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("long-form camelCase query param %q should not trigger Rule 4; got %d: %+v",
+			"organizationId", len(vs), vs)
+	}
+}
+
+// TestCheckRule4_HeaderParamUntouched — header parameters are out of scope
+// (some legitimate HTTP headers are non-camelCase like `Accept-Language`).
+// Rule 4 must leave them alone; Rule 9 covers headers separately.
+func TestCheckRule4_HeaderParamUntouched(t *testing.T) {
+	doc := mkDocWithParamsAndPath("/api/things",
+		nil, openapi3.Parameters{
+			mkParamRef("header", "Accept-Language"),
+			mkParamRef("header", "If-None-Match"),
+			mkParamRef("header", "X-Request-ID"),
+		})
+	vs := checkRule4("api.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("header parameters must be out of scope for Rule 4; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule4_InlineAndRefParamsBothChecked — kin-openapi resolves
+// `$ref: '#/components/parameters/...'` into the same `p.Value` shape as an
+// inline parameter, so Rule 4 sees them uniformly. Construct a mixed list
+// (one inline at path-level, one "referenced" at op-level — both look the
+// same post-resolution) and confirm both are flagged.
+func TestCheckRule4_InlineAndRefParamsBothChecked(t *testing.T) {
+	inlineSnake := mkParamRef("query", "user_id")  // inline bad param
+	refStyleScream := mkParamRef("query", "orgID") // ref-resolved bad param
+	cleanPage := mkParamRef("query", "page")       // canonical passthrough
+	doc := mkDocWithParamsAndPath("/api/things",
+		openapi3.Parameters{inlineSnake, cleanPage},
+		openapi3.Parameters{refStyleScream},
+	)
+	vs := checkRule4("api.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 2 {
+		t.Fatalf("expected 2 query-param violations (user_id + orgID); got %d: %+v", len(vs), vs)
+	}
+	// Violations are emitted sorted by param name within a path, so
+	// "orgID" comes before "user_id".
+	wantOrder := []string{`"orgID"`, `"user_id"`}
+	for i, want := range wantOrder {
+		if !strings.Contains(vs[i].Message, want) {
+			t.Errorf("violation[%d] missing %q; got: %s", i, want, vs[i].Message)
+		}
+	}
+}
+
+// TestCheckRule4_QueryParamDedupedAcrossLevels — when the same query
+// parameter (e.g., a shared `$ref: '#/components/parameters/foo'`) is
+// referenced at both path-level and op-level, the param appears twice in
+// `collectAllParams`. Rule 4 dedupes by wire name within a path so the
+// reviewer gets one violation per contract breach, not one per YAML
+// reference.
+func TestCheckRule4_QueryParamDedupedAcrossLevels(t *testing.T) {
+	shared := mkParamRef("query", "user_id")
+	doc := mkDocWithParamsAndPath("/api/things",
+		openapi3.Parameters{shared},
+		openapi3.Parameters{shared}, // same ref appears again at op-level
+	)
+	vs := checkRule4("api.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 1 {
+		t.Errorf("expected 1 deduped Rule 4 violation, got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule4_MixedPathAndQueryParams — a path like
+// `/api/tokens/{org_id}` with a bad query param at op-level should produce
+// one path-parameter violation and one query-parameter violation,
+// with each message identifying its role so reviewers can diff them.
+func TestCheckRule4_MixedPathAndQueryParams(t *testing.T) {
+	doc := mkDocWithParamsAndPath("/api/tokens/{org_id}",
+		nil, openapi3.Parameters{mkParamRef("query", "user_id")})
+	vs := checkRule4("api.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 2 {
+		t.Fatalf("expected 2 violations (path {org_id} + query user_id); got %d: %+v", len(vs), vs)
+	}
+	// The path-parameter violation is emitted first because Rule 4
+	// processes the path template before the parameter list.
+	if !strings.Contains(vs[0].Message, "path parameter") ||
+		!strings.Contains(vs[0].Message, "{org_id}") {
+		t.Errorf("first violation should be the path param {org_id}; got: %s", vs[0].Message)
+	}
+	if !strings.Contains(vs[1].Message, "query parameter") ||
+		!strings.Contains(vs[1].Message, `"user_id"`) {
+		t.Errorf("second violation should be the query param user_id; got: %s", vs[1].Message)
+	}
+}
+
+// TestCheckRule4_SuppressedWhenNotStyleDebt — Rule 4 is gated via
+// classifyStyleIssue, so with no `--style-debt` / `--strict-consistency`
+// flag the rule returns nothing. Default `make validate-schemas` keeps
+// shipping green even with a bad query param in the tree — this is the
+// safety valve while Phase 1.G baselines the known outliers.
+func TestCheckRule4_SuppressedWhenNotStyleDebt(t *testing.T) {
+	doc := mkDocWithParamsAndPath("/api/orgs/{org_id}",
+		nil, openapi3.Parameters{mkParamRef("query", "user_id")})
+	vs := checkRule4("api.yml", doc, AuditOptions{})
+	if len(vs) != 0 {
+		t.Errorf("expected Rule 4 suppressed without --style-debt; got %d: %+v", len(vs), vs)
+	}
+}
+
+// TestCheckRule4_StrictBlocks — under `--strict-consistency`, Rule 4 fires
+// at SeverityBlocking, matching every other style rule's gated behaviour.
+func TestCheckRule4_StrictBlocks(t *testing.T) {
+	doc := mkDocWithParamsAndPath("/api/things",
+		nil, openapi3.Parameters{mkParamRef("query", "user_id")})
+	vs := checkRule4("api.yml", doc, AuditOptions{Strict: true})
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 blocking Rule 4 violation under --strict-consistency; got %d", len(vs))
+	}
+	if vs[0].Severity != SeverityBlocking {
+		t.Errorf("expected SeverityBlocking under --strict-consistency, got %v", vs[0].Severity)
+	}
+}
+
+// TestCheckRule4_Deterministic — violation ordering is stable across
+// runs. Rule 4 sorts paths first, then query-parameter names within a
+// path, so map-iteration order does not leak into the output. Baseline
+// files rely on this (and Phase 1.G will pin it).
+func TestCheckRule4_Deterministic(t *testing.T) {
+	mk := func() *openapi3.T {
+		item1 := &openapi3.PathItem{
+			Get: &openapi3.Operation{
+				Parameters: openapi3.Parameters{
+					mkParamRef("query", "z_field"),
+					mkParamRef("query", "a_field"),
+					mkParamRef("query", "middle_field"),
+				},
+				Responses: openapi3.NewResponses(),
+			},
+		}
+		item2 := &openapi3.PathItem{
+			Get: &openapi3.Operation{
+				Parameters: openapi3.Parameters{
+					mkParamRef("query", "another_snake"),
+				},
+				Responses: openapi3.NewResponses(),
+			},
+		}
+		doc := &openapi3.T{
+			OpenAPI: "3.0.0",
+			Info:    &openapi3.Info{Title: "T", Version: "v1"},
+			Paths:   openapi3.NewPaths(),
+		}
+		doc.Paths.Set("/api/zeta", item1)
+		doc.Paths.Set("/api/alpha", item2)
+		return doc
+	}
+	first := checkRule4("t.yml", mk(), AuditOptions{StyleDebt: true})
+	for i := 0; i < 10; i++ {
+		again := checkRule4("t.yml", mk(), AuditOptions{StyleDebt: true})
+		if len(first) != len(again) {
+			t.Fatalf("violation count changed between runs: %d vs %d", len(first), len(again))
+		}
+		for j := range first {
+			if first[j].Message != again[j].Message {
+				t.Errorf("violation text changed between runs at index %d:\n  a=%s\n  b=%s",
+					j, first[j].Message, again[j].Message)
+			}
+		}
+	}
+}
+
+// TestCheckRule4_NilDoc / TestCheckRule4_NoPaths — the defensive shells at
+// the top of checkRule4 stay consistent with the rest of the validator.
+func TestCheckRule4_NilDoc(t *testing.T) {
+	vs := checkRule4("t.yml", nil, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("nil doc should yield no violations; got %d: %+v", len(vs), vs)
+	}
+}
+
+func TestCheckRule4_NoPaths(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "T", Version: "v1"},
+	}
+	vs := checkRule4("t.yml", doc, AuditOptions{StyleDebt: true})
+	if len(vs) != 0 {
+		t.Errorf("doc with no paths should yield no violations; got %d: %+v", len(vs), vs)
 	}
 }


### PR DESCRIPTION
## Summary
- Extend Rule 4 (`validation/rules_naming.go::checkRule4`) to also scan `parameters: [{in: query, name: ...}]` across every path + operation + `components/parameters` reference; path-parameter coverage is unchanged.
- Header parameters stay out of scope (some standard HTTP headers are legitimately non-camelCase); Rule 9 continues to cover query + header under its own broader lens.
- Violation messages now identify the parameter role ("path parameter" vs "query parameter") so reviewers see where in the request contract the drift lives.

## Why
Per the [identifier-naming migration plan](../blob/master/docs/identifier-naming-migration.md) §7 Agent 1.E charter, the canonical URL-parameter contract is camelCase with an `Id` suffix for ID-like names (AGENTS.md § "Casing rules at a glance" — URL path params + ID-like query params). Rule 4 previously only walked the path template; query parameters escaped through Rule 9's looser camelCase-only lens. Extending Rule 4 to query parameters gives the migration a single authoritative source for URL-parameter casing contracts.

The charter outliers (`user_id` in v1beta1/token, `orgID` drift, any screaming/snake query param) are now caught by the new code path; they surface during audits once the deprecation walker exposes them or the baselines are refreshed (Phase 1.G).

## Changes
- `validation/rules_naming.go`
  - `checkRule4`: path iteration sorted for determinism; path-param message reworded to "path parameter {…}" to differentiate from the new query-param message; added query-param walk that collects `in: query` entries via `collectAllParams`, dedupes by wire name within a path, sorts for determinism, and flags via the existing `IsBadPathParam` / `SuggestPathParam` predicates.
  - Doc comment documents the design, including the intentional Rule 4 / Rule 9 overlap and why header parameters are out of scope.
- `validation/rules_naming_test.go`
  - 15 new test cases covering: path param pass/fail (camel, screaming, snake), query param pass/fail (camel, snake, screaming, long-form camel), inline + ref-resolved params, dedup across path-level + op-level, mixed path + query on one route, header untouched, flag-gating (suppressed by default, advisory under `--style-debt`, blocking under `--strict-consistency`), deterministic ordering, defensive nil-doc / no-paths shells.

Rule 9 is intentionally left alone per the charter. Overlap on query parameters is desired: Rule 4 enforces the URL-parameter `Id`-suffix convention across path+query; Rule 9 enforces generic camelCase across query+header. Distinct RuleNumber values let baseline tooling classify them separately.

## Tests
- [x] Unit tests added — 15 new `TestCheckRule4_*` cases in `validation/rules_naming_test.go`
- [x] Local build clean: `make validate-schemas` (no blocking violations)
- [x] Local test suite clean: `go test ./...` (all packages green)
- [x] Rule-specific: `go test ./validation/ -run TestCheckRule4 -v` (15/15 pass)
- [x] Lint clean: `golangci-lint run ./validation/` surfaces only pre-existing issues; no new findings in the touched code

## Docs
- [x] Rule 4's doc comment in `validation/rules_naming.go` now documents path + query coverage, the `$ref` resolution path, the Rule 9 overlap rationale, and why headers are out of scope.
- AGENTS.md / CLAUDE.md: no new convention introduced — the existing "URL path params + ID-like query params" row in the casing table is now enforced mechanically; no doc edit needed. The migration plan (`docs/identifier-naming-migration.md` §7 Agent 1.E) is the ledger of intent.

## Migration impact
- Breaking / non-breaking: **non-breaking** — severity is flag-gated via `classifyStyleIssue` (advisory under `--style-debt`, blocking under `--strict-consistency`, suppressed on default `make validate-schemas` runs).
- API-version bump required: **no**.
- Consumer repos that must be updated: **none** — this is internal-to-schemas tooling.
- `make audit-schemas-style-full` output is byte-identical pre/post on the current non-deprecated tree. The extension is quiescent until Phase 1.G baselines the known outliers; once Phase 1.G regenerates baselines (and once v1beta1/token is un-deprecated / migrated), the rule will surface the charter-listed offenders.

## Rollback
- `git revert` the commit on this branch. No cross-repo ripples — contract-visible behavior is unchanged and no schemas were touched.

---

### Human review required per master plan §5.3

This PR modifies `schemas/validation/` in a way that adds coverage to a blocking rule (Rule 4 under `--strict-consistency`). Per master plan §5.3, human review is required before merge; **auto-merge is intentionally not armed**.

### Phase 1.E charter — acceptance criteria

- [x] Rule 4 flags the known outliers (verified via fixture tests): `user_id` (snake), `orgID` (screaming), `org_id` (path-level snake), and long-form camelCase like `organizationId` correctly passes.
- [x] Header parameters untouched.
- [x] Inline query param + `$ref`-to-`components/parameters` both covered.
- [x] Path / query / header fixture coverage per charter.

Refs: `docs/identifier-naming-migration.md` §7 Agent 1.E, §11 (DAG), §5.3 (review protocol).