### PR TITLE
validation: add TypeScript consumer auditor (consumer_ts.go) per Phase 1.F

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -447,6 +447,31 @@ make baseline-consumer-audit  MESHERY_REPO=../meshery CLOUD_REPO=../meshery-clou
 make baseline-consumer-graph  MESHERY_REPO=../meshery CLOUD_REPO=../meshery-cloud EXTENSIONS_REPO=../meshery-extensions
 ```
 
+## Consumer audit
+
+The consumer audit joins the schemas endpoint index against the routers and RTK Query clients of the downstream repos, producing a per-endpoint coverage and drift report. Three parsers are registered:
+
+- **Gorilla (Go)** — `meshery/meshery`'s `server/router/server.go`.
+- **Echo (Go)** — `meshery-cloud`'s `server/router/router.go` and related handler files.
+- **TypeScript (RTK Query)** — `meshery/meshery/ui/rtk-query`, `meshery-cloud/ui/api` + `meshery-cloud/ui/rtk-query`, and `meshery-extensions/meshmap/src/rtk-query`.
+
+The TS consumer is intentionally regex-based per the Phase 1.F charter; full TypeScript semantic analysis would require the TS compiler. It extracts `builder.query({url, params})` and `builder.mutation({url, params, body})` sites and flags three finding kinds:
+
+- `case-flip` — a wire key that re-introduces SCREAMING or mixed-case identifiers the camelCase schema contract forbids (e.g. `orgID: queryArg.orgId`).
+- `snake-case-wrapper` — a body wrapper keyed in snake_case (`pattern_data`, `k8s_manifest`) instead of the camelCase schema contract.
+- `snake-case-param` — a params key in snake_case outside the reserved pagination envelope (`page_size`, `total_count` are exempt).
+
+Run it against any or all downstream repos:
+
+```bash
+make consumer-audit MESHERY_REPO=../meshery CLOUD_REPO=../meshery-cloud \
+                    EXTENSIONS_REPO=../meshery-extensions
+```
+
+Each `*_REPO` variable is optional; consumers whose path is not provided are silently skipped. Override the TS scan path independently when the UI lives outside the Go checkout via `MESHERY_REPO_UI=` / `CLOUD_REPO_UI=`. Add `VERBOSE=1` to print the full schema-only / consumer-only lists after the summary.
+
+The TS findings section appears below the main audit report and is grouped by repo so reviewers can focus on one downstream at a time.
+
 ## Questions?
 
 If you're unsure about any schema modification:

--- a/Makefile
+++ b/Makefile
@@ -160,17 +160,30 @@ baseline-consumer-graph:
 #-----------------------------------------------------------------------------
 .PHONY: consumer-audit consumer-audit-update
 
-# Override via: make consumer-audit MESHERY_REPO=../meshery CLOUD_REPO=../meshery-cloud
-MESHERY_REPO ?=
-CLOUD_REPO   ?=
-SHEET_ID     ?=
-CREDENTIALS  ?=
+# Override via:
+#   make consumer-audit MESHERY_REPO=../meshery CLOUD_REPO=../meshery-cloud \
+#                       EXTENSIONS_REPO=../meshery-extensions
+# Each *_REPO variable is optional; the audit iterates every registered
+# consumer (Go Gorilla, Go Echo, TypeScript RTK Query) and skips trees that
+# were not provided. MESHERY_REPO_UI / CLOUD_REPO_UI override the TS scan
+# path independently of the Go path (rarely needed — only when the UI lives
+# in a separate checkout).
+MESHERY_REPO     ?=
+CLOUD_REPO       ?=
+EXTENSIONS_REPO  ?=
+MESHERY_REPO_UI  ?=
+CLOUD_REPO_UI    ?=
+SHEET_ID         ?=
+CREDENTIALS      ?=
 
 ## Dry-run the consumer audit without reconciling or updating Google Sheets.
 consumer-audit:
 	@go run ./cmd/consumer-audit \
 		$(if $(MESHERY_REPO),--meshery-repo=$(MESHERY_REPO)) \
 		$(if $(CLOUD_REPO),--cloud-repo=$(CLOUD_REPO)) \
+		$(if $(EXTENSIONS_REPO),--extensions-repo=$(EXTENSIONS_REPO)) \
+		$(if $(MESHERY_REPO_UI),--meshery-repo-ui=$(MESHERY_REPO_UI)) \
+		$(if $(CLOUD_REPO_UI),--cloud-repo-ui=$(CLOUD_REPO_UI)) \
 		$(if $(VERBOSE),--verbose)
 
 ## Reconcile the consumer audit against the canonical Google Sheet and update it.
@@ -181,6 +194,9 @@ consumer-audit-update:
 	@go run ./cmd/consumer-audit \
 		$(if $(MESHERY_REPO),--meshery-repo=$(MESHERY_REPO)) \
 		$(if $(CLOUD_REPO),--cloud-repo=$(CLOUD_REPO)) \
+		$(if $(EXTENSIONS_REPO),--extensions-repo=$(EXTENSIONS_REPO)) \
+		$(if $(MESHERY_REPO_UI),--meshery-repo-ui=$(MESHERY_REPO_UI)) \
+		$(if $(CLOUD_REPO_UI),--cloud-repo-ui=$(CLOUD_REPO_UI)) \
 		$(if $(VERBOSE),--verbose) \
 		--sheet-id=$(SHEET_ID) \
 		--credentials=$(CREDENTIALS)

--- a/cmd/consumer-audit/main.go
+++ b/cmd/consumer-audit/main.go
@@ -2,10 +2,16 @@
 // it against handler implementations in meshery/meshery and meshery-cloud,
 // and reports per-endpoint coverage and implementation drift.
 //
+// It also runs the TypeScript consumer auditor (validation.parseTSConsumer)
+// against each provided TS tree and surfaces RTK Query drift findings —
+// camelCase case-flips, snake_case body wrappers, and snake_case param keys
+// — as a post-script to the main endpoint table.
+//
 // Usage:
 //
 //	go run ./cmd/consumer-audit
 //	go run ./cmd/consumer-audit --meshery-repo=../meshery --cloud-repo=../meshery-cloud
+//	go run ./cmd/consumer-audit --extensions-repo=../meshery-extensions
 //	go run ./cmd/consumer-audit --sheet-id=<id> --credentials=<path>      # reconcile and update the canonical sheet
 package main
 
@@ -22,8 +28,11 @@ import (
 )
 
 func main() {
-	mesheryRepo := flag.String("meshery-repo", "", "Path to a meshery/meshery checkout (Gorilla router)")
-	cloudRepo := flag.String("cloud-repo", "", "Path to a meshery-cloud checkout (Echo router)")
+	mesheryRepo := flag.String("meshery-repo", "", "Path to a meshery/meshery checkout (Gorilla router + ui/rtk-query)")
+	cloudRepo := flag.String("cloud-repo", "", "Path to a meshery-cloud checkout (Echo router + ui/api + ui/rtk-query)")
+	extensionsRepo := flag.String("extensions-repo", "", "Path to a meshery-extensions checkout (meshmap/src/rtk-query)")
+	mesheryRepoUI := flag.String("meshery-repo-ui", "", "Override the TS scan path for meshery (defaults to --meshery-repo)")
+	cloudRepoUI := flag.String("cloud-repo-ui", "", "Override the TS scan path for meshery-cloud (defaults to --cloud-repo)")
 	verbose := flag.Bool("verbose", false, "Print per-endpoint Schema-only and Consumer-only lists")
 	sheetID := flag.String("sheet-id", "", "Google Sheet ID to reconcile against and update")
 	credentials := flag.String("credentials", "", "Path to Google service-account JSON credentials (required with --sheet-id)")
@@ -41,9 +50,12 @@ func main() {
 	}
 
 	opts := validation.ConsumerAuditOptions{
-		RootDir:     rootDir,
-		MesheryRepo: *mesheryRepo,
-		CloudRepo:   *cloudRepo,
+		RootDir:        rootDir,
+		MesheryRepo:    *mesheryRepo,
+		CloudRepo:      *cloudRepo,
+		MesheryRepoUI:  *mesheryRepoUI,
+		CloudRepoUI:    *cloudRepoUI,
+		ExtensionsRepo: *extensionsRepo,
 	}
 
 	if *sheetID != "" {
@@ -65,6 +77,7 @@ func main() {
 	out := io.Writer(os.Stdout)
 	printAuditReport(out, result)
 	printActionItems(out, result, *mesheryRepo != "", *cloudRepo != "")
+	printTSFindings(out, result.TSFindings)
 
 	if *verbose {
 		printVerbose(out, result)
@@ -351,6 +364,50 @@ func consumerScopeLabel(label string) string {
 		return "Cloud"
 	default:
 		return label
+	}
+}
+
+// printTSFindings renders the TypeScript consumer auditor output. Findings
+// are grouped by repo so reviewers can focus on a single downstream at a
+// time. An empty list is a no-op so we don't introduce a header row for
+// runs that didn't scan any TS tree.
+func printTSFindings(out io.Writer, findings []validation.TSFinding) {
+	if len(findings) == 0 {
+		return
+	}
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "TypeScript Consumer Findings")
+	fmt.Fprintln(out)
+
+	byRepo := map[validation.TSConsumerRepo][]validation.TSFinding{}
+	for _, f := range findings {
+		byRepo[f.Repo] = append(byRepo[f.Repo], f)
+	}
+	repos := make([]string, 0, len(byRepo))
+	for repo := range byRepo {
+		repos = append(repos, string(repo))
+	}
+	sort.Strings(repos)
+
+	for _, repoName := range repos {
+		repo := validation.TSConsumerRepo(repoName)
+		list := byRepo[repo]
+		if len(list) == 0 {
+			continue
+		}
+		fmt.Fprintf(out, "  %s (%d %s):\n", repo, len(list), pluralize("finding", len(list)))
+		for _, f := range list {
+			loc := f.File
+			if f.Line > 0 {
+				loc = fmt.Sprintf("%s:%d", f.File, f.Line)
+			}
+			fmt.Fprintf(out, "    [%s] %s  %s %s  key=%q\n",
+				f.Kind, loc, f.Method, f.URL, f.Key)
+			if f.Message != "" {
+				fmt.Fprintf(out, "      %s\n", f.Message)
+			}
+		}
+		fmt.Fprintln(out)
 	}
 }
 

--- a/validation/consumer_audit.go
+++ b/validation/consumer_audit.go
@@ -3,6 +3,7 @@ package validation
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -104,6 +105,15 @@ type ConsumerAuditOptions struct {
 	MesheryRepo string
 	CloudRepo   string
 
+	// TypeScript consumer repos. Each of these points at a checkout whose
+	// ui/rtk-query (or equivalent) directories are parsed by the TS
+	// consumer auditor. MesheryRepoUI defaults to MesheryRepo when unset
+	// because meshery/meshery keeps Go and TS consumers in the same
+	// checkout; CloudRepoUI likewise defaults to CloudRepo.
+	MesheryRepoUI   string
+	CloudRepoUI     string
+	ExtensionsRepo  string
+
 	// Google Sheets update. Empty = no sheet interaction (dry run).
 	SheetID           string
 	SheetsCredentials []byte
@@ -132,6 +142,12 @@ type ConsumerAuditResult struct {
 
 	// Summary counts for terminal display.
 	Summary auditSummary
+
+	// TSFindings is the flat list of TypeScript consumer drift findings
+	// (case-flips, snake_case wrappers, snake_case params) produced by
+	// the TS consumer auditor. Sorted by (file, line, key) for
+	// deterministic output. Empty when no TS consumer trees are provided.
+	TSFindings []TSFinding
 }
 
 // ConsumerAuditRow is one row of the audit output.
@@ -404,11 +420,62 @@ func runConsumerAudit(opts ConsumerAuditOptions, mesheryTree, cloudTree sourceTr
 		Summary: summary,
 	}
 
+	// TypeScript consumer pass. Each tree is optional; callers that only
+	// care about the Go routers will not provide any. Findings are
+	// accumulated onto the result so the CLI can surface them as a
+	// post-script to the main endpoint table.
+	result.TSFindings = runTSConsumers(opts, mesheryTree, cloudTree)
+
 	if err := reconcileFromOpts(opts, result); err != nil {
 		return result, err
 	}
 
 	return result, nil
+}
+
+// runTSConsumers invokes parseTSConsumer against every configured TS
+// consumer tree and returns the aggregated findings. Each entry in
+// tsConsumerRegistry couples a repo identity with a lazy tree constructor so
+// new consumers can be added by appending to the registry.
+func runTSConsumers(opts ConsumerAuditOptions, mesheryGoTree, cloudGoTree sourceTree) []TSFinding {
+	registry := []struct {
+		repo TSConsumerRepo
+		tree sourceTree
+	}{
+		{TSConsumerMeshery, resolveTSTree(opts.MesheryRepoUI, opts.MesheryRepo, mesheryGoTree)},
+		{TSConsumerCloud, resolveTSTree(opts.CloudRepoUI, opts.CloudRepo, cloudGoTree)},
+		{TSConsumerExtensions, resolveTSTree(opts.ExtensionsRepo, "", nil)},
+	}
+	var findings []TSFinding
+	for _, entry := range registry {
+		if entry.tree == nil {
+			continue
+		}
+		_, fs, err := parseTSConsumer(entry.tree, entry.repo)
+		if err != nil {
+			// Don't abort the whole audit on a single TS-repo parse error;
+			// the log message is sufficient for the regenerator, and the
+			// Go-side audit should still surface.
+			log.Printf("consumer-audit: ts: %s: %v", entry.repo, err)
+			continue
+		}
+		findings = append(findings, fs...)
+	}
+	sortTSFindings(findings)
+	return findings
+}
+
+// resolveTSTree picks the best source tree for a TS consumer given the
+// explicit override path, the Go-side repo path (fallback for repos that
+// co-locate Go and TS), and a pre-built Go tree (reused for tests).
+func resolveTSTree(override, fallback string, reuse sourceTree) sourceTree {
+	if override != "" {
+		return localTree{root: override}
+	}
+	if fallback != "" {
+		return localTree{root: fallback}
+	}
+	return reuse
 }
 
 // buildAuditRows materializes one AuditRow per endpoint, joining schema and

--- a/validation/consumer_ts.go
+++ b/validation/consumer_ts.go
@@ -1,0 +1,827 @@
+package validation
+
+import (
+	"fmt"
+	"log"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// TSConsumerRepo identifies a TypeScript consumer repository.
+type TSConsumerRepo string
+
+const (
+	// TSConsumerMeshery is meshery/meshery's ui/rtk-query tree.
+	TSConsumerMeshery TSConsumerRepo = "meshery"
+	// TSConsumerCloud is layer5io/meshery-cloud's ui/api + ui/rtk-query trees.
+	TSConsumerCloud TSConsumerRepo = "meshery-cloud"
+	// TSConsumerExtensions is layer5labs/meshery-extensions' meshmap/src/rtk-query tree.
+	TSConsumerExtensions TSConsumerRepo = "meshery-extensions"
+)
+
+// tsScanDirs maps each TS consumer repo to the relative directories that
+// contain RTK Query endpoint definitions. Any `.ts` file under these paths is
+// a candidate for scanning. Directories that do not exist in a given checkout
+// are silently skipped — consumer repos may add or drop RTK modules over time.
+var tsScanDirs = map[TSConsumerRepo][]string{
+	TSConsumerMeshery: {
+		"ui/rtk-query",
+	},
+	TSConsumerCloud: {
+		"ui/api",
+		"ui/rtk-query",
+	},
+	TSConsumerExtensions: {
+		"meshmap/src/rtk-query",
+	},
+}
+
+// TSFindingKind enumerates the classes of drift that the TS consumer flags.
+// These are advisory signals — they do not fail CI directly, but the audit
+// surface makes them visible so Phase 2/3 migration work can target them.
+type TSFindingKind string
+
+const (
+	// TSFindingCaseFlip marks a param/body site that translates a
+	// camelCase query-arg into a non-camelCase wire key
+	// (e.g. `orgID: queryArg.orgId`). The schema contract is camelCase;
+	// the case-flip undoes that.
+	TSFindingCaseFlip TSFindingKind = "case-flip"
+
+	// TSFindingSnakeCaseWrapper marks a body wrapper whose top-level key is
+	// snake_case (`pattern_data`, `k8s_manifest`). These wrappers predate the
+	// identifier-naming migration contract.
+	TSFindingSnakeCaseWrapper TSFindingKind = "snake-case-wrapper"
+
+	// TSFindingSnakeCaseParam marks a params object whose key is snake_case
+	// (e.g. `page_size`, `total_count` used outside the reserved pagination
+	// envelope).
+	TSFindingSnakeCaseParam TSFindingKind = "snake-case-param"
+)
+
+// TSFinding is one drift observation produced by the TypeScript consumer
+// auditor. It carries enough context (file:line, repo, endpoint, wire key)
+// for a downstream tool or CI report to point a reviewer at the exact site.
+type TSFinding struct {
+	Repo     TSConsumerRepo
+	File     string // repo-relative path, forward slashes
+	Line     int    // 1-based source line
+	Endpoint string // RTK endpoint name, e.g. "getWorkspaceForCatalog"
+	URL      string // URL template extracted from the `url` property
+	Method   string // HTTP method (upper-case)
+	Kind     TSFindingKind
+	Key      string // the offending wire key (e.g. "orgID", "pattern_data")
+	Message  string // human-readable description
+}
+
+// String renders the finding in a compact, deterministic form suitable for
+// terminal output and baseline files.
+func (f TSFinding) String() string {
+	loc := f.File
+	if f.Line > 0 {
+		loc = fmt.Sprintf("%s:%d", f.File, f.Line)
+	}
+	return fmt.Sprintf("[%s] %s (%s %s): %s", f.Repo, loc, f.Method, f.URL, f.Message)
+}
+
+// parseTSConsumer walks the configured scan dirs of a TS consumer source tree
+// and extracts RTK endpoint sites. Findings are returned alongside the
+// endpoint records so the caller can surface both in the audit report.
+func parseTSConsumer(tree sourceTree, repo TSConsumerRepo) ([]consumerEndpoint, []TSFinding, error) {
+	if tree == nil {
+		return nil, nil, nil
+	}
+	dirs, ok := tsScanDirs[repo]
+	if !ok || len(dirs) == 0 {
+		return nil, nil, fmt.Errorf("consumer-audit: ts parser: no scan dirs configured for repo %q", repo)
+	}
+
+	var (
+		endpoints []consumerEndpoint
+		findings  []TSFinding
+	)
+
+	for _, dir := range dirs {
+		err := tree.Walk(dir, func(p string) error {
+			if !strings.HasSuffix(p, ".ts") && !strings.HasSuffix(p, ".tsx") {
+				return nil
+			}
+			// Skip test fixtures, generated mocks, and declaration files
+			// — they rarely contain the real endpoint surface and would
+			// add noise to the audit.
+			if strings.HasSuffix(p, ".d.ts") ||
+				strings.HasSuffix(p, ".test.ts") ||
+				strings.HasSuffix(p, ".test.tsx") ||
+				strings.Contains(p, "/__tests__/") ||
+				strings.Contains(p, "/mocks/") {
+				return nil
+			}
+			data, err := tree.ReadFile(p)
+			if err != nil {
+				log.Printf("consumer-audit: ts parser: read %s: %v", p, err)
+				return nil
+			}
+			eps, fs := extractTSEndpoints(string(data), p, repo)
+			endpoints = append(endpoints, eps...)
+			findings = append(findings, fs...)
+			return nil
+		})
+		if err != nil {
+			log.Printf("consumer-audit: ts parser: walk %s: %v", dir, err)
+		}
+	}
+
+	for i := range endpoints {
+		endpoints[i].Repo = string(repo)
+	}
+
+	sortConsumerEndpoints(endpoints)
+	sortTSFindings(findings)
+	return endpoints, findings, nil
+}
+
+// sortTSFindings orders findings deterministically for stable output.
+func sortTSFindings(fs []TSFinding) {
+	sort.Slice(fs, func(i, j int) bool {
+		if fs[i].File != fs[j].File {
+			return fs[i].File < fs[j].File
+		}
+		if fs[i].Line != fs[j].Line {
+			return fs[i].Line < fs[j].Line
+		}
+		return fs[i].Key < fs[j].Key
+	})
+}
+
+// tsEndpointHeadRE locates the start of an RTK endpoint definition. It
+// matches both the Redux-toolkit-builder-function form
+//
+//	getWorkspaceForCatalog: builder.query({
+//
+// and the "build" alias used by codegen output:
+//
+//	getUserKeys: build.mutation({
+var tsEndpointHeadRE = regexp.MustCompile(`(?m)^\s*([A-Za-z_$][\w$]*)\s*:\s*(?:builder|build)\.(query|mutation)\s*\(\s*\{`)
+
+// tsURLRE matches the `url:` property inside an RTK query/mutation site. The
+// URL may be a back-tick template, a single-quoted literal, or a call
+// expression like `mesheryApiPath('integrations/…')`. The anchor is a word
+// boundary rather than start-of-line so inline forms like `{ url: ... }`
+// are matched alongside the more common multi-line layout. Only the first
+// line of the RHS is captured; multi-line expressions (rare in practice)
+// are left to the caller to normalize.
+var tsURLRE = regexp.MustCompile("\\burl\\s*:\\s*([`'\"][^`'\"]*[`'\"]|[A-Za-z_$][\\w$]*\\s*\\([^)]*\\))")
+
+// tsMethodRE matches the `method:` property on a mutation site.
+var tsMethodRE = regexp.MustCompile(`\bmethod\s*:\s*['"]([A-Z]+)['"]`)
+
+// tsCaseFlipRE matches assignment patterns that alias a camelCase query-arg to
+// a non-camelCase wire key. The three canonical patterns are:
+//
+//	orgID: queryArg.orgId
+//	orgID: queryArg?.orgId
+//	orgID: selectedOrganization?.id
+//
+// The first two are the RTK-query case-flip form; the third is an out-of-band
+// identity assignment from session state that still emits the legacy casing
+// on the wire. The anchor matches either start-of-line or the start of an
+// object literal entry so same-line keys like `{ orgID: ... }` surface.
+var tsCaseFlipRE = regexp.MustCompile(`(?m)(?:[{,]\s*|^\s*)([A-Za-z_$][\w$]*[A-Z][A-Za-z_$]*)\s*:\s*[A-Za-z_$][\w$]*\??\.[A-Za-z_$][\w$]*`)
+
+// tsWireKeyRE matches every `key: value` pair inside a params or body
+// literal. The anchor is a `{` or `,` followed by whitespace so same-line
+// keys (`{ orgID: ..., sub_type: ... }`) surface alongside multi-line
+// layouts. The key group is the identifier to the left of the colon.
+var tsWireKeyRE = regexp.MustCompile(`(?m)(?:[{,]\s*|^\s*)([A-Za-z_$][\w$]*)\s*:`)
+
+// tsAllowedSnakeKeys is the set of snake_case wire keys that are part of a
+// published contract (pagination envelope) rather than legacy drift. These
+// must not flip to camelCase inside an already-published API version per
+// the "Casing rules at a glance" table in AGENTS.md.
+var tsAllowedSnakeKeys = map[string]struct{}{
+	"page_size":   {},
+	"total_count": {},
+}
+
+// extractTSEndpoints scans a single TS source file for RTK query/mutation
+// sites and returns one consumerEndpoint per site, plus any findings surfaced
+// by the casing checks. The parser is intentionally regex-based: full TS
+// semantic analysis would require a TypeScript compiler, and the charter
+// is explicit that simpler heuristics are acceptable here.
+//
+// Findings have two surfaces:
+//
+//   - Per-endpoint: `builder.query` / `builder.mutation` sites flag drift
+//     inside their own `params` / `body` literals so each finding is
+//     attributed to a concrete endpoint name.
+//   - File-level: free-standing helpers like
+//     `initiateQuery(api.endpoints.x, { body: {...} })` also send payloads
+//     over the wire but live outside the `builder.query` body. The parser
+//     scans every `body: { ... }` and `params: { ... }` literal in the
+//     file and flags any drift not already covered by an endpoint site,
+//     so the charter-required `designs.ts:308` `pattern_data:` wrapper is
+//     not missed when it appears inside an exported helper function.
+func extractTSEndpoints(src, file string, repo TSConsumerRepo) ([]consumerEndpoint, []TSFinding) {
+	var (
+		endpoints []consumerEndpoint
+		findings  []TSFinding
+	)
+
+	// Track covered ranges so the file-level scan does not double-report
+	// anything already attributed to an endpoint site.
+	var covered []struct{ start, end int }
+
+	heads := tsEndpointHeadRE.FindAllStringSubmatchIndex(src, -1)
+	for i, head := range heads {
+		if len(head) < 6 {
+			continue
+		}
+		endpointStart := head[0]
+		bodyStart := head[1] // position of the opening brace's interior
+		endpointName := src[head[2]:head[3]]
+		kind := src[head[4]:head[5]]
+
+		// Determine the end of this RTK site by finding the matching closing
+		// brace or the start of the next endpoint. Using the next endpoint's
+		// position as a right boundary keeps extraction bounded even if the
+		// brace counter under-counts due to template literals or comments.
+		bodyEnd := len(src)
+		if i+1 < len(heads) {
+			bodyEnd = heads[i+1][0]
+		}
+		if brace := findMatchingBrace(src, bodyStart-1, bodyEnd); brace > 0 {
+			bodyEnd = brace + 1
+		}
+		body := src[bodyStart:bodyEnd]
+		covered = append(covered, struct{ start, end int }{start: bodyStart, end: bodyEnd})
+
+		// URL is the first `url: ...` occurrence inside the site body.
+		urlMatch := tsURLRE.FindStringSubmatchIndex(body)
+		var rawURL string
+		if urlMatch != nil {
+			rawURL = strings.TrimSpace(body[urlMatch[2]:urlMatch[3]])
+		}
+		urlTemplate := normalizeTSURL(rawURL)
+
+		method := "GET"
+		if kind == "mutation" {
+			method = "POST" // sensible default for RTK mutations
+		}
+		if m := tsMethodRE.FindStringSubmatch(body); len(m) == 2 {
+			method = strings.ToUpper(m[1])
+		}
+
+		ep := consumerEndpoint{
+			Method:      method,
+			Path:        urlTemplate,
+			HandlerName: endpointName,
+			HandlerFile: file,
+			RouterFile:  file,
+			RouterLine:  lineOf(src, endpointStart),
+		}
+
+		// Flag case-flips and snake_case wire keys. Each finding gets
+		// attached as a Note on the endpoint and returned separately so
+		// the CLI can surface the full list at the bottom of the report.
+		for _, f := range findTSFindings(body, file, bodyStart, endpointName, method, urlTemplate, repo, src) {
+			findings = append(findings, f)
+			ep.Notes = append(ep.Notes, f.Message)
+		}
+
+		endpoints = append(endpoints, ep)
+	}
+
+	// File-level pass: catch `body: { ... }` / `params: { ... }` literals
+	// that live outside a builder.query block (e.g. inside exported helper
+	// functions that call initiateQuery). Drift covered by an endpoint
+	// site above is skipped so findings are not double-counted.
+	findings = append(findings, findFreeFormFindings(src, file, repo, covered)...)
+
+	// File-wide case-flip pass: hook call-sites like
+	// `useGetWorkspacesQuery({ orgID: selectedOrganization?.id })` live
+	// outside both endpoint bodies AND body/params property literals, but
+	// still emit the drift identifier on the wire once the hook triggers
+	// a request. The dedupe set ensures we don't double-count sites
+	// already surfaced by one of the scans above.
+	seenFileWide := make(map[string]struct{}, len(findings))
+	for _, f := range findings {
+		seenFileWide[keyFinding(f)] = struct{}{}
+	}
+	for _, m := range tsCaseFlipRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		key := src[m[2]:m[3]]
+		if !hasMixedCase(key) {
+			continue
+		}
+		// Skip endpoint-definition sites where the RHS is `builder.query`,
+		// `builder.mutation`, `build.query`, or `build.mutation`. Those
+		// are the RTK endpoint header lines themselves, not wire-format
+		// assignments, so their "key" (the endpoint function name) is
+		// allowed to use whatever TS identifier convention the author
+		// prefers. The matched range `src[m[2]..m[1]]` contains the full
+		// `key: rhs` so we can inspect the RHS identifier directly.
+		fullMatch := src[m[2]:m[1]]
+		if rhs := rhsOfKeyAssignment(fullMatch); rhs == "builder.query" ||
+			rhs == "builder.mutation" ||
+			rhs == "build.query" ||
+			rhs == "build.mutation" {
+			continue
+		}
+		absLine := lineOf(src, m[2])
+		f := TSFinding{
+			Repo:    repo,
+			File:    file,
+			Line:    absLine,
+			Kind:    TSFindingCaseFlip,
+			Key:     key,
+			Message: fmt.Sprintf("wire key %q preserves legacy SCREAMING/mixed casing instead of camelCase schema contract", key),
+		}
+		k := keyFinding(f)
+		if _, ok := seenFileWide[k]; ok {
+			continue
+		}
+		seenFileWide[k] = struct{}{}
+		findings = append(findings, f)
+	}
+
+	return endpoints, findings
+}
+
+// rhsOfKeyAssignment returns the right-hand identifier chain of a
+// `key: rhs` TS fragment, trimmed of whitespace. Used to tell an endpoint
+// definition like `verifyConnectionURL: builder.mutation` apart from a
+// wire-format assignment like `orgID: queryArg.orgId` so the former is not
+// misreported as a case-flip. An unparseable input yields "".
+func rhsOfKeyAssignment(s string) string {
+	idx := strings.Index(s, ":")
+	if idx < 0 {
+		return ""
+	}
+	return strings.TrimSpace(s[idx+1:])
+}
+
+// findFreeFormFindings scans the entire file for body/params literals that
+// live outside a tracked endpoint range. Every bare `body: { ... }` or
+// `params: { ... }` is inspected for snake_case keys and SCREAMING-case
+// flips; findings are emitted without an endpoint attribution so the
+// reviewer can still locate the site via file:line.
+func findFreeFormFindings(src, file string, repo TSConsumerRepo, covered []struct{ start, end int }) []TSFinding {
+	isCovered := func(at int) bool {
+		for _, c := range covered {
+			if at >= c.start && at < c.end {
+				return true
+			}
+		}
+		return false
+	}
+
+	var out []TSFinding
+	seen := make(map[string]struct{})
+
+	for _, prop := range []struct {
+		name string
+		kind TSFindingKind
+	}{
+		{"body", TSFindingSnakeCaseWrapper},
+		{"params", TSFindingSnakeCaseParam},
+	} {
+		anchor := regexp.MustCompile(`\b` + regexp.QuoteMeta(prop.name) + `\s*:\s*\{`)
+		for _, loc := range anchor.FindAllStringIndex(src, -1) {
+			open := loc[1] - 1
+			if isCovered(open) {
+				continue
+			}
+			closeIdx := findMatchingBrace(src, open, len(src))
+			if closeIdx < 0 {
+				continue
+			}
+			snippet := src[open+1 : closeIdx]
+			for _, m := range tsWireKeyRE.FindAllStringSubmatchIndex(snippet, -1) {
+				if len(m) < 4 {
+					continue
+				}
+				key := snippet[m[2]:m[3]]
+				if _, allowed := tsAllowedSnakeKeys[key]; allowed {
+					continue
+				}
+				line := lineOf(src, open+1+m[2])
+				findingKind := prop.kind
+				var msg string
+				switch {
+				case hasMixedCase(key):
+					findingKind = TSFindingCaseFlip
+					msg = fmt.Sprintf("wire key %q preserves legacy SCREAMING/mixed casing instead of camelCase schema contract", key)
+				case isSnakeCase(key):
+					msg = fmt.Sprintf("wire key %q uses snake_case instead of camelCase schema contract", key)
+				default:
+					continue
+				}
+				f := TSFinding{
+					Repo:    repo,
+					File:    file,
+					Line:    line,
+					Method:  "",
+					URL:     "",
+					Kind:    findingKind,
+					Key:     key,
+					Message: msg,
+				}
+				k := keyFinding(f)
+				if _, ok := seen[k]; ok {
+					continue
+				}
+				seen[k] = struct{}{}
+				out = append(out, f)
+			}
+		}
+	}
+	return out
+}
+
+// findMatchingBrace returns the index of the `}` that matches the `{` at
+// openIdx, constrained to the [openIdx, limit) range. The scanner skips
+// characters inside template literals, single/double quoted strings, and
+// line/block comments so braces buried in a URL template or comment body
+// do not shift the balance.
+func findMatchingBrace(src string, openIdx, limit int) int {
+	if openIdx < 0 || openIdx >= len(src) || src[openIdx] != '{' {
+		return -1
+	}
+	if limit > len(src) {
+		limit = len(src)
+	}
+	depth := 0
+	i := openIdx
+	for i < limit {
+		c := src[i]
+		switch c {
+		case '{':
+			depth++
+			i++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+			i++
+		case '`':
+			i = skipDelim(src, i+1, limit, '`')
+		case '\'':
+			i = skipDelim(src, i+1, limit, '\'')
+		case '"':
+			i = skipDelim(src, i+1, limit, '"')
+		case '/':
+			if i+1 < limit && src[i+1] == '/' {
+				// line comment
+				for i < limit && src[i] != '\n' {
+					i++
+				}
+			} else if i+1 < limit && src[i+1] == '*' {
+				// block comment
+				i += 2
+				for i+1 < limit && !(src[i] == '*' && src[i+1] == '/') {
+					i++
+				}
+				i += 2
+			} else {
+				i++
+			}
+		default:
+			i++
+		}
+	}
+	return -1
+}
+
+// skipDelim advances past a JS/TS string or template-literal delimiter.
+// Back-slash escapes are honored so `"a\"b"` is treated as one literal.
+func skipDelim(src string, start, limit int, delim byte) int {
+	i := start
+	for i < limit {
+		if src[i] == '\\' && i+1 < limit {
+			i += 2
+			continue
+		}
+		if src[i] == delim {
+			return i + 1
+		}
+		i++
+	}
+	return limit
+}
+
+// lineOf returns the 1-based line number of idx in src.
+func lineOf(src string, idx int) int {
+	if idx < 0 {
+		return 0
+	}
+	if idx > len(src) {
+		idx = len(src)
+	}
+	return 1 + strings.Count(src[:idx], "\n")
+}
+
+// tsTemplateParamRE matches `${expr}` placeholders in a back-tick template
+// string — RTK's standard form for dynamic URL segments.
+var tsTemplateParamRE = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+// tsRawParamSegmentRE isolates the trailing identifier in an interpolated
+// expression so `queryArg.id` is rendered as `{id}` while a more complex
+// expression like `queryArg.nested?.id` still collapses cleanly.
+var tsRawParamSegmentRE = regexp.MustCompile(`([A-Za-z_$][\w$]*)\s*$`)
+
+// normalizeTSURL converts a raw `url:` RHS into the canonical OpenAPI-style
+// path expected by the endpoint matcher. It handles:
+//
+//   - back-tick templates with `${queryArg.id}` → `{id}`
+//   - single/double-quoted literals: stripped of quotes
+//   - `mesheryApiPath('foo/bar')` helpers: inner literal extracted and
+//     re-prefixed with `/api/`
+//
+// An empty or unparseable RHS yields an empty string so the downstream
+// matcher treats the site as unresolved rather than binding to the wrong path.
+func normalizeTSURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+
+	// Helper call form: `mesheryApiPath('integrations/…')`.
+	if strings.HasPrefix(raw, "mesheryApiPath") {
+		inside := trimCall(raw, "mesheryApiPath")
+		inner := stripQuotes(inside)
+		if inner == "" {
+			return ""
+		}
+		if !strings.HasPrefix(inner, "/") {
+			inner = "/" + inner
+		}
+		inner = replaceTemplateParams(inner)
+		if !strings.HasPrefix(inner, "/api/") {
+			inner = "/api" + inner
+		}
+		return inner
+	}
+
+	// Literal form: strip surrounding quotes/backticks.
+	s := stripQuotes(raw)
+	s = replaceTemplateParams(s)
+	if !strings.HasPrefix(s, "/") {
+		s = "/" + s
+	}
+	return s
+}
+
+// stripQuotes peels leading/trailing `"` / `'` / `` ` `` from a raw URL
+// expression. Mismatched delimiters yield the input unchanged so the
+// caller can decide how to treat it.
+func stripQuotes(s string) string {
+	s = strings.TrimSpace(s)
+	if len(s) < 2 {
+		return s
+	}
+	first, last := s[0], s[len(s)-1]
+	if first == last && (first == '\'' || first == '"' || first == '`') {
+		return s[1 : len(s)-1]
+	}
+	return s
+}
+
+// trimCall returns the argument list of `name(...)` without the enclosing
+// parentheses, or the empty string if the call shape does not match.
+func trimCall(s, name string) string {
+	open := strings.Index(s, "(")
+	if open < 0 || !strings.HasPrefix(s, name) {
+		return ""
+	}
+	close := strings.LastIndex(s, ")")
+	if close <= open {
+		return ""
+	}
+	return strings.TrimSpace(s[open+1 : close])
+}
+
+// replaceTemplateParams rewrites `${expr}` placeholders into OpenAPI-style
+// `{name}` segments. The trailing identifier of the expression is preferred
+// (`queryArg.foo.id` → `{id}`) so paths align with spec param names even
+// when the consumer uses a nested query-arg structure.
+func replaceTemplateParams(s string) string {
+	return tsTemplateParamRE.ReplaceAllStringFunc(s, func(match string) string {
+		inner := strings.TrimSpace(match[2 : len(match)-1])
+		if m := tsRawParamSegmentRE.FindStringSubmatch(inner); m != nil && m[1] != "" {
+			return "{" + m[1] + "}"
+		}
+		return "{}"
+	})
+}
+
+// findTSFindings scans a single endpoint body for the three finding kinds:
+// case-flip, snake-case-wrapper, and snake-case-param. Line numbers are
+// calculated relative to the full source so the report points at the real
+// file:line, not at the endpoint-local offset.
+func findTSFindings(body, file string, bodyOffset int, endpoint, method, url string, repo TSConsumerRepo, fullSrc string) []TSFinding {
+	var out []TSFinding
+
+	// Detect params / body blocks by scanning for their literal property
+	// anchors. Each scanning regex consumes its match so the same key is
+	// never reported twice from the same site.
+	paramsRange := findPropertyBraceRange(body, "params")
+	bodyRange := findPropertyBraceRange(body, "body")
+
+	if paramsRange.valid() {
+		out = append(out, scanParamsOrBody(body, paramsRange, bodyOffset, fullSrc, file, endpoint, method, url, repo, "params")...)
+	}
+	if bodyRange.valid() {
+		out = append(out, scanParamsOrBody(body, bodyRange, bodyOffset, fullSrc, file, endpoint, method, url, repo, "body")...)
+	}
+
+	// Case-flips outside the standard params/body literals still need to be
+	// caught — e.g. a site that builds a plain request object with
+	// `orgID: selectedOrganization?.id`. Scan the whole endpoint body and
+	// dedupe against findings already recorded above.
+	seen := make(map[string]struct{}, len(out))
+	for _, f := range out {
+		if f.Kind == TSFindingCaseFlip {
+			seen[keyFinding(f)] = struct{}{}
+		}
+	}
+	for _, m := range tsCaseFlipRE.FindAllStringSubmatchIndex(body, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		key := body[m[2]:m[3]]
+		if !hasMixedCase(key) {
+			continue
+		}
+		absLine := lineOf(fullSrc, bodyOffset+m[2])
+		f := TSFinding{
+			Repo:     repo,
+			File:     file,
+			Line:     absLine,
+			Endpoint: endpoint,
+			URL:      url,
+			Method:   method,
+			Kind:     TSFindingCaseFlip,
+			Key:      key,
+			Message:  fmt.Sprintf("wire key %q preserves legacy SCREAMING/mixed casing instead of camelCase schema contract", key),
+		}
+		k := keyFinding(f)
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, f)
+	}
+
+	return out
+}
+
+// keyFinding produces a compact dedupe key for a finding. Two findings with
+// the same (file, line, kind, key) tuple describe the same drift.
+func keyFinding(f TSFinding) string {
+	return fmt.Sprintf("%s|%d|%s|%s", f.File, f.Line, f.Kind, f.Key)
+}
+
+// bodyRange is a half-open [start, end) slice of a TS property literal body.
+type bodyRange struct {
+	start int
+	end   int
+}
+
+func (r bodyRange) valid() bool { return r.end > r.start && r.start >= 0 }
+
+// findPropertyBraceRange locates the `{ ... }` literal that follows a
+// property declaration like `params:` or `body:`. The returned range is
+// half-open over the literal's *interior* (excluding the outer braces) so
+// callers can apply key-level regexes without re-skipping the delimiter.
+func findPropertyBraceRange(src, prop string) bodyRange {
+	// Find every occurrence of the property anchor; the literal body is
+	// always the one opened by the nearest following `{`. Multiple matches
+	// can occur when a site defines both `params` and `body` — the caller
+	// invokes this helper once per property.
+	anchor := regexp.MustCompile(`(?m)\b` + regexp.QuoteMeta(prop) + `\s*:\s*\{`)
+	m := anchor.FindStringIndex(src)
+	if m == nil {
+		return bodyRange{-1, -1}
+	}
+	// m[1]-1 is the `{` position; findMatchingBrace locates its partner.
+	open := m[1] - 1
+	closeIdx := findMatchingBrace(src, open, len(src))
+	if closeIdx < 0 {
+		return bodyRange{-1, -1}
+	}
+	return bodyRange{start: open + 1, end: closeIdx}
+}
+
+// scanParamsOrBody inspects a params or body literal and returns findings
+// for every drift-worthy wire key (case-flip + snake_case + SCREAMING).
+func scanParamsOrBody(
+	full string,
+	r bodyRange,
+	bodyOffset int,
+	fullSrc, file, endpoint, method, url string,
+	repo TSConsumerRepo,
+	kind string,
+) []TSFinding {
+	if !r.valid() {
+		return nil
+	}
+	snippet := full[r.start:r.end]
+	var out []TSFinding
+
+	// Walk every `key:` pair. An assignment like `orgID: queryArg.orgId`
+	// surfaces as a case-flip; a bare snake_case key like `pattern_data`
+	// surfaces as a snake-case-wrapper (body kind) or snake-case-param
+	// (params kind). Keys in the allow-list (pagination envelope) are
+	// skipped to avoid false positives on contract-required fields.
+	for _, m := range tsWireKeyRE.FindAllStringSubmatchIndex(snippet, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		key := snippet[m[2]:m[3]]
+		if _, allowed := tsAllowedSnakeKeys[key]; allowed {
+			continue
+		}
+
+		absLine := lineOf(fullSrc, bodyOffset+r.start+m[2])
+
+		// SCREAMING_CASE / mixed-case key — emit as case-flip.
+		if hasMixedCase(key) {
+			out = append(out, TSFinding{
+				Repo:     repo,
+				File:     file,
+				Line:     absLine,
+				Endpoint: endpoint,
+				URL:      url,
+				Method:   method,
+				Kind:     TSFindingCaseFlip,
+				Key:      key,
+				Message:  fmt.Sprintf("wire key %q preserves legacy SCREAMING/mixed casing instead of camelCase schema contract", key),
+			})
+			continue
+		}
+		if isSnakeCase(key) {
+			findingKind := TSFindingSnakeCaseParam
+			if kind == "body" {
+				findingKind = TSFindingSnakeCaseWrapper
+			}
+			out = append(out, TSFinding{
+				Repo:     repo,
+				File:     file,
+				Line:     absLine,
+				Endpoint: endpoint,
+				URL:      url,
+				Method:   method,
+				Kind:     findingKind,
+				Key:      key,
+				Message:  fmt.Sprintf("wire key %q uses snake_case instead of camelCase schema contract", key),
+			})
+		}
+	}
+
+	return out
+}
+
+// hasMixedCase returns true if an identifier contains both a lowercase
+// first letter AND an uppercase cluster (e.g. `orgID`, `userURL`). A
+// purely-camelCase identifier like `orgId` is not flagged because the
+// single-letter casing transition is the published wire form; the drift
+// is the *two+ consecutive uppercase letters* after a lowercase prefix.
+func hasMixedCase(s string) bool {
+	if s == "" {
+		return false
+	}
+	if s[0] < 'a' || s[0] > 'z' {
+		return false
+	}
+	// Look for two consecutive uppercase letters after a lowercase
+	// character. That's the signature of SCREAMING/initialism drift
+	// (`orgID`, `userURL`, `apiID`) and it's what the identifier-naming
+	// contract outlaws.
+	sawLower := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'a' && c <= 'z' {
+			sawLower = true
+			continue
+		}
+		if c >= 'A' && c <= 'Z' && sawLower {
+			if i+1 < len(s) && s[i+1] >= 'A' && s[i+1] <= 'Z' {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// isSnakeCase reports whether an identifier contains `_` — the coarse
+// discriminator between snake_case and camelCase. We intentionally do
+// *not* parse the full identifier; the presence of `_` is the contract
+// violation (the migration plan camelCases wire keys unconditionally
+// except for the fixed pagination envelope).
+func isSnakeCase(s string) bool {
+	return strings.Contains(s, "_")
+}

--- a/validation/consumer_ts.go
+++ b/validation/consumer_ts.go
@@ -97,6 +97,11 @@ func parseTSConsumer(tree sourceTree, repo TSConsumerRepo) ([]consumerEndpoint, 
 		return nil, nil, fmt.Errorf("consumer-audit: ts parser: no scan dirs configured for repo %q", repo)
 	}
 
+	// Deduplicate nested scan dirs: if `ui/rtk-query` is under `ui`, walking
+	// both would process the same files twice and double-count findings.
+	// Keep only the shortest ancestor per prefix group.
+	dirs = dedupNestedDirs(dirs)
+
 	var (
 		endpoints []consumerEndpoint
 		findings  []TSFinding
@@ -141,14 +146,63 @@ func parseTSConsumer(tree sourceTree, repo TSConsumerRepo) ([]consumerEndpoint, 
 	return endpoints, findings, nil
 }
 
-// sortTSFindings orders findings deterministically for stable output.
+// dedupNestedDirs returns the subset of `dirs` that are not descended from
+// another entry in `dirs`. Walks a parent directory and its child
+// separately would re-process the same files, producing duplicate findings
+// and inflating counts.
+func dedupNestedDirs(dirs []string) []string {
+	// Normalize: strip trailing slashes, collect into a set.
+	norm := make([]string, 0, len(dirs))
+	seen := map[string]bool{}
+	for _, d := range dirs {
+		d = strings.TrimRight(d, "/")
+		if d == "" || seen[d] {
+			continue
+		}
+		seen[d] = true
+		norm = append(norm, d)
+	}
+	// Sort shortest first; a shorter path can never be a descendant of
+	// a longer one, so we can filter descendants in a single pass.
+	sort.Slice(norm, func(i, j int) bool {
+		if len(norm[i]) != len(norm[j]) {
+			return len(norm[i]) < len(norm[j])
+		}
+		return norm[i] < norm[j]
+	})
+	kept := norm[:0]
+	for _, d := range norm {
+		covered := false
+		for _, k := range kept {
+			if d == k || strings.HasPrefix(d, k+"/") {
+				covered = true
+				break
+			}
+		}
+		if !covered {
+			kept = append(kept, d)
+		}
+	}
+	return kept
+}
+
+// sortTSFindings orders findings by (Repo, File, Line, Kind, Key) so output
+// is a strict total order — important because sort.Slice is not stable and
+// the audit contract requires byte-identical output across runs. Every tie-
+// breaker is covered so there is no map-order leak.
 func sortTSFindings(fs []TSFinding) {
 	sort.Slice(fs, func(i, j int) bool {
+		if fs[i].Repo != fs[j].Repo {
+			return fs[i].Repo < fs[j].Repo
+		}
 		if fs[i].File != fs[j].File {
 			return fs[i].File < fs[j].File
 		}
 		if fs[i].Line != fs[j].Line {
 			return fs[i].Line < fs[j].Line
+		}
+		if fs[i].Kind != fs[j].Kind {
+			return fs[i].Kind < fs[j].Kind
 		}
 		return fs[i].Key < fs[j].Key
 	})
@@ -785,22 +839,42 @@ func scanParamsOrBody(
 	return out
 }
 
-// hasMixedCase returns true if an identifier contains both a lowercase
-// first letter AND an uppercase cluster (e.g. `orgID`, `userURL`). A
-// purely-camelCase identifier like `orgId` is not flagged because the
-// single-letter casing transition is the published wire form; the drift
-// is the *two+ consecutive uppercase letters* after a lowercase prefix.
+// hasMixedCase returns true if an identifier departs from the canonical
+// camelCase wire contract. A value is flagged when any of the following
+// holds:
+//
+//   - All-uppercase identifier (`ID`, `ORGID`) — pure SCREAMING.
+//   - PascalCase identifier (`OrgId`, `UserID`) — starts with an
+//     uppercase letter but has lowercase too; wire keys must start
+//     lowercase.
+//   - camelCase that embeds a 2+ consecutive-uppercase acronym cluster
+//     (`orgID`, `userURL`, `apiID`) — the SCREAMING initialism drift.
+//
+// Canonical camelCase like `orgId` (only one uppercase transition, not
+// two in a row) is NOT flagged — that's the published wire form.
 func hasMixedCase(s string) bool {
 	if s == "" {
 		return false
 	}
-	if s[0] < 'a' || s[0] > 'z' {
-		return false
+	hasLower, hasUpper := false, false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c >= 'a' && c <= 'z' {
+			hasLower = true
+		}
+		if c >= 'A' && c <= 'Z' {
+			hasUpper = true
+		}
 	}
-	// Look for two consecutive uppercase letters after a lowercase
-	// character. That's the signature of SCREAMING/initialism drift
-	// (`orgID`, `userURL`, `apiID`) and it's what the identifier-naming
-	// contract outlaws.
+	// All-uppercase (ID, ORGID).
+	if hasUpper && !hasLower {
+		return true
+	}
+	// PascalCase — starts with uppercase but has lowercase later.
+	if s[0] >= 'A' && s[0] <= 'Z' && hasLower {
+		return true
+	}
+	// camelCase with a 2+ consecutive-uppercase cluster (orgID, userURL).
 	sawLower := false
 	for i := 0; i < len(s); i++ {
 		c := s[i]

--- a/validation/consumer_ts_test.go
+++ b/validation/consumer_ts_test.go
@@ -1,0 +1,595 @@
+package validation
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// memTree is an in-memory sourceTree used by the TS consumer tests so the
+// fixtures do not need to hit the filesystem. It reuses the walk-order
+// contract of localTree (sorted) to match the real runtime.
+type memTree struct {
+	ref   string
+	files map[string]string
+}
+
+func (t *memTree) ReadFile(path string) ([]byte, error) {
+	data, ok := t.files[path]
+	if !ok {
+		return nil, fmt.Errorf("memTree: file %q not found", path)
+	}
+	return []byte(data), nil
+}
+
+func (t *memTree) Walk(dir string, fn func(path string) error) error {
+	var paths []string
+	for p := range t.files {
+		if strings.HasPrefix(p, strings.TrimRight(dir, "/")+"/") {
+			paths = append(paths, p)
+		}
+	}
+	sort.Strings(paths)
+	for _, p := range paths {
+		if err := fn(p); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (t *memTree) Ref() string {
+	if t.ref == "" {
+		return "mem:"
+	}
+	return t.ref
+}
+
+// findFinding returns the first finding matching (file, kind, key), or nil.
+// Test failures quote the matched tuple so drift in positional assertions
+// surfaces clearly.
+func findFinding(findings []TSFinding, file string, kind TSFindingKind, key string) *TSFinding {
+	for i := range findings {
+		f := &findings[i]
+		if f.File == file && f.Kind == kind && f.Key == key {
+			return f
+		}
+	}
+	return nil
+}
+
+// TestConsumerTS_CaseFlipInCatalog recreates the `catalog.ts:110`
+// `orgID: queryArg.orgId` fixture called out in the Phase 1.F charter.
+// The parser must find the endpoint and attach a case-flip finding.
+func TestConsumerTS_CaseFlipInCatalog(t *testing.T) {
+	// Padding lines keep the orgID assignment on line 110 so the fixture
+	// matches the real `meshery-extensions/meshmap/src/rtk-query/catalog.ts`
+	// coordinates. The charter's acceptance criterion names this line
+	// number explicitly and a regression in line accounting should be
+	// caught by the test.
+	const prefix = "// padding line placeholder. line 1\n"
+	var builder strings.Builder
+	for i := 1; i < 100; i++ {
+		builder.WriteString(prefix)
+	}
+	builder.WriteString(`export const catalogApi = api.injectEndpoints({
+  endpoints: builder => ({
+    getWorkspaceForCatalog: builder.query({
+      query: queryArg => ({
+        url: ` + "`/api/extensions/api/workspaces`" + `,
+        params: {
+          page: queryArg.page,
+          pagesize: queryArg.pagesize,
+          search: queryArg.search,
+          order: queryArg.order,
+          orgID: queryArg.orgId
+        }
+      }),
+      providesTags: ["workspace"]
+    })
+  })
+});
+`)
+	src := builder.String()
+
+	tree := &memTree{
+		ref:   "test",
+		files: map[string]string{"meshmap/src/rtk-query/catalog.ts": src},
+	}
+	endpoints, findings, err := parseTSConsumer(tree, TSConsumerExtensions)
+	if err != nil {
+		t.Fatalf("parseTSConsumer: %v", err)
+	}
+	if len(endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d: %+v", len(endpoints), endpoints)
+	}
+	ep := endpoints[0]
+	if ep.HandlerName != "getWorkspaceForCatalog" {
+		t.Errorf("HandlerName = %q, want getWorkspaceForCatalog", ep.HandlerName)
+	}
+	if ep.Path != "/api/extensions/api/workspaces" {
+		t.Errorf("Path = %q, want /api/extensions/api/workspaces", ep.Path)
+	}
+	if ep.Method != "GET" {
+		t.Errorf("Method = %q, want GET", ep.Method)
+	}
+
+	// Charter: must surface catalog.ts:110 case-flip.
+	f := findFinding(findings, "meshmap/src/rtk-query/catalog.ts", TSFindingCaseFlip, "orgID")
+	if f == nil {
+		t.Fatalf("no case-flip finding for orgID; findings: %+v", findings)
+	}
+	if f.Line != 110 {
+		t.Errorf("case-flip line = %d, want 110", f.Line)
+	}
+	if f.Repo != TSConsumerExtensions {
+		t.Errorf("case-flip repo = %q, want %q", f.Repo, TSConsumerExtensions)
+	}
+}
+
+// TestConsumerTS_DesignsWrapper recreates the `designs.ts:308` `pattern_data`
+// body wrapper case from the charter.
+func TestConsumerTS_DesignsWrapper(t *testing.T) {
+	// 306 padding lines bring the body wrapper to line 308 exactly so the
+	// parser's line number matches the real checkout fixture.
+	const pad = "// pad\n"
+	var builder strings.Builder
+	for i := 1; i < 303; i++ {
+		builder.WriteString(pad)
+	}
+	builder.WriteString(`
+uploadPatternBySourceType: builder.mutation({
+  query: queryArg => ({
+    url: ` + "`/api/content/patterns/${queryArg.sourceType}`" + `,
+    method: "POST",
+    body: { pattern_data: { name: queryArg.fileName, patternFile: queryArg.patternFileData }, save: queryArg.save }
+  })
+}),
+`)
+	src := builder.String()
+
+	tree := &memTree{
+		files: map[string]string{"meshmap/src/rtk-query/designs.ts": src},
+	}
+	endpoints, findings, err := parseTSConsumer(tree, TSConsumerExtensions)
+	if err != nil {
+		t.Fatalf("parseTSConsumer: %v", err)
+	}
+	if len(endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(endpoints))
+	}
+	if got, want := endpoints[0].Method, "POST"; got != want {
+		t.Errorf("Method = %q, want %q", got, want)
+	}
+	if got, want := endpoints[0].Path, "/api/content/patterns/{sourceType}"; got != want {
+		t.Errorf("Path = %q, want %q", got, want)
+	}
+
+	f := findFinding(findings, "meshmap/src/rtk-query/designs.ts", TSFindingSnakeCaseWrapper, "pattern_data")
+	if f == nil {
+		t.Fatalf("no pattern_data wrapper finding; got: %+v", findings)
+	}
+	if f.Line != 308 {
+		t.Errorf("wrapper line = %d, want 308", f.Line)
+	}
+}
+
+// TestConsumerTS_UserHookInconsistencies covers the "user.ts hook
+// inconsistencies" acceptance criterion: a mutation body that retains
+// SCREAMING-casing for orgID should surface as a case-flip, and an
+// adjacent snake_case param key should be flagged as drift.
+func TestConsumerTS_UserHookInconsistencies(t *testing.T) {
+	src := `import { mesheryApi } from "@meshery/schemas/mesheryApi";
+
+export const userApi = mesheryApi.injectEndpoints({
+  endpoints: builder => ({
+    notifyMentionedUsers: builder.mutation({
+      query: queryArg => ({
+        url: "/api/extensions/api/identity/users/notify/comment",
+        method: "POST",
+        body: { orgID: selectedOrganization?.id, sub_type: queryArg.subType, userIds: queryArg.userIds }
+      })
+    }),
+    getAllUsers: builder.query({
+      query: queryArg => ({
+        url: "/api/identity/users",
+        params: { page_size: queryArg.pageSize, orgID: queryArg.orgId }
+      })
+    })
+  })
+});
+`
+	tree := &memTree{
+		files: map[string]string{"meshmap/src/rtk-query/user.ts": src},
+	}
+	endpoints, findings, err := parseTSConsumer(tree, TSConsumerExtensions)
+	if err != nil {
+		t.Fatalf("parseTSConsumer: %v", err)
+	}
+	if len(endpoints) != 2 {
+		t.Fatalf("expected 2 endpoints, got %d", len(endpoints))
+	}
+
+	// body { orgID: selectedOrganization?.id } — case-flip
+	if f := findFinding(findings, "meshmap/src/rtk-query/user.ts", TSFindingCaseFlip, "orgID"); f == nil {
+		t.Errorf("missing orgID case-flip; got %+v", findings)
+	}
+	// body { sub_type: ... } — snake-case wrapper
+	if f := findFinding(findings, "meshmap/src/rtk-query/user.ts", TSFindingSnakeCaseWrapper, "sub_type"); f == nil {
+		t.Errorf("missing sub_type wrapper finding; got %+v", findings)
+	}
+	// page_size is in the pagination envelope allow-list — must NOT be flagged.
+	for _, f := range findings {
+		if f.Key == "page_size" {
+			t.Errorf("page_size should be allow-listed, got finding %+v", f)
+		}
+	}
+}
+
+// TestConsumerTS_AllowedPaginationKeys confirms page_size / total_count are
+// exempt from snake_case flags per the published contract.
+func TestConsumerTS_AllowedPaginationKeys(t *testing.T) {
+	src := `
+listItems: builder.query({
+  query: queryArg => ({
+    url: "/api/items",
+    params: { page: queryArg.page, page_size: queryArg.pageSize, total_count: queryArg.total }
+  })
+})
+`
+	tree := &memTree{
+		files: map[string]string{"ui/rtk-query/items.ts": src},
+	}
+	_, findings, err := parseTSConsumer(tree, TSConsumerMeshery)
+	if err != nil {
+		t.Fatalf("parseTSConsumer: %v", err)
+	}
+	for _, f := range findings {
+		if f.Key == "page_size" || f.Key == "total_count" {
+			t.Errorf("pagination-envelope key %q was flagged: %+v", f.Key, f)
+		}
+	}
+}
+
+// TestConsumerTS_URLNormalization validates the template-to-OpenAPI
+// URL conversion contract. The matcher relies on `{paramName}` form so
+// joins against the schema endpoint index succeed.
+func TestConsumerTS_URLNormalization(t *testing.T) {
+	cases := []struct {
+		name, src, want string
+	}{
+		{
+			name: "backtick-single-param",
+			src: `getOne: builder.query({
+  query: queryArg => ({ url: ` + "`/api/items/${queryArg.id}`" + ` })
+})`,
+			want: "/api/items/{id}",
+		},
+		{
+			name: "backtick-nested-param",
+			src: `getSub: builder.query({
+  query: queryArg => ({ url: ` + "`/api/items/${queryArg.parent.subId}/sub`" + ` })
+})`,
+			want: "/api/items/{subId}/sub",
+		},
+		{
+			name: "plain-literal",
+			src: `listAll: builder.query({
+  query: () => ({ url: "/api/items" })
+})`,
+			want: "/api/items",
+		},
+		{
+			name: "mesheryApiPath-helper",
+			src: `getX: builder.query({
+  query: () => ({ url: mesheryApiPath('integrations/foo') })
+})`,
+			want: "/api/integrations/foo",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tree := &memTree{
+				files: map[string]string{"ui/rtk-query/fx.ts": tc.src},
+			}
+			endpoints, _, err := parseTSConsumer(tree, TSConsumerMeshery)
+			if err != nil {
+				t.Fatalf("parseTSConsumer: %v", err)
+			}
+			if len(endpoints) != 1 {
+				t.Fatalf("expected 1 endpoint, got %d", len(endpoints))
+			}
+			if endpoints[0].Path != tc.want {
+				t.Errorf("Path = %q, want %q", endpoints[0].Path, tc.want)
+			}
+		})
+	}
+}
+
+// TestConsumerTS_BuildAliasParsed confirms the `build.query` / `build.mutation`
+// form used by meshery-cloud's RTK codegen output is picked up alongside the
+// `builder.query` form used elsewhere.
+func TestConsumerTS_BuildAliasParsed(t *testing.T) {
+	src := `const api = base.injectEndpoints({
+  endpoints: build => ({
+    handleUserInvite: build.mutation({
+      query: queryArg => ({
+        url: ` + "`/api/identity/orgs/${queryArg.orgId}/users/invite`" + `,
+        method: "POST",
+        body: queryArg.userInvite
+      })
+    })
+  })
+});`
+	tree := &memTree{
+		files: map[string]string{"ui/api/api.ts": src},
+	}
+	endpoints, _, err := parseTSConsumer(tree, TSConsumerCloud)
+	if err != nil {
+		t.Fatalf("parseTSConsumer: %v", err)
+	}
+	if len(endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(endpoints))
+	}
+	if endpoints[0].HandlerName != "handleUserInvite" {
+		t.Errorf("HandlerName = %q", endpoints[0].HandlerName)
+	}
+	if endpoints[0].Method != "POST" {
+		t.Errorf("Method = %q, want POST", endpoints[0].Method)
+	}
+	if endpoints[0].Path != "/api/identity/orgs/{orgId}/users/invite" {
+		t.Errorf("Path = %q", endpoints[0].Path)
+	}
+}
+
+// TestConsumerTS_SkipsTestAndMockFiles confirms the parser does not walk
+// into __tests__/mocks/*.d.ts paths which would otherwise drown the audit
+// in fixture noise.
+func TestConsumerTS_SkipsTestAndMockFiles(t *testing.T) {
+	srcLive := `live: builder.query({ query: () => ({ url: "/api/live" }) })`
+	srcFixture := `fixture: builder.query({ query: () => ({ url: "/api/fixture", params: { orgID: q.orgId } }) })`
+
+	tree := &memTree{
+		files: map[string]string{
+			"ui/rtk-query/live.ts":                         srcLive,
+			"ui/rtk-query/__tests__/live.test.ts":          srcFixture,
+			"ui/rtk-query/mocks/mock.ts":                   srcFixture,
+			"ui/rtk-query/generated.d.ts":                  srcFixture,
+		},
+	}
+	endpoints, findings, err := parseTSConsumer(tree, TSConsumerMeshery)
+	if err != nil {
+		t.Fatalf("parseTSConsumer: %v", err)
+	}
+	if len(endpoints) != 1 {
+		t.Fatalf("expected 1 endpoint (live), got %d", len(endpoints))
+	}
+	if len(findings) != 0 {
+		t.Errorf("expected 0 findings from fixture-excluded files, got %+v", findings)
+	}
+}
+
+// TestConsumerTS_DeterministicOrder asserts that parser output is stable
+// across runs so reconciliation against the Google Sheet stays clean. The
+// acceptance criteria require the audit produce deterministic output.
+func TestConsumerTS_DeterministicOrder(t *testing.T) {
+	src := `
+b: builder.query({ query: () => ({ url: "/api/b" }) }),
+a: builder.query({ query: () => ({ url: "/api/a" }) }),
+c: builder.query({ query: () => ({ url: "/api/c" }) }),
+`
+	tree := &memTree{
+		files: map[string]string{"ui/rtk-query/order.ts": src},
+	}
+	eps1, _, _ := parseTSConsumer(tree, TSConsumerMeshery)
+	eps2, _, _ := parseTSConsumer(tree, TSConsumerMeshery)
+	if len(eps1) != len(eps2) {
+		t.Fatalf("run lengths differ: %d vs %d", len(eps1), len(eps2))
+	}
+	for i := range eps1 {
+		if eps1[i].Path != eps2[i].Path || eps1[i].HandlerName != eps2[i].HandlerName {
+			t.Errorf("non-deterministic order at index %d: %+v vs %+v", i, eps1[i], eps2[i])
+		}
+	}
+}
+
+// TestConsumerTS_RegistryCoversAllRepos ensures every TSConsumerRepo has
+// associated scan dirs. A new repo added to the enum without a scan-dirs
+// entry would silently do nothing — this test surfaces that drift.
+func TestConsumerTS_RegistryCoversAllRepos(t *testing.T) {
+	for _, repo := range []TSConsumerRepo{TSConsumerMeshery, TSConsumerCloud, TSConsumerExtensions} {
+		if dirs, ok := tsScanDirs[repo]; !ok || len(dirs) == 0 {
+			t.Errorf("repo %q missing scan dirs", repo)
+		}
+	}
+}
+
+// TestConsumerTS_FreeFormBodyCapturesHelperWrapper covers the charter's
+// `designs.ts:308` acceptance case where a `body: { pattern_data: {...} }`
+// wrapper lives inside a plain helper function (outside any
+// `builder.query`/`builder.mutation` block). The file-level scan is what
+// surfaces these.
+func TestConsumerTS_FreeFormBodyCapturesHelperWrapper(t *testing.T) {
+	src := `import { initiateQuery } from ".";
+
+export const uploadPatternFile = async ({
+  patternFileData,
+  fileName
+}: {
+  patternFileData: string;
+  fileName: string;
+}) => {
+  return await initiateQuery(designsApi.endpoints.uploadPatternBySourceType, {
+    sourceType: "Design",
+    body: { pattern_data: { name: fileName, patternFile: patternFileData } }
+  });
+};
+`
+	tree := &memTree{
+		files: map[string]string{"meshmap/src/rtk-query/designs.ts": src},
+	}
+	_, findings, err := parseTSConsumer(tree, TSConsumerExtensions)
+	if err != nil {
+		t.Fatalf("parseTSConsumer: %v", err)
+	}
+	if f := findFinding(findings, "meshmap/src/rtk-query/designs.ts", TSFindingSnakeCaseWrapper, "pattern_data"); f == nil {
+		t.Errorf("missing pattern_data wrapper finding; got %+v", findings)
+	}
+}
+
+// TestConsumerTS_IntegrationAgainstMesheryExtensions is the Phase 1.F
+// acceptance integration: when a local `../meshery-extensions` checkout is
+// available, parsing its meshmap/src/rtk-query tree must produce all three
+// charter-named findings. The test skips cleanly when the sibling repo is
+// not present, so CI that does not mount the downstream checkouts still
+// passes and the acceptance check is only asserted on a workstation that
+// mirrors the full Phase 1.F environment.
+func TestConsumerTS_IntegrationAgainstMesheryExtensions(t *testing.T) {
+	root, ok := locateSiblingRepo("meshery-extensions", "meshmap/src/rtk-query/catalog.ts")
+	if !ok {
+		t.Skip("meshery-extensions sibling repo not present; integration test skipped")
+	}
+	tree := localTree{root: root}
+	_, findings, err := parseTSConsumer(&tree, TSConsumerExtensions)
+	if err != nil {
+		t.Fatalf("parseTSConsumer: %v", err)
+	}
+
+	// Deterministic order — re-run and compare.
+	_, findings2, _ := parseTSConsumer(&tree, TSConsumerExtensions)
+	if len(findings) != len(findings2) {
+		t.Fatalf("non-deterministic finding counts: %d vs %d", len(findings), len(findings2))
+	}
+	for i := range findings {
+		if keyFinding(findings[i]) != keyFinding(findings2[i]) {
+			t.Errorf("non-deterministic ordering at %d: %q vs %q",
+				i, keyFinding(findings[i]), keyFinding(findings2[i]))
+		}
+	}
+
+	// Charter acceptance: the catalog case-flip at line 110 must be
+	// flagged. The file also contains an earlier `orgID: queryArg.orgID`
+	// self-assignment at line 58 which the parser surfaces as well; the
+	// charter-named finding is specifically the line 110 site.
+	if !hasFindingAt(findings, "meshmap/src/rtk-query/catalog.ts", TSFindingCaseFlip, "orgID", 110) {
+		t.Errorf("catalog.ts:110 orgID case-flip missing from integration findings; got %+v", findings)
+	}
+
+	// Charter acceptance: the designs.ts:308 pattern_data wrapper must be flagged.
+	if !hasFindingAt(findings, "meshmap/src/rtk-query/designs.ts", TSFindingSnakeCaseWrapper, "pattern_data", 308) {
+		t.Errorf("designs.ts:308 pattern_data wrapper missing from integration findings; got %+v", findings)
+	}
+}
+
+// hasFindingAt reports whether the findings slice contains a site that
+// matches all four coordinates (file, kind, key, line). Tests use this
+// when the real fixture produces multiple findings with the same (kind,
+// key) pair — the line number is what distinguishes the charter-named
+// site from its siblings.
+func hasFindingAt(findings []TSFinding, file string, kind TSFindingKind, key string, line int) bool {
+	for _, f := range findings {
+		if f.File == file && f.Kind == kind && f.Key == key && f.Line == line {
+			return true
+		}
+	}
+	return false
+}
+
+// locateSiblingRepo walks up from the working directory looking for a
+// neighbouring checkout named repoName that contains the probe file. It
+// returns (repoRoot, true) on match and (_, false) when the sibling is
+// not available. The probe file makes the check cheap — readdir on a
+// well-known path — and avoids false positives from empty directories.
+func locateSiblingRepo(repoName, probeFile string) (string, bool) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", false
+	}
+	// Walk up to six levels looking for the sibling dir. Six covers the
+	// standard `../sibling` layout (package-level cwd = validation/) and
+	// the Claude-harness worktree layout
+	// (`<repo>/.claude/worktrees/<slug>/validation/`), both of which
+	// need to traverse multiple parents to reach the sibling root.
+	for i := 0; i < 6; i++ {
+		candidate := filepath.Join(cwd, "..", repoName, probeFile)
+		if _, err := os.Stat(candidate); err == nil {
+			return filepath.Join(cwd, "..", repoName), true
+		}
+		cwd = filepath.Dir(cwd)
+	}
+	return "", false
+}
+
+// TestConsumerTS_EndpointNameNotFlaggedAsCaseFlip guards against a known
+// false-positive shape: an RTK endpoint declared with a mixed-case name
+// (`verifyConnectionURL: builder.mutation({...})`) must not be treated
+// as a wire-format case-flip. The endpoint header's "key" is a TS
+// function name, not a wire identifier.
+func TestConsumerTS_EndpointNameNotFlaggedAsCaseFlip(t *testing.T) {
+	src := `const api = base.injectEndpoints({
+  endpoints: builder => ({
+    verifyConnectionURL: builder.mutation({
+      query: queryArg => ({
+        url: "/api/connections/verify",
+        method: "POST",
+        params: { id: queryArg.repoURL }
+      })
+    })
+  })
+});`
+	tree := &memTree{
+		files: map[string]string{"ui/rtk-query/connection.ts": src},
+	}
+	_, findings, err := parseTSConsumer(tree, TSConsumerMeshery)
+	if err != nil {
+		t.Fatalf("parseTSConsumer: %v", err)
+	}
+	for _, f := range findings {
+		if f.Key == "verifyConnectionURL" {
+			t.Errorf("endpoint header %q was flagged as case-flip: %+v", f.Key, f)
+		}
+	}
+}
+
+// TestConsumerTS_FileWideCaseFlipCapturesHookCallSites covers the
+// charter's "user.ts hook inconsistencies" case where a consumer invokes
+// an RTK hook with a SCREAMING-case key (e.g.
+// `useGetWorkspacesQuery({ orgID: selectedOrganization?.id })`). These
+// sites are not inside a `builder.query` body so the endpoint-scoped
+// scan misses them; the file-wide case-flip pass is what surfaces the
+// drift.
+func TestConsumerTS_FileWideCaseFlipCapturesHookCallSites(t *testing.T) {
+	src := `import { useGetWorkspacesQuery } from "@meshery/schemas/mesheryApi";
+
+export function HookSite() {
+  const { data } = useGetWorkspacesQuery(
+    {
+      page: 0,
+      pagesize: "all",
+      order: "updated_at desc",
+      orgID: selectedOrganization?.id,
+    },
+    { skip: !selectedOrganization?.id },
+  );
+  return data;
+}
+`
+	tree := &memTree{
+		files: map[string]string{"ui/rtk-query/user.ts": src},
+	}
+	_, findings, err := parseTSConsumer(tree, TSConsumerMeshery)
+	if err != nil {
+		t.Fatalf("parseTSConsumer: %v", err)
+	}
+	f := findFinding(findings, "ui/rtk-query/user.ts", TSFindingCaseFlip, "orgID")
+	if f == nil {
+		t.Fatalf("missing orgID case-flip at hook call site; got %+v", findings)
+	}
+	if f.Line < 4 || f.Line > 12 {
+		t.Errorf("orgID line = %d, want within hook call range 4-12", f.Line)
+	}
+}

--- a/validation/doc.go
+++ b/validation/doc.go
@@ -7,7 +7,7 @@
 // allows meshkit/schema and model helper methods to import this package
 // without creating cycles.
 //
-// Two concerns live here:
+// Three concerns live here:
 //
 //   - Schema Auditing: validates that OpenAPI schema files follow project
 //     conventions (naming, dual-schema pattern, codegen annotations, etc.).
@@ -15,4 +15,18 @@
 //
 //   - Document Validation: validates JSON documents against OpenAPI schemas
 //     at runtime using kin-openapi. Used by Meshery server and CLI.
+//
+//   - Consumer Auditing: walks consumer repos (meshery/meshery,
+//     layer5io/meshery-cloud, layer5labs/meshery-extensions) and diffs
+//     their registered endpoints against the schemas endpoint index.
+//     Three parsers are registered: consumer_gorilla (Go Gorilla router in
+//     meshery/meshery), consumer_echo (Go Echo router in meshery-cloud), and
+//     consumer_ts (TypeScript RTK Query endpoints across all three repos).
+//     The TS consumer is regex-based — full semantic TS analysis would
+//     require the TypeScript compiler, and the migration plan calls for
+//     simpler heuristics — and it surfaces wire-format drift such as
+//     camelCase → SCREAMING case-flips (`orgID: queryArg.orgId`),
+//     snake_case body wrappers (`pattern_data`, `k8s_manifest`), and
+//     snake_case params keys outside the pagination envelope.
+//     Invoked at review/maintenance time via cmd/consumer-audit.
 package validation


### PR DESCRIPTION
## Summary
- Adds `validation/consumer_ts.go`, a regex-based RTK Query parser that walks `ui/rtk-query`, `ui/api`, and `meshmap/src/rtk-query` across all three downstream repos and flags three wire-format drift kinds against the camelCase schema contract: `case-flip` (SCREAMING/mixed-case keys like `orgID: queryArg.orgId`), `snake-case-wrapper` (body literals keyed by `pattern_data`/`k8s_manifest`), and `snake-case-param` (non-pagination snake keys).
- Registers the TS consumer alongside the existing Echo/Gorilla Go consumers, extends `cmd/consumer-audit/main.go` with `--extensions-repo`, `--meshery-repo-ui`, `--cloud-repo-ui`, and the Makefile target with `EXTENSIONS_REPO=`, `MESHERY_REPO_UI=`, `CLOUD_REPO_UI=`. Findings land on a new `ConsumerAuditResult.TSFindings` slice and print grouped by repo below the main endpoint table.
- Inline-fixture unit tests + an integration test against `../meshery-extensions` that skips cleanly when the sibling repo is not mounted. Docs added: `validation/doc.go` is extended to three concerns; `AGENTS.md § Consumer audit` describes the new target and finding kinds.

## Scope notes
- The parser is intentionally heuristic per the Phase 1.F charter (full TS semantic analysis would need the TypeScript compiler). Three scanning tiers cover the charter's acceptance cases: per-endpoint `params`/`body` literals, file-level `body:`/`params:` literals outside endpoint sites (catches `designs.ts:308` where the wrapper lives inside a helper function calling `initiateQuery`), and a file-wide case-flip scan (catches hook call sites like `useGetWorkspacesQuery({ orgID: selectedOrganization?.id })` in `user.ts:384`).
- Endpoint headers of the form `verifyConnectionURL: builder.mutation(...)` are excluded from the case-flip heuristic — the "key" there is a TS function name, not a wire identifier.
- This PR implements the endpoint parser only; a TS imports scanner was not in scope (Phase 0.D already covered schema import attribution in `cmd/phase0-consumer-graph`).

## Acceptance
Running `make consumer-audit MESHERY_REPO=../meshery CLOUD_REPO=../meshery-cloud EXTENSIONS_REPO=../meshery-extensions` surfaces each of the charter-named findings:

```
[case-flip] meshmap/src/rtk-query/catalog.ts:110  GET /api/extensions/api/workspaces  key="orgID"
[snake-case-wrapper] meshmap/src/rtk-query/designs.ts:308     key="pattern_data"
[case-flip] ui/rtk-query/user.ts:384     key="orgID"
```

Full TS-findings section reports 40 findings across 3 repos (8 meshery + 24 meshery-cloud + 8 meshery-extensions) with deterministic ordering across back-to-back runs (verified via `diff`).

## New flags
- CLI: `--extensions-repo`, `--meshery-repo-ui`, `--cloud-repo-ui`
- Makefile: `EXTENSIONS_REPO=`, `MESHERY_REPO_UI=`, `CLOUD_REPO_UI=`

## Test plan
- [x] `go test ./validation/ -run TestConsumerTS -v` — all pass (11 sub-cases)
- [x] `go test ./...` — no failures
- [x] `make validate-schemas` — no blocking violations
- [x] `make build` — green
- [x] `npm run build` — green
- [x] `make consumer-audit` with all three sibling repos — deterministic output, all three charter-named findings surface
- [x] `make consumer-audit` with only `MESHERY_REPO=` — clean skip of TS scan for unset trees

Refs: `docs/identifier-naming-migration.md` §7 Agent 1.F.