### PR TITLE
docs(consumer-audit): note CI_CONSUMER_PAT is provisioned

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -501,13 +501,13 @@ On each run the job:
 
 ### Provisioning `CI_CONSUMER_PAT`
 
-The secret must be a fine-grained or classic PAT with read access to:
+The secret is **provisioned** on `meshery/schemas` and authorises all three sibling checkouts. It must be a fine-grained or classic PAT with read access to:
 
 - `meshery/meshery` (public — read access is implicit, but including the repo in the PAT's scope list keeps all three checkouts on a single credential path)
 - `layer5io/meshery-cloud` (private — PAT must be a member of the `layer5io` org with `contents: read`)
 - `layer5labs/meshery-extensions` (private — PAT must be a member of the `layer5labs` org with `contents: read`)
 
-If the secret is absent, `actions/checkout@v4` will receive an empty `token:` input and fall back to unauthenticated access. The public `meshery/meshery` checkout still succeeds; both private siblings will fail and — thanks to `continue-on-error: true` — be skipped cleanly. The job remains green, the comment surfaces only the public column, and the "Skipped consumer checkouts" note lists which consumers were omitted.
+If the secret is ever removed or becomes under-scoped, `actions/checkout@v4` receives an empty `token:` input and falls back to unauthenticated access. The public `meshery/meshery` checkout still succeeds; both private siblings will fail and — thanks to `continue-on-error: true` — be skipped cleanly. The job remains green, the comment surfaces only the public column, and the "Skipped consumer checkouts" note lists which consumers were omitted. When the PAT nears expiry it must be rotated in the repo secrets; the workflow itself needs no change.
 
 ## Questions?
 


### PR DESCRIPTION
## Summary

Doc-only update to \`AGENTS.md § Provisioning CI_CONSUMER_PAT\` to record that the secret is now configured on \`meshery/schemas\`, plus a one-sentence PAT-rotation note.

## Why

Two purposes:
1. Future maintainers (and AI agents) reading the Consumer audit section see that the PAT exists rather than reading conditional "if absent" language and wondering what the current state is.
2. This PR is a trivial no-op schema change that exercises the \`consumer-audit\` workflow end-to-end against all three sibling repos. With the PAT now in place, the PR-comment summary should list \`meshery-cloud\` and \`meshery-extensions\` counts alongside \`meshery\`, and the "Skipped consumer checkouts" note should drop.

## Changes

- \`AGENTS.md\` — §Provisioning: replaced the "must be" language with "is provisioned," and added a rotation note.

## Tests

N/A — docs-only. CI itself is the validation: the consumer-audit job should now authenticate against all three consumers.

## Docs / Migration impact

None.

## Rollback

Revert the commit.

## Test plan

- [x] \`git commit -s\`
- [ ] CI \`consumer-audit (blocking)\` job completes; PR-comment lists all three repos; no "Skipped consumer checkouts" note