### PR TITLE
feat(schemas): canonical camelCase coverage for 9 deferred wire keys

### DIFF
--- a/schemas/constructs/v1beta2/schedule/api.yml
+++ b/schemas/constructs/v1beta2/schedule/api.yml
@@ -200,17 +200,37 @@ components:
             db: "cron_expression"
             json: cronExpression
           maxLength: 500
+        lastRun:
+          $ref: "../../v1alpha1/core/api.yml#/components/schemas/nullTime"
+          description: >
+            Server-computed timestamp of the schedule's most recent execution.
+            Null until the first run completes. Server-managed; clients must
+            not set this on create/update.
+          x-order: 5
+          x-oapi-codegen-extra-tags:
+            db: "last_run"
+            json: lastRun
+        nextRun:
+          $ref: "../../v1alpha1/core/api.yml#/components/schemas/nullTime"
+          description: >
+            Server-computed timestamp of the schedule's next planned execution,
+            derived from the cron expression. Server-managed; clients must not
+            set this on create/update.
+          x-order: 6
+          x-oapi-codegen-extra-tags:
+            db: "next_run"
+            json: nextRun
         createdAt:
           $ref: "../../v1alpha1/core/api.yml#/components/schemas/Time"
           description: Timestamp when the schedule was created.
-          x-order: 5
+          x-order: 7
           x-oapi-codegen-extra-tags:
             db: "created_at"
             json: createdAt
         updatedAt:
           $ref: "../../v1alpha1/core/api.yml#/components/schemas/Time"
           description: Timestamp when the schedule was last updated.
-          x-order: 6
+          x-order: 8
           x-oapi-codegen-extra-tags:
             db: "updated_at"
             json: updatedAt

--- a/schemas/constructs/v1beta2/team/api.yml
+++ b/schemas/constructs/v1beta2/team/api.yml
@@ -191,8 +191,24 @@ components:
 
     TeamMember:
       type: object
-      description: A user who is a prospective or existing team member.
+      description: >
+        A user who is a prospective or existing team member. Returned by the
+        "list users in team" endpoint. `joinedAt` is the first canonicalised
+        projection field — other user fields (`id`, `firstName`, `lastName`,
+        `email`, `avatarUrl`) continue to flow through `additionalProperties`
+        pending migration of the user schema to the canonical-casing
+        contract. See meshery/schemas#832 for the per-field roadmap.
       additionalProperties: true
+      properties:
+        joinedAt:
+          $ref: ../../v1alpha1/core/api.yml#/components/schemas/nullTime
+          description: >
+            Timestamp when the user joined the team. Server-computed from the
+            earliest matching row in `users_teams_mapping` for this
+            (team, user) pair. Server-managed; clients cannot set this.
+          x-oapi-codegen-extra-tags:
+            db: joined_at
+            json: joinedAt
 
     TeamMembersPage:
       type: object

--- a/schemas/constructs/v1beta3/design/api.yml
+++ b/schemas/constructs/v1beta3/design/api.yml
@@ -866,6 +866,74 @@ components:
         visibility:
           $ref: "../../v1beta2/core/api.yml#/components/schemas/Text"
           description: Visibility scope (private, public, published).
+        designType:
+          type: string
+          description: >
+            Discriminator identifying the source format of the design body.
+            Projected server-side (not stored in a column of its own); for
+            catalog listings the server derives it from the attached catalog
+            metadata, for user-owned designs the server derives it from the
+            import source. Use this field to branch rendering between native
+            Meshery designs and imported Helm charts, Kubernetes manifests,
+            and Docker Compose files.
+          x-enum-casing-exempt: true
+          enum:
+            - Design
+            - Helm Chart
+            - Docker Compose
+            - Kubernetes Manifest
+          maxLength: 64
+        viewCount:
+          type: integer
+          description: >
+            Server-aggregated count of views on this design in the catalog.
+            Present on list/catalog responses; server-managed and ignored on
+            writes.
+          minimum: 0
+          default: 0
+          x-oapi-codegen-extra-tags:
+            db: view_count
+            json: "viewCount,omitempty"
+        downloadCount:
+          type: integer
+          description: >
+            Server-aggregated count of downloads of this design from the
+            catalog. Server-managed and ignored on writes.
+          minimum: 0
+          default: 0
+          x-oapi-codegen-extra-tags:
+            db: download_count
+            json: "downloadCount,omitempty"
+        cloneCount:
+          type: integer
+          description: >
+            Server-aggregated count of times this design has been cloned from
+            the catalog. Server-managed and ignored on writes.
+          minimum: 0
+          default: 0
+          x-oapi-codegen-extra-tags:
+            db: clone_count
+            json: "cloneCount,omitempty"
+        deploymentCount:
+          type: integer
+          description: >
+            Server-aggregated count of deployments originated from this
+            design. Server-managed and ignored on writes.
+          minimum: 0
+          default: 0
+          x-oapi-codegen-extra-tags:
+            db: deployment_count
+            json: "deploymentCount,omitempty"
+        shareCount:
+          type: integer
+          description: >
+            Server-aggregated count of share events for this design.
+            Server-managed and ignored on writes.
+          minimum: 0
+          default: 0
+          x-oapi-codegen-extra-tags:
+            db: share_count
+            json: "shareCount,omitempty"
         createdAt:
           $ref: "../../v1beta2/core/api.yml#/components/schemas/Time"
           description: Timestamp of design creation.


### PR DESCRIPTION
## Summary

Closes meshery/schemas#832.

Add canonical camelCase coverage for the 10 wire keys deferred by Sistent Phase 2.K to `Team v1beta2`, `Schedule v1beta2`, and `Design v1beta3`. After this lands, Sistent and the other typed consumers can flip those keys to camelCase without diverging from the canonical schema.

The 10th key (`team_name`) turned out to be a display-only alias; the disposition table below explains. So the PR adds 9 new canonical properties and explicitly documents the `team_name` rejection.

## Per-key disposition

| camelCase | Owning resource | DB column | Disposition |
|---|---|---|---|
| `teamName` | Team v1beta2 | (n/a) | **Alias of existing `Team.name` — not added.** The only occurrence of `team_name` in meshery-cloud is inside the team-update email template (`server/handlers/smtp.go`) as a local field name on a struct that is never serialised onto the wire. Consumers must read this as `.name`. |
| `joinedAt` | TeamMember (v1beta2 team) | `joined_at` | Added to `TeamMember` as a nullable server-computed timestamp. Projected by `/api/identity/teams/{teamId}/users` from `MIN(utm.created_at)` on `users_teams_mapping`. |
| `lastRun` | Schedule v1beta2 | `last_run` | Added to `Schedule` entity (response-only; explicitly absent from `SchedulePayload`). |
| `nextRun` | Schedule v1beta2 | `next_run` | Same treatment as `lastRun`. |
| `designType` | MesheryPattern (v1beta3 design) | (server-projected) | Added as a server-projected discriminator with enum `Design` / `Helm Chart` / `Docker Compose` / `Kubernetes Manifest` (the existing `DesignType` values published by meshery-cloud — annotated `x-enum-casing-exempt: true` because those values are already live). No `db:` tag: the UI has been synthesising this from `catalogData.type` / the import source; this PR makes that contract explicit on the wire. |
| `viewCount` | MesheryPattern | `view_count` | Added to `MesheryPattern` with `db:"view_count"` + `json:"viewCount,omitempty"`. |
| `downloadCount` | MesheryPattern | `download_count` | Same. |
| `cloneCount` | MesheryPattern | `clone_count` | Same. |
| `deploymentCount` | MesheryPattern | `deployment_count` | Same. |
| `shareCount` | MesheryPattern | `share_count` | Same. |

The catalog counts all land on `MesheryPattern` directly (not a nested `CatalogMetrics` sub-object) because the existing meshery-cloud `MesheryPattern` Go struct surfaces them flat — embedding matches the payload clients see.

## Scope discipline on `TeamMember`

`TeamMember` was typed `additionalProperties: true` with no declared properties. The full canonicalisation of the user projection (`id`, `firstName`, `lastName`, `email`, `avatarUrl`) will land when the `user` construct migrates to the canonical-casing contract; this PR adds only `joinedAt` — the key the Phase 2.K deferral list names — and leaves the rest flowing through `additionalProperties`. The expanded `TeamMember` description documents the migration path.

An earlier draft inlined all five user fields alongside `joinedAt`. The combination of `additionalProperties: true` and an `id` property that `$ref`s a core UUID with `x-go-name: ID` tripped a known oapi-codegen interaction — the generator's Marshal/Unmarshal bodies reference `a.Id` while the field gets renamed to `ID` by the post-processor (`build/generate-golang.js` line 454). Rather than carry a fragile full canonicalisation here, this PR stays scoped to the charter field. The wider `TeamMember` canonicalisation will come when the user construct version-bumps.

## Downstream cascade this unblocks

Per meshery/schemas#832 and the [identifier-naming migration plan](../blob/master/docs/identifier-naming-migration.md):

1. **Sistent** can now flip the 10 deferred keys to camelCase.
2. **meshery-cloud / meshery** server-side can land dual-accept for one release cycle (Phase 2 tail pattern).
3. **consumer-audit** will begin flagging snake_case uses of these keys across downstream repos once Sistent catches up.

Publication of the `@meshery/schemas` npm package and the downstream repoint PRs are tracked as follow-on work — not in this PR.

## Out-of-scope findings

While investigating `team_name`, I confirmed that meshery-cloud's email templating (`smtp.go:415-430`, `smtp.go:477-490`) uses `TeamName` as a local struct field on an ephemeral template-vars struct. Since that struct is never JSON-marshalled onto the wire, no schema coverage is required. Flagging here so reviewers don't spend time re-deriving it.

## Test plan

- [x] `make validate-schemas` — clean, no blocking violations.
- [x] `make build` — green (Go + TS regen + RTK clients). Pre-existing `TestConsumerTS_IntegrationAgainstMesheryExtensions` failure is unrelated (Sistent PR #1431 already flipped `orgID` → `orgId` in the meshery-extensions sibling checkout; the test expectation is stale on master too — verified by rerun on clean master).
- [x] `make audit-schemas` — finding count unchanged at 255 (no new advisory-baseline violations introduced).
- [x] `go build ./...` — clean.
- [x] `npm run build` — clean (tsup CJS + ESM + DTS).
- [x] Spot-checked generated artefacts:
  - `models/v1beta2/team/team.go`: `TeamMember.JoinedAt core.NullTime` with `db:"joined_at" json:"joinedAt"` — correct.
  - `models/v1beta2/schedule/schedule.go`: `LastRun` / `NextRun` fields with `db:"last_run"` / `db:"next_run"` and `json:"lastRun"` / `json:"nextRun"`.
  - `models/v1beta3/design/design.go`: `DesignType *MesheryPatternDesignType`, five `*int` count fields with `db:"*_count"` + `json:"*Count,omitempty"`.
  - `typescript/generated/v1beta2/schedule/Schedule.ts`: `lastRun?: string` / `nextRun?: string` present.

No template edits were required: Schedule has no entity YAML / template dir, `MesheryPattern` is defined inside `design/api.yml` (the existing `templates/design_template.json` is for the inner `PatternFile` schema), and the `Team` template already represents the entity shape (new `TeamMember.joinedAt` lives on a separate schema used by the list-users-in-team endpoint).

## Follow-on work

Tracked under meshery/schemas#832:

- [ ] Publish `@meshery/schemas` minor.
- [ ] Sistent PR: flip the 10 deferred keys.
- [ ] Server-side dual-accept in `meshery-cloud` / `meshery`.