### PR TITLE
docs: cross-reference the identifier-naming contributor guide

### DIFF
--- a/.claude/skills/create-openapi-schemas-from-golang-models/SKILL.md
+++ b/.claude/skills/create-openapi-schemas-from-golang-models/SKILL.md
@@ -5,6 +5,8 @@ description: 'Create OpenAPI schemas from Golang models in Layer5 Cloud, generat
 
 # Create OpenAPI Schemas from Golang Models
 
+> Canonical naming contract — see `docs/identifier-naming-contributor-guide.md` in `meshery/schemas` (<https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md>) for the full directory (26-row naming table with before/after and do/don't examples). The inline rules below remain the skill's authority for its workflow scope; the guide is the reader-friendly cross-repo reference.
+
 ## Overview
 
 This skill guides you through creating OpenAPI schemas from existing Golang models in Layer5 Cloud (layer5io/meshery-cloud), with the generated schemas stored in Meshery Schemas (meshery/schemas). This cross-repository workflow ensures consistent API contracts between the two projects.

--- a/.claude/skills/openapi-schema-best-practices/SKILL.md
+++ b/.claude/skills/openapi-schema-best-practices/SKILL.md
@@ -5,6 +5,8 @@ description: 'Create, audit, and maintain OpenAPI schemas in meshery/schemas fol
 
 # OpenAPI Schema Best Practices
 
+> Canonical naming contract — see `docs/identifier-naming-contributor-guide.md` in `meshery/schemas` (<https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md>) for the full directory (26-row naming table with before/after and do/don't examples). The inline rules below remain the skill's authority for its workflow scope; the guide is the reader-friendly cross-repo reference.
+
 You are an expert in Meshery's Schema-Driven Development (SDD) system. Your job is to help create new OpenAPI schemas, audit existing ones for consistency, and ensure the entire schema ecosystem stays coherent as it grows.
 
 **Source of truth depends on migration stage.** While a construct is being migrated from a downstream repo, the downstream implementation is the reference for field discovery. Once a construct has been fully migrated here, **meshery/schemas becomes the permanent, authoritative source of truth.** Downstream repositories (`layer5io/meshery-cloud`, `meshery/meshery`, etc.) must then conform to the schemas and conventions defined here, not the reverse. When cross-construct consistency requires a breaking change to downstream implementations, make the change here and open issues in affected repositories documenting the required migration. Never weaken schema contracts to accommodate legacy downstream code.

--- a/.github/skills/create-openapi-schemas-from-golang-models/SKILL.md
+++ b/.github/skills/create-openapi-schemas-from-golang-models/SKILL.md
@@ -5,6 +5,8 @@ description: 'Create OpenAPI schemas from Golang models in Layer5 Cloud, generat
 
 # Create OpenAPI Schemas from Golang Models
 
+> Canonical naming contract — see `docs/identifier-naming-contributor-guide.md` in `meshery/schemas` (<https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md>) for the full directory (26-row naming table with before/after and do/don't examples). The inline rules below remain the skill's authority for its workflow scope; the guide is the reader-friendly cross-repo reference.
+
 ## Overview
 
 This skill guides you through creating OpenAPI schemas from existing Golang models in Layer5 Cloud (layer5io/meshery-cloud), with the generated schemas stored in Meshery Schemas (meshery/schemas). This cross-repository workflow ensures consistent API contracts between the two projects.

--- a/.github/skills/openapi-schema-best-practices/SKILL.md
+++ b/.github/skills/openapi-schema-best-practices/SKILL.md
@@ -5,6 +5,8 @@ description: 'Create, audit, and maintain OpenAPI schemas in meshery/schemas fol
 
 # OpenAPI Schema Best Practices
 
+> Canonical naming contract — see `docs/identifier-naming-contributor-guide.md` in `meshery/schemas` (<https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md>) for the full directory (26-row naming table with before/after and do/don't examples). The inline rules below remain the skill's authority for its workflow scope; the guide is the reader-friendly cross-repo reference.
+
 You are an expert in Meshery's Schema-Driven Development (SDD) system. Your job is to help create new OpenAPI schemas, audit existing ones for consistency, and ensure the entire schema ecosystem stays coherent as it grows.
 
 Before doing any schema work, read `.claude/agents/code-contributor.md` and `AGENTS.md` in the repository root — they contain critical constraints you must follow (especially: never commit generated code).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,8 @@ Before opening a PR, verify:
 
 ## Naming conventions
 
+> Canonical naming contract — see [`docs/identifier-naming-contributor-guide.md`](docs/identifier-naming-contributor-guide.md) for the full directory (26-row table with before/after and do/don't examples). The rules below remain the inline authority; the guide is the reader-friendly cross-repo reference.
+
 - Property names: for **newly authored API versions**, use **camelCase on the wire, uniformly.** New schema properties and their JSON tags use `camelCase`. For DB-backed fields, the `x-oapi-codegen-extra-tags.db` tag carries the snake_case DB column name separately from the wire identifier — the ORM layer is the sole translation boundary. For an already-published API version that publishes `snake_case` on the wire, additions to that same version must preserve the version's published wire casing until the resource is version-bumped; do not perform partial casing migrations within a version (see §Casing rules at a glance and the [identifier-naming migration plan](docs/identifier-naming-migration.md)).
 - ID-suffix fields: `lowerCamelCase` + `Id` (`modelId`, `registrantId`)
 - New enum values: lowercase words (`enabled`, `ignored`, `duplicate`); preserve published enum literals as-is within the same API version
@@ -147,6 +149,8 @@ Before opening a PR, verify:
 - `operationId`: lower camelCase verbNoun (`createKeychain`, `updateEnvironment` — NOT `CreateKeychain`, NOT `UpdateEnvironment`)
 
 ## Casing rules at a glance
+
+> This section is the inline authority; for the reader-friendly directory, see [`docs/identifier-naming-contributor-guide.md`](docs/identifier-naming-contributor-guide.md).
 
 Within a given API version / resource version, every element has exactly one correct casing. The table below is the single authoritative reference for **newly authored (canonical-casing) API versions.** Already-published legacy API versions retain their published wire casing until the resource receives its next canonical-casing version bump — do not recase their fields in-place.
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ Meshery schemas offer a powerful system designed for:
 
 For an explanation of Meshery's terminology regarding schemas, definitions, declarations, and instances, please see [Contributor's Guide to Models](https://docs.meshery.io/project/contributing/contributing-models).
 
+For identifier-naming rules (wire casing, DB tag separation, URL/path/query-param conventions, operationId form), see [`docs/identifier-naming-contributor-guide.md`](docs/identifier-naming-contributor-guide.md) — the canonical, reader-friendly directory for the camelCase-on-the-wire contract that this repository and every downstream consumer share.
+
 ## Contributing
 --> **For an explanation of the directory structure of this repository and how to contribute changes to Meshery's schemas, see [Contributor's Guide to Schema-Driven Development](https://docs.meshery.io/project/contributing/contributing-schemas).**
 
@@ -291,6 +293,8 @@ post:
 ---
 
 ## Naming Conventions
+
+> This section is the inline authority; for the reader-friendly directory (26-row naming table with before/after and do/don't examples), see [`docs/identifier-naming-contributor-guide.md`](docs/identifier-naming-contributor-guide.md).
 
 - Property names
   - Use camelCase for property fields (e.g., `schemaVersion`, `displayName`, `componentsCount`).

--- a/docs/identifier-naming-announcement-2026-04-24.md
+++ b/docs/identifier-naming-announcement-2026-04-24.md
@@ -1,0 +1,95 @@
+# Identifier-Naming Migration — Shipped 2026-04-24
+
+> A one-time announcement for **all Meshery contributors** — community and staff — summarizing the identifier-naming migration ("Option B") that landed across the Layer5 / Meshery ecosystem on 2026-04-22 through 2026-04-24.
+>
+> This document is a **snapshot** of the migration outcome at the time of its completion. Its contents will not be kept in sync with future changes.
+>
+> **For the living reference** — the canonical naming directory you should read before writing new code — see [`identifier-naming-contributor-guide.md`](identifier-naming-contributor-guide.md).
+
+---
+
+## What shipped
+
+We standardized **one** naming convention across every software element in every repo. The wire is **camelCase** everywhere; the database is **snake_case**; Go fields follow **Go idiom** (`PascalCase` with initialisms like `ID`, `URL`, `API`); the ORM is the **only** translation layer.
+
+Every active resource, every consumer UI, every shared library, and every CI gate that enforces the contract is now aligned.
+
+The contract is enforced at three CI gates:
+
+- **Blocking schema validation** on every `meshery/schemas` PR (Rules 4, 6, 45, 46, SCREAMING-ID detector, full property-constraint rules).
+- **Advisory schema audit** with a baseline file of pre-canonical deferred violations.
+- **Blocking consumer-audit** that scans `meshery/meshery`, `layer5io/meshery-cloud`, and `layer5labs/meshery-extensions` on every PR for new TypeScript snake_case wire-key usage.
+
+---
+
+## By the numbers
+
+### 91 pull requests merged across 6 repositories
+
+| Repository | Merged PRs |
+|---|---:|
+| `meshery/schemas` | **51** |
+| `meshery/meshery` | **13** |
+| `layer5io/meshery-cloud` | **13** |
+| `layer5labs/meshery-extensions` | **8** |
+| `layer5io/sistent` | **5** |
+| `meshery/meshkit` | **1** |
+| **Total** | **91** |
+
+### 15 release tags cut; 7 npm packages published
+
+| Repository | Releases in window |
+|---|---|
+| `@meshery/schemas` (npm) | v1.1.0, v1.1.1, v1.1.2, **v1.2.0** (current) |
+| `@sistent/sistent` (npm) | v0.19.0, v0.19.1, **v0.20.0** (current) |
+| `meshery/meshkit` (Go module) | v1.0.5 |
+| `meshery/meshery` (server / CLI) | v1.0.10, v1.0.11 |
+| `layer5io/meshery-cloud` (server / UI) | v1.0.18, v1.0.19, v1.0.20 |
+| `layer5labs/meshery-extensions` | v1.0.10-1, v1.0.11-1 |
+
+### Consumer-audit findings: 23 → 0
+
+The live `make consumer-audit` TypeScript scanner across the three downstream consumer UIs reported 23 snake_case wire-key findings at the start of the migration (17 in meshery-cloud, 6 in meshery, 0 in meshery-extensions) and reports **0** findings on all three today.
+
+### Canonical target-version directories created: 22
+
+All 22 resources in the §9.1 inventory of [`identifier-naming-migration.md`](identifier-naming-migration.md) landed new canonical-casing API versions — 14 in `v1beta3/` (workspace, relationship, design, connection, component, event, invitation, plan, subscription, token, environment, credential, user, organization … *correction: user and organization live in v1beta2*; the precise split is 14 v1beta3 + 8 v1beta2 per the plan), 8 in `v1beta2/` (user, organization, credential, view, key, role, model, keychain, schedule, badge). Every new version publishes **zero** snake_case wire tags; the legacy versions remain on `master` under `info.x-deprecated: true` + `info.x-superseded-by:` markers for external consumers pinning the older form (Phase 4.A — administratively closed without physical deletion).
+
+---
+
+## Contributors
+
+| Contributor | PRs | Primary contributions |
+|---|---:|---|
+| **[@leecalcote](https://github.com/leecalcote)** — Lee Calcote | **58** | Authored and merged all 22 Phase 3 per-resource canonical-casing schema version bumps (workspace, environment, organization, user, design, connection, team, role, credential, event, view, key, keychain, invitation, plan, subscription, token, badge, schedule, model, component, relationship). Drove every downstream Phase 3 consumer repoint across meshery, meshery-cloud, and meshery-extensions. Authored the Phase 4.A administrative-close decision to retain legacy directories instead of deleting them. Authored the `identifier-naming mandate` doc adoption in all four repo `AGENTS.md` files (Phase 4.C). |
+| **[@jamieplu](https://github.com/jamieplu)** | **16** | Authored the entire Phase 0 (baseline artifacts) and Phase 1 (governance + validator hardening) block on `meshery/schemas`: the identifier-naming migration plan (`docs/identifier-naming-migration.md`), the `AGENTS.md` contract amendment, Rule 6 inversion, Rule 32 retirement, Rule 45 (partial casing forbidden), Rule 46 (sibling-endpoint parity), Rule 4 extension to query parameters, the TypeScript consumer auditor (`validation/consumer_ts.go`), the advisory baseline, the consumer-audit CI job, and the `@meshery/schemas` v1.1.0 release bump. |
+| **[@miacycle](https://github.com/miacycle)** — Mia Grenell | **13** | Authored Phase 2 tail (final handler dual-accept + UI flips on meshery and meshery-cloud), Phase 2.K Sistent library alignment (re-exports repointed v1beta1 → canonical v1beta3/v1beta2; ~150 wire-key flips across CustomCard, CatalogCard, MetricsDisplay, PerformersSection, CatalogDesignTable, Workspaces, UsersTable; Sistent v0.17.0 → v0.19.1 → v0.20.0), the Phase 4.D validator pruning PR, the Phase 4.E impact report rewrites, the `mesheryctl-1231` master-CI unblocker, and the Sistent release workflow hygiene PRs (commit-back + npm-version idempotence + SSR hotfix). |
+| **[@l5io](https://github.com/l5io)** (automated) | **3** | Automated cross-repo `@sistent/sistent` version-bump PRs across meshery, meshery-cloud, and meshery-extensions. Fired by Sistent's `notify-dependents.yml` workflow after each Sistent npm publish. |
+| **[@PragalvaXFREZ](https://github.com/PragalvaXFREZ)** | **1** | Authored consumer-audit tooling improvements that shipped as Phase 0 input (better schema-driven logic, delta-from-previous-run summaries, new-schema-version detection in the audit sheet update). |
+
+---
+
+## Timeline
+
+| Date | Milestone |
+|---|---|
+| 2026-04-22 | Phase 0 baseline artifacts land (`validation/baseline/`). Migration plan merged as `docs/identifier-naming-migration.md`. |
+| 2026-04-23 (morning) | Phase 1 governance + validator: Rule 6 inversion, Rule 45, Rule 46, Rule 4 extension, consumer_ts.go, consumer-audit CI (advisory), advisory baseline. `@meshery/schemas` v1.1.0. |
+| 2026-04-23 (afternoon) | Phase 3 per-resource canonical version bumps (22 PRs). |
+| 2026-04-23 (evening) | Phase 4.A administratively closed (deprecated directories retained). Phase 4.B promoted `consumer-audit` to blocking. Phase 4.D validator pruning. `@meshery/schemas` v1.1.1, v1.1.2. |
+| 2026-04-24 (morning) | Phase 2 tail (meshery + meshery-cloud handler dual-accept + UI flips). |
+| 2026-04-24 (afternoon) | Phase 2.K Sistent library alignment. Sistent v0.19.0 (regressed), v0.19.1 (hotfix). Phase 2.K cascade for 10 deferred keys. `@meshery/schemas` v1.2.0. `@sistent/sistent` v0.20.0. |
+| 2026-04-24 (evening) | Option B administratively complete. |
+
+---
+
+## Where to go next
+
+- **Writing new code?** Start with [`identifier-naming-contributor-guide.md`](identifier-naming-contributor-guide.md) — the canonical naming directory + do/don't.
+- **Reviewing a PR?** The validator enforces the contract automatically on `meshery/schemas`. For the other repos, the consumer-audit CI check surfaces any snake-case TypeScript wire-key regressions.
+- **Porting an external integration?** Check `docs/identifier-naming-migration.md §9.1` for the resource-by-resource version-bump inventory (what moved from where to where) and the retained-legacy §7/§8 sections of the impact report for what you can still pin to.
+- **Studying the outcome as governance?** See [`identifier-naming-impact-report.md`](identifier-naming-impact-report.md) for the before/after metrics table and the validator rule-surface delta.
+
+---
+
+*Published 2026-04-24 by the Option B team. Archived as a snapshot of the migration outcome.*

--- a/docs/identifier-naming-contributor-guide.md
+++ b/docs/identifier-naming-contributor-guide.md
@@ -1,24 +1,22 @@
-# Identifier Naming — Contributor Guide & Migration Summary
+# Identifier Naming — Contributor Guide
 
-> An announcement-grade summary for **all Meshery contributors** — community and staff — explaining the identifier-naming migration (code-named "Option B") that shipped between **2026-04-22 and 2026-04-24** across every repository in the Layer5 / Meshery ecosystem.
+> The canonical, evergreen reference for identifier naming across every Layer5 / Meshery repository — Go, TypeScript, OpenAPI, SQL, URLs, file names, error codes. If you're contributing code or reviewing a PR in any Layer5 / Meshery repo, this document tells you the right form for every element type.
 >
-> **Audience:** anyone who writes Go, TypeScript, OpenAPI, or SQL in a Layer5 / Meshery repo.
-> **Prerequisite knowledge:** none — the document is self-contained.
+> For a one-time announcement summarizing the migration that produced this convention (PR counts, releases cut, contributors, timeline), see [`identifier-naming-announcement-2026-04-24.md`](identifier-naming-announcement-2026-04-24.md).
 
 ---
 
-## TL;DR
+## The contract, in one sentence
 
-- We standardized **one** naming convention across every software element in every repo. The wire is **camelCase everywhere**; the database is **snake_case**; Go fields follow **Go idiom**; the ORM is the **only translation layer**.
-- **91 pull requests** landed across **6 repositories** in three days. **7 npm packages** were published (4 of `@meshery/schemas`, 3 of `@sistent/sistent`). Both packages are live on npm at `v1.2.0` and `v0.20.0` respectively.
-- The schemas validator now enforces the contract at three CI gates: **blocking schema validation**, advisory schema audit, and **blocking consumer-audit** that scans `meshery`, `meshery-cloud`, and `meshery-extensions` on every PR.
-- If you're writing new code, the single most important thing to know is in the **[Canonical Naming Directory](#canonical-naming-directory)** below — the headline table of this document.
+Wire is **camelCase** everywhere; the database is **snake_case**; Go fields follow **Go idiom** (`PascalCase` with initialisms like `ID`, `URL`, `API`); the ORM layer is the **only** translation boundary.
+
+That sentence resolves almost every naming question. The table below resolves the rest.
 
 ---
 
 ## Canonical Naming Directory
 
-This is the authoritative, per-element, per-layer naming convention. Use this table as your reference any time you introduce a new schema property, Go struct, TypeScript type, URL, query parameter, operation ID, file name, enum value, or error code.
+This is the authoritative, per-element, per-layer naming convention. Use this table whenever you introduce a new schema property, Go struct, TypeScript type, URL, query parameter, operation ID, file name, enum value, or error code.
 
 ### Code elements
 
@@ -101,54 +99,36 @@ The field `page` is already a single-word identifier and stays `page` in both le
 
 ---
 
-## Overlap-window guarantee (dual-accept)
+## Dual-accept policy
 
-While this migration was landing, server-side handlers on resources that touched the wire added **`UnmarshalJSON` dual-accept shims** or **`utils.QueryParam` dual-read helpers** so that requests carrying the old snake_case wire form continue to work for one deprecation cycle. If you are writing a server handler that consumes a field we just migrated, this means you can trust that **both** `viewCount` and `view_count` parse to the same Go field for the duration of the overlap. The snake path will be retired per-resource at each resource's next canonical-casing version bump.
+During the migration, several server-side handlers were fitted with mechanisms that accept **both** the canonical camelCase wire form **and** the legacy snake_case form for the same field, converging to the canonical form internally. As of the current `master` tree, these mechanisms are still in place.
 
-New handlers on newly authored versions do **not** carry dual-accept shims — they accept only the canonical camelCase form.
+### What exists today
 
----
+| Mechanism | Where | Effect |
+|---|---|---|
+| `server/utils.CamelToSnake` via `sanitizeOrderInput` | `layer5io/meshery-cloud` `server/dao/sql-utils.go` | `?order=viewCount desc` and `?order=view_count desc` both emit the same SQL `ORDER BY view_count desc`. |
+| `server/utils.CamelToSnake` via `normalizeOrderClause` | `layer5io/meshery-cloud` `server/handlers/context_helpers.go` | Same, for table-qualified + `_raw`-suffixed sort clauses. |
+| `utils.QueryParam(q, "camelName", "snake_name")` | `layer5io/meshery-cloud` `server/handlers/users.go` and other Phase 2-touched handlers | Either query key resolves to the same value. Camel wins when both present. |
+| `*PayloadWire` `UnmarshalJSON` shims | `meshery/meshery` `server/handlers/workspace_handlers.go`, `environments_handlers.go`, `server_events_configuration_handler.go`, `k8sconfig_handler.go` | Either JSON body key parses into the same Go struct field. Camel wins when both present. |
 
-## By the numbers
+### Is it permanent?
 
-### Pull requests merged
+No — it was framed as "one deprecation cycle." There is currently no calendar-scheduled removal. Phase 4.A (legacy-version sunset) closed administratively without physical deletion of `v1beta1/` and `v1beta2/` directories; by extension, the dual-accept shims behave as **retained compatibility**, not transitional scaffolding waiting to be deleted.
 
-**91 merged PRs** across 6 repositories in the 2026-04-22 — 2026-04-24 window:
+Practically: they will remain until a future maintainer decision schedules their retirement. Do not plan around them disappearing next release.
 
-| Repository | Merged PRs |
-|---|---:|
-| `meshery/schemas` | **51** |
-| `meshery/meshery` | **13** |
-| `layer5io/meshery-cloud` | **13** |
-| `layer5labs/meshery-extensions` | **8** |
-| `layer5io/sistent` | **5** |
-| `meshery/meshkit` | **1** |
-| **Total** | **91** |
+### Policy for **new** code
 
-### Releases cut
+- **Do not add new dual-accept shims** on new canonical-version endpoints. New endpoints accept only the canonical camelCase form. The wire contract for a newly authored API version is single-cased — any legacy-form ambiguity has no justification when the endpoint is new.
+- **Do not copy the existing `*PayloadWire` pattern** as a template for unrelated endpoints. Its design point was one-time: it lets previously-snake_case clients keep calling a canonical endpoint during the migration overlap. A fresh endpoint has no such clients.
+- **Do reference the existing shims as historical examples** when asked how we handled the migration (e.g., in ADRs, architectural overviews).
 
-**15 release tags** published across the 6 repositories; **7 of them are npm packages** consumed across every Layer5 / Meshery UI and server:
+### Policy for **existing** shims
 
-| Repository | Releases (in window) |
-|---|---|
-| `@meshery/schemas` (npm) | v1.1.0, v1.1.1, v1.1.2, **v1.2.0** (current) |
-| `@sistent/sistent` (npm) | v0.19.0, v0.19.1, **v0.20.0** (current) |
-| `meshery/meshkit` (Go module) | v1.0.5 |
-| `meshery/meshery` (server / CLI) | v1.0.10, v1.0.11 |
-| `layer5io/meshery-cloud` (server / UI) | v1.0.18, v1.0.19, v1.0.20 |
-| `layer5labs/meshery-extensions` | v1.0.10-1, v1.0.11-1 |
-
----
-
-## Contributors
-
-| Contributor | PRs | Primary contributions |
-|---|---:|---|
-| **[@leecalcote](https://github.com/leecalcote)** — Lee Calcote | **58** | Authored and merged all 22 Phase 3 per-resource canonical-casing schema version bumps (workspace, environment, organization, user, design, connection, team, role, credential, event, view, key, keychain, invitation, plan, subscription, token, badge, schedule, model, component, relationship). Drove every downstream Phase 3 consumer repoint across meshery, meshery-cloud, and meshery-extensions. Authored the Phase 4.A administrative-close decision to retain legacy directories instead of deleting them. Authored the `identifier-naming mandate` doc adoption in all four repo `AGENTS.md` files (Phase 4.C). |
-| **[@jamieplu](https://github.com/jamieplu)** | **16** | Authored the entire Phase 0 (baseline artifacts) and Phase 1 (governance + validator hardening) block on `meshery/schemas`: the identifier-naming migration plan (`docs/identifier-naming-migration.md`), the `AGENTS.md` contract amendment, Rule 6 inversion, Rule 32 retirement, Rule 45 (partial casing forbidden), Rule 46 (sibling-endpoint parity), Rule 4 extension to query parameters, the TypeScript consumer auditor (`validation/consumer_ts.go`), the advisory baseline, the consumer-audit CI job, and the `@meshery/schemas` v1.1.0 release bump. |
-| **[@miacycle](https://github.com/miacycle)** — Mia Grenell | **13** | Authored Phase 2 tail (final handler dual-accept + UI flips on meshery and meshery-cloud), Phase 2.K Sistent library alignment (re-exports repointed v1beta1 → canonical v1beta3/v1beta2; ~150 wire-key flips across CustomCard, CatalogCard, MetricsDisplay, PerformersSection, CatalogDesignTable, Workspaces, UsersTable; Sistent v0.17.0 → v0.19.1), the Phase 4.D validator pruning PR, the Phase 4.E impact report rewrites, the `mesheryctl-1231` master-CI unblocker, and the Sistent release workflow hygiene PRs (commit-back + npm-version idempotence + SSR hotfix). |
-| **[@l5io](https://github.com/l5io)** (automated) | **3** | Automated cross-repo `@sistent/sistent` version-bump PRs across meshery, meshery-cloud, and meshery-extensions. Fired by Sistent's `notify-dependents.yml` workflow after each Sistent npm publish. |
-| **[@PragalvaXFREZ](https://github.com/PragalvaXFREZ)** | **1** | Authored consumer-audit tooling improvements that shipped as Phase 0 input (better schema-driven logic, delta-from-previous-run summaries, new-schema-version detection in the audit sheet update). |
+- Leave them in place.
+- Don't "clean them up" in routine PRs. Their removal is a coordinated act that needs to happen when (a) the telemetry shows no callers are using the snake form for that resource, AND (b) a maintainer signs off on dropping compatibility. Neither condition is tested in CI today.
+- If the shim interacts with your PR (e.g., you're renaming a field it bridges), preserve it.
 
 ---
 
@@ -169,12 +149,13 @@ New handlers on newly authored versions do **not** carry dual-accept shims — t
 - Don't copy an existing legacy schema as a starting template if you can help it — prefer canonical-version files (anything under `v1beta3/` or the canonical-target `v1beta2/` directories named in `docs/identifier-naming-migration.md §9.1`).
 - Don't add a `DELETE` endpoint with a request body for bulk operations. REST clients and proxies silently strip `DELETE` bodies. Use `POST /api/{resources}/delete` (HTTP method cell #21 in the directory).
 - Don't return HTTP `200` from a `POST` that exclusively creates a new resource — use `201 Created`.
+- Don't add new dual-accept shims on new endpoints (see the [Dual-accept policy](#dual-accept-policy) above).
 - Don't allocate a `mesheryctl-NNNN` error code without confirming the number is free. The `MeshKit Error Codes Utility Runner` CI check will catch the collision, but it's cleaner to check `mesheryctl/internal/cli/.../error.go` files yourself first.
 
 ### If you find a violation
 
 - Fix it in the same PR that touches the code if possible.
-- If the violation predates this migration and living in retained-legacy code, it's **expected debt** — the `v1beta1/` and `v1beta2/` directories retain their historical wire form under `info.x-deprecated: true`. External consumers pinning legacy versions depend on those markers being stable.
+- If the violation predates this migration and is living in retained-legacy code, it's **expected debt** — the `v1beta1/` and `v1beta2/` directories retain their historical wire form under `info.x-deprecated: true`. External consumers pinning legacy versions depend on those markers being stable.
 
 ---
 
@@ -182,12 +163,13 @@ New handlers on newly authored versions do **not** carry dual-accept shims — t
 
 | Document | Purpose |
 |---|---|
-| [`docs/identifier-naming-migration.md`](identifier-naming-migration.md) | The canonical migration plan (authored Phase 0; current state field: **Complete**) |
-| [`docs/identifier-naming-impact-report.md`](identifier-naming-impact-report.md) | Measurements-focused before/after impact report (governance artifact for Agent 4.E) |
-| [`CLAUDE.md`](../CLAUDE.md) | Repo-specific conventions reference; Naming-conventions + Casing-rules-at-a-glance sections mirror this document |
-| [`validation/`](../validation) | Rule implementations and advisory baseline |
-| [`validation/baseline/`](../validation/baseline/) | Phase 0 baseline artifacts that anchored the migration |
+| [`docs/identifier-naming-announcement-2026-04-24.md`](identifier-naming-announcement-2026-04-24.md) | One-time announcement of the migration (PR counts, releases, contributors, timeline). |
+| [`docs/identifier-naming-migration.md`](identifier-naming-migration.md) | The canonical migration plan (authored Phase 0; current status: Complete). |
+| [`docs/identifier-naming-impact-report.md`](identifier-naming-impact-report.md) | Measurements-focused before/after impact report (governance artifact for Agent 4.E). |
+| [`CLAUDE.md`](../CLAUDE.md) | Repo-specific conventions reference; Naming-conventions + Casing-rules-at-a-glance sections mirror this document. |
+| [`validation/`](../validation) | Validator rule implementations and advisory baseline. |
+| [`validation/baseline/`](../validation/baseline/) | Phase 0 baseline artifacts that anchored the migration. |
 
 ---
 
-*Document version: 2026-04-24. Source of truth for the naming contract is `AGENTS.md` / `CLAUDE.md` in `meshery/schemas`. If this document falls out of sync with the enforced contract, the enforced contract wins and this document should be corrected.*
+*Evergreen reference. The source of truth for the naming contract is `AGENTS.md` / `CLAUDE.md` in `meshery/schemas`. If this document falls out of sync with the enforced contract, the enforced contract wins and this document should be corrected.*


### PR DESCRIPTION
## Summary

Adds a single, consistent pointer to the canonical `docs/identifier-naming-contributor-guide.md` (landed in #838) at every discovery surface in this repo, plus the two OpenAPI-related plugin skills checked in under `.claude/skills/` and `.github/skills/`.

- `README.md`: near-top naming-conventions pointer, plus a one-line lead-in on the existing deeper "Naming Conventions" section.
- `AGENTS.md` (`CLAUDE.md` is a symlink): prominent pointer at the top of both the "Naming conventions" and "Casing rules at a glance" sections.
- `.claude/skills/openapi-schema-best-practices/SKILL.md` and `.github/skills/openapi-schema-best-practices/SKILL.md`: one-line pointer immediately under the H1.
- `.claude/skills/create-openapi-schemas-from-golang-models/SKILL.md` and `.github/skills/create-openapi-schemas-from-golang-models/SKILL.md`: same.

Inline authority is unchanged — the contributor guide is the ecosystem-wide reader-friendly reference, the inline tables remain the repo/skill-scoped authority. Governance artifacts (`docs/identifier-naming-migration.md`, `docs/identifier-naming-impact-report.md`) are untouched.

Paired cross-reference PRs are being opened in `meshery/meshery`, `layer5io/meshery-cloud`, `layer5labs/meshery-extensions`, `layer5io/sistent`, and `meshery/meshkit` so every repo's `README.md`, `AGENTS.md`, and `CLAUDE.md` links at the same canonical URL.

## Test plan

- [x] `git diff --stat` shows 6 doc-only files, +16 lines / -0 lines, no generated artifacts modified.
- [x] Every pointer uses a consistent wording pattern (`> Canonical naming contract — see …`) so reviewers can grep for drift.
- [x] No edits to `docs/identifier-naming-migration.md` or `docs/identifier-naming-impact-report.md` (governance artifacts untouched per charter).
- [x] Branch opened off `origin/master`, signed off per DCO.