### PR TITLE
feat(filter): v1beta3 canonical-casing schema

### DIFF
--- a/schemas/constructs/v1beta3/design/api.yml
+++ b/schemas/constructs/v1beta3/design/api.yml
@@ -577,63 +577,6 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
-  /api/content/filters/{filterId}:
-    get:
-      x-internal: ["cloud"]
-      tags:
-        - designs
-      summary: Get filter by ID
-      operationId: getFilter
-      parameters:
-        - $ref: "#/components/parameters/filterId"
-      responses:
-        "200":
-          description: Filter
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/MesheryFilter"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
-
-  /api/content/filters/clone/{filterId}:
-    post:
-      x-internal: ["cloud"]
-      tags:
-        - designs
-      summary: Clone filter
-      operationId: cloneFilter
-      parameters:
-        - $ref: "#/components/parameters/filterId"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              additionalProperties: true
-      responses:
-        "200":
-          description: Cloned filter
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/MesheryFilter"
-        "400":
-          $ref: "#/components/responses/400"
-        "401":
-          $ref: "#/components/responses/401"
-        "404":
-          $ref: "#/components/responses/404"
-        "500":
-          $ref: "#/components/responses/500"
-
   /api/resource/{resourceType}/share/{resourceId}:
     post:
       x-internal: ["cloud"]
@@ -809,13 +752,6 @@ components:
       schema:
         type: string
         format: uuid
-    filterId:
-      name: filterId
-      in: path
-      description: Filter ID
-      required: true
-      schema:
-        $ref: "../../v1beta2/core/api.yml#/components/schemas/Uuid"
 
   schemas:
     DeletePatternModel:
@@ -1089,7 +1025,11 @@ components:
         filters:
           type: array
           items:
-            $ref: "#/components/schemas/MesheryFilter"
+            $ref: "../filter/api.yml#/components/schemas/MesheryFilter"
+            x-go-type: filterv1beta3.MesheryFilter
+            x-go-type-import:
+              path: github.com/meshery/schemas/models/v1beta3/filter
+              name: filterv1beta3
           description: Published filters included on this page.
         modelsCount:
           type: array
@@ -1141,10 +1081,6 @@ components:
           type: string
           description: Description of the catalogcontentclass.
           maxLength: 5000
-      additionalProperties: true
-
-    MesheryFilter:
-      type: object
       additionalProperties: true
 
     ResourceAccessMapping:

--- a/schemas/constructs/v1beta3/filter/api.yml
+++ b/schemas/constructs/v1beta3/filter/api.yml
@@ -1,0 +1,475 @@
+openapi: 3.0.0
+info:
+  title: Filter
+  description: |
+    OpenAPI schema for managing Meshery filters. Filters carry an
+    opaque body (`filterFile`) plus catalog and visibility metadata,
+    persisted by `meshery-cloud` in the `meshery_filters` table and
+    consumed locally by `meshery/server/models.MesheryFilter`.
+
+    The endpoint surface mirrors the live `meshery-cloud` Echo handlers
+    (`POST/GET /api/content/filters`,
+    `GET/DELETE /api/content/filters/{filterId}`,
+    `POST /api/content/filters/clone/{filterId}`,
+    `GET /api/content/filters/download/{filterId}`) plus the bulk-delete
+    sub-resource and the cross-construct content-share endpoint owned by
+    the design package.
+  version: v1beta3
+  contact:
+    name: Meshery Maintainers
+    email: maintainers@meshery.io
+    url: https://meshery.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+security:
+  - jwt: []
+tags:
+  - name: filters
+    description: Operations related to Meshery filters.
+
+paths:
+  /api/content/filters:
+    get:
+      x-internal: ["cloud"]
+      tags:
+        - filters
+      summary: Get filters
+      operationId: getFilters
+      description: Returns a paginated list of filters accessible to the user.
+      parameters:
+        - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
+        - $ref: "#/components/parameters/search"
+        - $ref: "#/components/parameters/order"
+        - $ref: "#/components/parameters/orgIdQuery"
+        - name: visibility
+          in: query
+          required: false
+          description: Filter by visibility (public, private, published). May be repeated.
+          schema:
+            type: array
+            items:
+              type: string
+        - name: userId
+          in: query
+          required: false
+          description: |
+            UUID of the owning user. Pass when fetching public/published
+            filters for a specific user (public-profile lookups).
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Filters response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MesheryFilterPage"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+    post:
+      x-internal: ["cloud"]
+      tags:
+        - filters
+      summary: Save filter
+      operationId: upsertFilter
+      description: Creates or updates a Meshery filter.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MesheryFilterRequestBody"
+      responses:
+        "200":
+          description: Filter saved
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MesheryFilter"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /api/content/filters/delete:
+    post:
+      x-internal: ["cloud"]
+      tags:
+        - filters
+      summary: Bulk delete filters
+      operationId: deleteFilters
+      description: |
+        Deletes multiple filters by ID. Modeled as a `POST .../delete`
+        sub-resource because REST clients and proxies may strip request
+        bodies on `DELETE`.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MesheryFilterDeleteRequestBody"
+      responses:
+        "200":
+          description: Filters deleted
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /api/content/filters/{filterId}:
+    get:
+      x-internal: ["cloud"]
+      tags:
+        - filters
+      summary: Get filter by ID
+      operationId: getFilter
+      parameters:
+        - $ref: "#/components/parameters/filterId"
+      responses:
+        "200":
+          description: Filter response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MesheryFilter"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+    put:
+      x-internal: ["cloud"]
+      tags:
+        - filters
+      summary: Update filter by ID
+      operationId: updateFilter
+      description: |
+        Updates the filter at the supplied ID with the provided payload.
+        Provided as a canonical-CRUD complement to the upsert `POST
+        /api/content/filters` form so consumers that prefer explicit
+        update semantics can address the resource directly.
+      parameters:
+        - $ref: "#/components/parameters/filterId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MesheryFilterPayload"
+      responses:
+        "200":
+          description: Filter updated
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MesheryFilter"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+    delete:
+      x-internal: ["cloud"]
+      tags:
+        - filters
+      summary: Delete filter by ID
+      operationId: deleteFilter
+      parameters:
+        - $ref: "#/components/parameters/filterId"
+      responses:
+        "204":
+          description: Filter deleted
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /api/content/filters/clone/{filterId}:
+    post:
+      x-internal: ["cloud"]
+      tags:
+        - filters
+      summary: Clone filter
+      operationId: cloneFilter
+      description: Creates a copy of an existing filter.
+      parameters:
+        - $ref: "#/components/parameters/filterId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MesheryFilterCloneRequestBody"
+      responses:
+        "200":
+          description: Filter cloned
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/MesheryFilter"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /api/content/filters/download/{filterId}:
+    get:
+      x-internal: ["cloud"]
+      tags:
+        - filters
+      summary: Download filter file
+      operationId: getFilterFile
+      description: |
+        Downloads the raw filter body associated with the supplied
+        filter ID. The server streams the bytes verbatim with
+        `Content-Type: application/wasm` and a
+        `Content-Disposition: attachment` header naming the filter.
+      parameters:
+        - $ref: "#/components/parameters/filterId"
+      responses:
+        "200":
+          description: Filter file content
+          content:
+            application/wasm:
+              schema:
+                type: string
+                format: binary
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
+components:
+  securitySchemes:
+    jwt:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  responses:
+    400:
+      $ref: "../../v1beta2/core/api.yml#/components/responses/400"
+    401:
+      $ref: "../../v1beta2/core/api.yml#/components/responses/401"
+    404:
+      $ref: "../../v1beta2/core/api.yml#/components/responses/404"
+    500:
+      $ref: "../../v1beta2/core/api.yml#/components/responses/500"
+
+  parameters:
+    filterId:
+      name: filterId
+      in: path
+      description: Filter ID
+      required: true
+      schema:
+        $ref: "../../v1beta2/core/api.yml#/components/schemas/Uuid"
+    page:
+      $ref: "../../v1beta2/core/api.yml#/components/parameters/page"
+    pageSize:
+      name: pageSize
+      in: query
+      description: Number of items per page (canonical camelCase form).
+      schema:
+        type: integer
+        minimum: 1
+    search:
+      $ref: "../../v1beta2/core/api.yml#/components/parameters/search"
+    order:
+      $ref: "../../v1beta2/core/api.yml#/components/parameters/order"
+    orgIdQuery:
+      name: orgId
+      in: query
+      description: User's organization ID
+      schema:
+        type: string
+        format: uuid
+
+  schemas:
+    MesheryFilter:
+      $ref: "./filter.yaml"
+
+    MesheryFilterPayload:
+      type: object
+      description: |
+        Payload for creating or updating a filter via
+        `POST /api/content/filters` or
+        `PUT /api/content/filters/{filterId}`. Contains only
+        client-settable fields; server-generated `createdAt` /
+        `updatedAt` and the owning `userId` (which the server derives
+        from the authenticated session) are intentionally excluded.
+      required:
+        - name
+      properties:
+        id:
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/Uuid"
+          description: |
+            Existing filter ID for updates; omit on create. Wrapped in
+            an `allOf` so we can attach the `json:"id,omitempty"` tag
+            for upsert ergonomics without recursing into the underlying
+            UUID definition.
+          x-oapi-codegen-extra-tags:
+            json: "id,omitempty"
+        name:
+          type: string
+          description: Human-readable filter name.
+          minLength: 1
+          maxLength: 255
+        filterFile:
+          type: string
+          format: byte
+          description: |
+            Raw filter source as base64-encoded bytes (`format: byte`).
+            Optional on update — the server preserves the existing body
+            when omitted.
+          maxLength: 10485760
+        filterResource:
+          type: string
+          description: |
+            Filter resource discriminator describing the body's source
+            format (e.g. WASM module identifier or external resource
+            path).
+          maxLength: 5000
+        location:
+          $ref: ../../v1beta2/core/api.yml#/components/schemas/MapObject
+          description: Optional structured location metadata.
+        visibility:
+          $ref: ../../v1beta2/core/api.yml#/components/schemas/Visibility
+          description: |
+            Requested visibility scope. The server may downgrade a
+            requested `published` value to `private` for callers that
+            do not own the filter.
+        catalogData:
+          $ref: ../../v1beta2/catalog/api.yml#/components/schemas/CatalogData
+          description: Catalog metadata to attach when publishing.
+          x-go-type: catalogv1alpha2.CatalogData
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/v1alpha2/catalog
+            name: catalogv1alpha2
+
+    MesheryFilterPage:
+      type: object
+      description: Paginated collection of filters.
+      properties:
+        page:
+          type: integer
+          description: Current page number of the result set.
+          minimum: 0
+        pageSize:
+          type: integer
+          description: Number of items per page.
+          minimum: 1
+        totalCount:
+          type: integer
+          description: Total number of items available.
+          minimum: 0
+        filters:
+          type: array
+          items:
+            $ref: "#/components/schemas/MesheryFilter"
+            x-go-type: MesheryFilter
+          description: Filters included on this page of results.
+
+    DeleteFilterModel:
+      type: object
+      description: Reference to a filter for bulk deletion by ID.
+      properties:
+        id:
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/Id"
+          description: Filter ID targeted for deletion.
+        name:
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/Text"
+          description: |
+            Human-readable filter name (informational only; the server
+            matches on `id`).
+
+    MesheryFilterDeleteRequestBody:
+      type: object
+      description: Payload for bulk deleting filters by ID.
+      required:
+        - filters
+      properties:
+        filters:
+          type: array
+          items:
+            $ref: "#/components/schemas/DeleteFilterModel"
+            x-go-type: DeleteFilterModel
+          description: Filters targeted for deletion.
+
+    MesheryFilterCloneRequestBody:
+      type: object
+      description: |
+        Payload for `POST /api/content/filters/clone/{filterId}`. The
+        only client-settable field is the optional name applied to the
+        cloned filter; the server derives ownership and visibility from
+        the request context.
+      properties:
+        name:
+          type: string
+          description: |
+            Optional name to apply to the cloned filter. Defaults to a
+            server-generated derivative of the source filter's name.
+          minLength: 1
+          maxLength: 255
+
+    MesheryFilterRequestBody:
+      type: object
+      description: |
+        Payload for upserting a filter via `POST /api/content/filters`.
+        Mirrors meshery-cloud's `MesheryFilterRequestBody` and
+        meshery's `MesheryFilterRequestBody` — the wrapper carries an
+        optional source URL/path plus a `save` toggle and an embedded
+        `filterData` payload. Wire form for the embedded payload field
+        is canonical camelCase (`filterData`); legacy snake_case
+        (`filter_data`) is accepted by the existing handlers for the
+        deprecation window but new clients MUST emit `filterData`.
+      properties:
+        url:
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/Endpoint"
+          description: Optional source URL the filter was fetched from.
+        path:
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/Text"
+          description: Optional source path the filter was loaded from.
+        save:
+          type: boolean
+          description: |
+            When true, persist the filter in addition to parsing it.
+            When false, the server returns the parsed payload without
+            committing it to the database.
+        filterData:
+          $ref: "#/components/schemas/MesheryFilterPayload"
+          description: Filter body to persist.
+          x-go-type: MesheryFilterPayload
+        config:
+          type: string
+          description: |
+            Optional opaque configuration string passed through to the
+            underlying filter runtime. Persisted only on the local
+            meshery `MesheryFilterPayload` shape; meshery-cloud
+            currently ignores the field, but it is documented here so
+            the canonical contract is single-sourced.
+          maxLength: 65536

--- a/schemas/constructs/v1beta3/filter/filter.yaml
+++ b/schemas/constructs/v1beta3/filter/filter.yaml
@@ -1,0 +1,84 @@
+$schema: http://json-schema.org/draft-07/schema#
+title: Filter Schema
+description: |
+  Server-returned Meshery filter resource as persisted by meshery-cloud
+  (`meshery_filters` table) and consumed by meshery's
+  `models.MesheryFilter`. Filters carry an opaque body (`filterFile`) plus
+  catalog and visibility metadata, and follow the same content-resource
+  shape as designs minus the catalog engagement counters (the
+  `meshery_filters` table has no `view_count` / `download_count` columns).
+type: object
+additionalProperties: false
+required:
+  - id
+  - name
+  - userId
+  - createdAt
+  - updatedAt
+properties:
+  id:
+    $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid
+    description: Server-generated filter ID.
+    x-order: 1
+  name:
+    type: string
+    description: Human-readable filter name; required, used for catalog listings.
+    minLength: 1
+    maxLength: 255
+    x-order: 2
+  userId:
+    $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid
+    description: Owning user ID.
+    x-oapi-codegen-extra-tags:
+      db: user_id
+    x-order: 3
+  filterFile:
+    type: string
+    format: byte
+    description: |
+      Raw filter source persisted as a byte array (`bytea` column
+      `filter_file`). Wire form is base64 per OpenAPI `format: byte`.
+    maxLength: 10485760
+    x-oapi-codegen-extra-tags:
+      db: filter_file
+    x-order: 4
+  filterResource:
+    type: string
+    description: |
+      Filter resource discriminator describing the filter body's source
+      format (e.g. WASM module identifier or external resource path).
+      Stored in the `filter_resource` text column.
+    maxLength: 5000
+    x-oapi-codegen-extra-tags:
+      db: filter_resource
+    x-order: 5
+  location:
+    $ref: ../../v1beta2/core/api.yml#/components/schemas/MapObject
+    description: Optional structured location metadata (branch, host, path, ...).
+    x-order: 6
+  visibility:
+    $ref: ../../v1beta2/core/api.yml#/components/schemas/Visibility
+    description: Visibility scope (private, public, published).
+    x-order: 7
+  catalogData:
+    $ref: ../../v1beta2/catalog/api.yml#/components/schemas/CatalogData
+    description: Catalog metadata attached to the filter when published.
+    x-go-type: catalogv1alpha2.CatalogData
+    x-go-type-import:
+      path: github.com/meshery/schemas/models/v1alpha2/catalog
+      name: catalogv1alpha2
+    x-oapi-codegen-extra-tags:
+      db: catalog_data
+    x-order: 8
+  createdAt:
+    $ref: ../../v1beta2/core/api.yml#/components/schemas/Time
+    description: Timestamp of filter creation.
+    x-oapi-codegen-extra-tags:
+      db: created_at
+    x-order: 9
+  updatedAt:
+    $ref: ../../v1beta2/core/api.yml#/components/schemas/Time
+    description: Timestamp of last filter modification.
+    x-oapi-codegen-extra-tags:
+      db: updated_at
+    x-order: 10

--- a/schemas/constructs/v1beta3/filter/templates/filter_template.json
+++ b/schemas/constructs/v1beta3/filter/templates/filter_template.json
@@ -1,0 +1,12 @@
+{
+  "id": "00000000-0000-0000-0000-000000000000",
+  "name": "",
+  "userId": "00000000-0000-0000-0000-000000000000",
+  "filterFile": "",
+  "filterResource": "",
+  "location": {},
+  "visibility": "private",
+  "catalogData": {},
+  "createdAt": "0001-01-01T00:00:00Z",
+  "updatedAt": "0001-01-01T00:00:00Z"
+}

--- a/schemas/constructs/v1beta3/filter/templates/filter_template.yaml
+++ b/schemas/constructs/v1beta3/filter/templates/filter_template.yaml
@@ -1,0 +1,10 @@
+id: "00000000-0000-0000-0000-000000000000"
+name: ""
+userId: "00000000-0000-0000-0000-000000000000"
+filterFile: ""
+filterResource: ""
+location: {}
+visibility: private
+catalogData: {}
+createdAt: "0001-01-01T00:00:00Z"
+updatedAt: "0001-01-01T00:00:00Z"


### PR DESCRIPTION
## Summary

Adds the canonical-casing v1beta3 schema for Meshery filters so the
locally-defined `MesheryFilter` Go structs in
`meshery/server/models/meshery_filter.go` and
`meshery-cloud/server/models/meshery_filters.go` can be retired
across the consumer repos. Filters are a content resource with the
same shape as designs (file body + visibility + catalog metadata),
modeled directly on `schemas/constructs/v1beta3/design/api.yml`
minus the catalog engagement counters that the `meshery_filters`
table doesn't store.

## Canonical field set

Derived empirically from the live consumer repos
(`meshery_filters` table in
`meshery-cloud/database/migrations/schema.sql`,
`server/models/meshery_filters.go` in meshery-cloud,
`server/models/meshery_filter.go` in meshery, and the live
meshery-cloud Echo handlers in `server/handlers/meshery_filters.go`).

| Wire | DB column | Source-of-truth notes |
|---|---|---|
| `id` (uuid) | `id` | Server-generated PK |
| `name` (string, 1-255) | `name` | Required, used in catalog listings |
| `userId` (uuid) | `user_id` | Owning user — required, not null |
| `filterFile` (base64) | `filter_file` (`bytea`) | Opaque filter body |
| `filterResource` (string) | `filter_resource` (`text`) | Body-format discriminator |
| `location` (jsonb) | `location` | Optional structured source metadata |
| `visibility` (enum) | `visibility` (`varchar`) | `private` / `public` / `published` |
| `catalogData` (CatalogData) | `catalog_data` (`jsonb`) | Catalog metadata when published |
| `createdAt`, `updatedAt` | `created_at`, `updated_at` | Server-managed timestamps |

`view_count` / `download_count` / `clone_count` / `deployment_count`
/ `share_count` are intentionally absent — the `meshery_filters`
table does not have those columns (the catalog engagement counters
live only on `meshery_patterns` today).

## Endpoints

Mirror the live `meshery-cloud` Echo handlers
(`server/router/router.go`):

- `GET    /api/content/filters` — paginated list (page, pageSize, search, order, orgId, visibility, userId)
- `POST   /api/content/filters` — upsert (200)
- `POST   /api/content/filters/delete` — bulk delete sub-resource
- `GET    /api/content/filters/{filterId}`
- `PUT    /api/content/filters/{filterId}` — explicit update (canonical-CRUD complement)
- `DELETE /api/content/filters/{filterId}` — 204
- `POST   /api/content/filters/clone/{filterId}`
- `GET    /api/content/filters/download/{filterId}` — streams raw bytes (`application/wasm`)

Sharing continues to flow through the cross-construct
`POST /api/content/design/share` endpoint owned by the design
package (its `ContentSharePayload.contentType` already accepts
`filter`).

## Dual-schema discipline (matches v1beta3/design)

- `filter.yaml`: `additionalProperties: false`, all server-generated
  fields in `properties`, required-on-response fields in `required`.
- `api.yml` defines `MesheryFilterPayload` for writes (only
  client-settable fields).
- `MesheryFilterRequestBody` wraps the payload to match the live
  `MesheryFilterRequestBody` in both meshery and meshery-cloud
  (URL/path/save/filterData fields). Wire form for the embedded
  payload is canonical camelCase (`filterData`); the legacy
  snake_case `filter_data` is dual-accepted by existing handlers
  for the deprecation window per the identifier-naming migration.
- `x-internal` and `tags` on every operation; ID-suffix params are
  `{filterId}` not `{filterID}`; `operationId` is lower camelCase
  verbNoun throughout.

## Knock-on changes in `v1beta3/design/api.yml`

The design package previously carried two filter operations
(`getFilter`, `cloneFilter` on `/api/content/filters/{filterId}`
and `/api/content/filters/clone/{filterId}`) plus an amorphous
`MesheryFilter: { additionalProperties: true }` placeholder schema
and a `filterId` parameter, all referenced by the prior agent as
"placeholder" work pending this PR. They're removed in the same
change set because the new filter package owns those paths now.
The `CatalogContentPage.filters` items ref is updated to a
cross-construct `$ref` plus `x-go-type`/`x-go-type-import` into
`models/v1beta3/filter`, so the merged spec keeps a single source
of truth for the entity. No cross-repo consumers reference the
removed placeholders by name (the placeholder schema was empty).

## Validation

- `go run ./cmd/validate-schemas` — clean.
- `make audit-schemas` — no new findings against
  `schemas/constructs/v1beta3/filter/` or the modified design file.
- `make bundle-openapi` — bundles cleanly (path collision resolved).
- `make build` — bundle and Go gen succeed end-to-end; the local
  RTK step requires `esbuild-runner`/`ts-node` which CI provides.
- `npm run build` — succeeds; emits `dist/constructs/v1beta3/filter/*`.
- `go build ./...` — clean.
- `go test ./...` — all tests pass except a pre-existing
  `TestConsumerTS_IntegrationAgainstMesheryExtensions` failure that
  reproduces on master and is unrelated to this change.

## Follow-ups (separate PRs)

- meshery: retire `server/models/meshery_filter.go`'s
  `MesheryFilter`, `MesheryFilterPayload`, and
  `MesheryFilterRequestBody` types in favour of the generated
  `github.com/meshery/schemas/models/v1beta3/filter` package.
- meshery-cloud: retire `server/models/meshery_filters.go`'s
  `MesheryFilter` and `server/handlers/meshery_filters.go`'s
  `MesheryFilterRequestBody` in favour of the same.

## Test plan

- [x] `go run ./cmd/validate-schemas`
- [x] `make audit-schemas`
- [x] `make bundle-openapi`
- [x] `make build` (bundle + Go generation)
- [x] `npm run build`
- [x] `go build ./...`
- [x] `go test ./...` (only pre-existing failure)
- [ ] CI artifact-generation workflow regenerates
      `models/v1beta3/filter/*` and the design package's
      generated artifacts.