### PR TITLE
feat(design): enrich MesheryPattern canonical schema for meshery-cloud local-struct retirement

### DIFF
--- a/schemas/constructs/v1beta3/design/api.yml
+++ b/schemas/constructs/v1beta3/design/api.yml
@@ -854,35 +854,90 @@ components:
           description: Owning user ID.
           x-oapi-codegen-extra-tags:
             db: user_id
+        user:
+          $ref: "../../v1beta2/user/api.yml#/components/schemas/User"
+          description: >
+            Owning user record, joined inline by the catalog list/get
+            handlers when shaping responses. Server-projected from the
+            users table via the design's userId; not a column on the
+            meshery_patterns table itself, so the generated Go field is
+            tagged `db:"-"` to keep it out of ORM column scans.
+          nullable: true
+          x-go-type: "*userV1beta.User"
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/v1beta2/user
+            name: userV1beta
+          x-oapi-codegen-extra-tags:
+            db: "-"
         location:
           $ref: "../../v1beta2/core/api.yml#/components/schemas/MapObject"
           description: Optional structured location metadata (branch, host, path, ...).
         patternFile:
-          $ref: "#/components/schemas/PatternFile"
-          description: Parsed design document body.
-          x-go-type: PatternFile
+          type: string
+          description: >
+            Raw design body as it is persisted in the meshery_patterns
+            table's `pattern_file` column. The wire form is the YAML/JSON
+            string the server stores verbatim; consumers that need the
+            structured form transcode at the boundary by parsing the
+            string into a PatternFile (see #/components/schemas/PatternFile)
+            and marshalling it back when they write. Keeping the wire
+            shape as a string mirrors the column's actual representation
+            and avoids forcing every consumer through the structured-vs-
+            string union that the previous *PatternFile typing implied.
+          maxLength: 16777216
           x-oapi-codegen-extra-tags:
             db: pattern_file
         visibility:
-          $ref: "../../v1beta2/core/api.yml#/components/schemas/Text"
-          description: Visibility scope (private, public, published).
+          type: string
+          description: >
+            Visibility scope of the design — controls whether non-owners
+            may read or list it. `private` is owner-only, `public` is
+            readable by anyone in the org, and `published` is visible in
+            the catalog.
+          enum:
+            - private
+            - public
+            - published
+          x-enum-casing-exempt: true
+          maxLength: 32
+          x-oapi-codegen-extra-tags:
+            db: visibility
         designType:
           type: string
           description: >
-            Discriminator identifying the source format of the design body.
-            Projected server-side (not stored in a column of its own); for
-            catalog listings the server derives it from the attached catalog
-            metadata, for user-owned designs the server derives it from the
-            import source. Use this field to branch rendering between native
-            Meshery designs and imported Helm charts, Kubernetes manifests,
-            and Docker Compose files.
+            Discriminator identifying the source format of the design body,
+            persisted in the meshery_patterns table's `source_type` column
+            (nullable; null for legacy rows imported before the column was
+            introduced). For catalog listings the server may also project
+            this field from the attached catalog metadata. Use this field
+            to branch rendering between native Meshery designs and imported
+            Helm charts, Kubernetes manifests, and Docker Compose files.
           x-enum-casing-exempt: true
+          nullable: true
           enum:
             - Design
             - Helm Chart
             - Docker Compose
             - Kubernetes Manifest
           maxLength: 64
+          x-oapi-codegen-extra-tags:
+            db: source_type
+        sourceContent:
+          type: string
+          format: byte
+          nullable: true
+          description: >
+            Raw bytes of the imported source artifact (Helm chart tarball,
+            Kubernetes manifest, Docker Compose file, etc.) preserved in
+            the meshery_patterns table's `source_content` column for
+            non-Meshery-Design imports. Empty / null for native Meshery
+            designs. Server-managed: populated by the import and upload
+            handlers and scrubbed to null on most read responses, so
+            clients should treat this as opaque base64-encoded bytes when
+            it does appear on the wire.
+          x-oapi-codegen-extra-tags:
+            db: source_content
+            json: "sourceContent,omitempty"
         viewCount:
           type: integer
           description: >
@@ -983,6 +1038,73 @@ components:
             x-go-type: DeletePatternModel
           description: Designs targeted for deletion.
 
+    MesheryPatternPayload:
+      type: object
+      description: >
+        Client-settable subset of the design (pattern) entity used as the
+        body of the inner `patternData` envelope on
+        POST /api/content/patterns. Server-generated fields (createdAt,
+        updatedAt, viewCount, downloadCount, cloneCount, deploymentCount,
+        shareCount, the joined `user` object, and the imported-source
+        `sourceContent` blob) are deliberately excluded — the server
+        ignores them on writes and re-projects them on the response.
+      properties:
+        id:
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/Id"
+          description: Existing design ID for updates; omit on create.
+          x-oapi-codegen-extra-tags:
+            json: "id,omitempty"
+        name:
+          type: string
+          description: Human-readable design name.
+          minLength: 1
+          maxLength: 255
+        userId:
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/Id"
+          description: Owning user ID. Server overrides with the authenticated caller on create.
+          x-oapi-codegen-extra-tags:
+            json: "userId,omitempty"
+        catalogData:
+          $ref: "../../v1beta2/catalog/api.yml#/components/schemas/CatalogData"
+          description: Catalog metadata to attach to the design when publishing.
+          x-go-type: catalogv1alpha2.CatalogData
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/v1alpha2/catalog
+            name: catalogv1alpha2
+        location:
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/MapObject"
+          description: Optional structured location metadata (branch, host, path, ...).
+        patternFile:
+          type: string
+          description: >
+            Raw design body to persist into the `pattern_file` column.
+            See MesheryPattern.patternFile for the transcode boundary
+            note that applies on both writes and reads.
+          maxLength: 16777216
+        visibility:
+          type: string
+          description: Visibility scope of the design.
+          enum:
+            - private
+            - public
+            - published
+          x-enum-casing-exempt: true
+          maxLength: 32
+        designType:
+          type: string
+          description: >
+            Discriminator identifying the source format of the design body,
+            stored in the `source_type` column. Optional on create (the
+            server defaults missing values to `Design`).
+          x-enum-casing-exempt: true
+          nullable: true
+          enum:
+            - Design
+            - Helm Chart
+            - Docker Compose
+            - Kubernetes Manifest
+          maxLength: 64
+
     MesheryPatternRequestBody:
       type: object
       description: Payload for upserting a design via POST /api/content/patterns.
@@ -991,9 +1113,9 @@ components:
           $ref: "../../v1beta2/core/api.yml#/components/schemas/Text"
           description: Optional source path the design was loaded from.
         patternData:
-          $ref: "#/components/schemas/MesheryPattern"
+          $ref: "#/components/schemas/MesheryPatternPayload"
           description: Design body to persist.
-          x-go-type: MesheryPattern
+          x-go-type: MesheryPatternPayload
         save:
           type: boolean
           description: When true, persist the design in addition to parsing it.


### PR DESCRIPTION
## Summary

Enriches the canonical `v1beta3` `MesheryPattern` schema so
`layer5io/meshery-cloud` can retire its local Go duplicate
(`server/models.MesheryPattern`) per the PR #5107 follow-up. Per the
source-of-truth directive, downstream consumers conform to the schema —
not the reverse — so this PR adds / type-fixes only the fields the local
struct actually uses today, with no speculative widening.

## Per-field disposition

| Field | Disposition | Rationale |
|---|---|---|
| `user` | **Added** | Optional joined `*User` (v1beta2/user.User), `db:"-"`. Mirrors the local struct's `User *User` join used by catalog list/get responses. |
| `sourceContent` | **Added** | `string` + `format: byte` + `nullable: true` + `db: source_content`. Mirrors the local `SourceContent []byte` (no JSON tag in local — gets encoded under the Go field name when present), used by import handlers for non-Meshery-Design artifacts. |
| `designType` | **Type-fixed** | Was a server-projected (no-DB) field; now DB-backed with `db: source_type` + `nullable: true`. Subsumes the local struct's `Type sql.NullString` (whose `db:"source_type"` tag is the same column). Wire stays canonical camelCase `designType`; the snake_case column name lives only in the `db:` tag. |
| `patternFile` | **Type-fixed** | Was `*PatternFile` (structured object); now `string`. The `pattern_file` DB column is YAML/JSON text — the local consumer types it as `string`, never round-trips a structured object back to the column. The `PatternFile` structured schema still exists for the parsed-form use cases; consumers transcode at the boundary. Doing this also collapses 16+ pre-existing validator advisories rooted at `PatternFile.components.items.allOf[0].model.registrant`. |
| `visibility` | **Type-fixed** | Was `core.Text`; now `string` + explicit enum `private` / `public` / `published` + `db: visibility`. Local struct types it as plain `string` and uses those three constant values exclusively. |
| Catalog counts (`viewCount`, `downloadCount`, `cloneCount`, `deploymentCount`, `shareCount`) | **Left as-is** | Already present on the canonical entity per #834, contrary to the PR #5107 audit text. Verified before editing. |
| `MesheryPatternPayload` | **Added** | Client-settable subset (excludes server-managed catalog counts, timestamps, the joined `user`, and the import-only `sourceContent`). `MesheryPatternRequestBody.patternData` now references this instead of the full entity, satisfying the dual-schema rule on the inner write envelope. |

## Discipline check

- Wire properties: camelCase throughout (`sourceContent`, `designType`, etc.).
- DB tags via `x-oapi-codegen-extra-tags.db`: snake_case (`source_content`, `source_type`, `pattern_file`, `user_id`, `visibility`).
- Property descriptions: present on every new / fixed property.
- Server-computed / read-only fields explicitly described (`sourceContent`, the catalog counts, the joined `user`).
- `additionalProperties: false` on the entity: preserved (still on `design.yaml`'s `PatternFile` structured schema).

## Validator + audit + build outcomes

- `make validate-schemas` — no blocking violations.
- `make audit-schemas-full` — v1beta3/design advisory finding count **drops from 23 (master) to 7**. The remaining 7 are pre-existing `PatternFile.components.items.allOf[0].model.registrant` advisories unchanged from master.
- `make build` — Go + TypeScript artifacts regenerate cleanly. `go build ./models/...` succeeds.
- `go test ./validation/...` — all unit tests pass. `TestConsumerTS_IntegrationAgainstMesheryExtensions` fails on master too (pre-existing local-environment test asserting against a stale copy of `layer5labs/meshery-extensions`); not introduced by this PR.

## Generated artifacts

Per CLAUDE.md, `models/` and `typescript/generated/` are committed by the
master artifact-generation workflow, so this PR carries only the schema
edit; the regeneration on master will produce the corresponding Go and
TS deltas in a follow-up `Generate build artifacts from schemas` commit.

## Notes on type-mismatch rationale (PatternFile)

Two options were on the table per the task brief:
1. Widen canonical to allow `string` form.
2. Document that consumers transcode at the boundary.

**Picked (1)** with documentation to (2): the wire is `string`, the
`PatternFile` structured schema remains available for callers that want
the parsed form, and the entity description spells out the transcode
contract. This preserves wire compatibility with every existing local
consumer (which already stores and emits the YAML/JSON string verbatim)
and avoids forcing every downstream client through an `oneOf`-string-or-
object union that would break the current ergonomics.

## Test plan

- [x] `make validate-schemas` clean.
- [x] `make audit-schemas-full` — v1beta3/design advisory count net-decreased.
- [x] `make build` — Go + TS artifacts regenerate.
- [x] `go build ./models/...` — generated Go compiles, including the cross-construct `userV1beta` import for the new `user` field.
- [x] `go test ./validation/...` — all unit tests pass.
- [x] Verified the regenerated `models/v1beta3/design/design.go` carries all five new / type-fixed fields with correct `db:` and `json:` tags before reverting it (artifacts are committed by the master workflow, not by this PR).

## Follow-up

Unblocks the `meshery-cloud` PR #5107 follow-up that retires
`server/models.MesheryPattern` in favor of
`github.com/meshery/schemas/models/v1beta3/design.MesheryPattern`,
per the canonical-conformance audit captured there.