### PR TITLE
ci: skip generate-artifacts on release-flow auto-commits

### DIFF
--- a/.github/workflows/generate-artifacts-from-schemas.yml
+++ b/.github/workflows/generate-artifacts-from-schemas.yml
@@ -9,6 +9,9 @@ on:
       - README.md
 jobs:
   build-artifacts:
+    # Skip auto-commits made by the release flow (publish-schemas.yml + publish-npm-package.yml)
+    # so generate-artifacts does not loop on its own commits or on release-driven schema bumps.
+    if: github.event_name == 'workflow_dispatch' || github.event.head_commit.author.email != 'ci@meshery.io'
     runs-on: ubuntu-24.04
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- Stops `Generate Artifacts from schemas` from re-firing on the auto-commits that the release pipeline (`publish-schemas.yml` + `publish-npm-package.yml`) pushes to master under `ci@meshery.io`.
- Gates the `build-artifacts` job on `github.event.head_commit.author.email != 'ci@meshery.io'` so it only runs for human/dependabot pushes and manual `workflow_dispatch`.

## Context
On the v1.2.4 release (`Publish Schemas` run [25087990466](https://github.com/meshery/schemas/actions/runs/25087990466)), the post-publish auto-commits would have triggered another `Generate Artifacts from schemas` cycle that simply duplicates work already produced by the publish pipeline (`make build` runs as part of `publish-npm-package.yml`). This guard removes that duplicate cycle.

## Scope
- Single edit to `.github/workflows/generate-artifacts-from-schemas.yml`.
- No change to any other workflow. The npm publish failure on the v1.2.4 run is a separate Trusted Publisher misalignment introduced by PR #855 (workflow filename in the npm TP config still pointed at the called reusable rather than the new caller `publish-schemas.yml`); fixing that lives on the npmjs.com side and is not part of this PR.

## Test plan
- [ ] Manually re-run `Generate Artifacts from schemas` via `workflow_dispatch` after merge — should still execute (job-level `if` permits `workflow_dispatch`).
- [ ] Push a normal commit to master under a human author — should execute.
- [ ] Confirm next release cycle: `publish-schemas.yml` lands `Update published schema versions` and `Update schema` auto-commits; `Generate Artifacts from schemas` should be skipped (job marked as not run because `if` evaluated false).