### PR TITLE
feat(provider): add Provider construct schema (v1beta1)

### DIFF
--- a/schemas/constructs/v1beta1/provider/api.yml
+++ b/schemas/constructs/v1beta1/provider/api.yml
@@ -1,0 +1,116 @@
+openapi: 3.0.0
+info:
+  title: Provider
+  description: >-
+    OpenAPI schema for the Provider Admin initialization configuration loaded
+    by Meshery Cloud at server boot. The Provider Admin is the top-level
+    platform tenant that owns and bootstraps the deployment. The schema
+    drives Go and TypeScript type generation for the boot-time configuration
+    consumer in `layer5io/meshery-cloud/server/init/provider_init.go`; the
+    configuration itself is supplied via a YAML file referenced by the
+    `INIT_CONFIG` environment variable rather than via an HTTP endpoint.
+  version: v1beta1
+  contact:
+    name: Meshery Maintainers
+    email: maintainers@meshery.io
+    url: https://meshery.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+tags:
+  - name: Provider
+    description: >-
+      Operations and types related to Provider Admin initialization. The
+      Provider Admin is the top-level platform tenant created at server
+      boot from a YAML configuration file.
+
+components:
+  schemas:
+    Provider:
+      $ref: ./provider.yaml
+
+    ProviderOrganization:
+      type: object
+      additionalProperties: false
+      description: >-
+        Provider Admin organization configuration. Bootstraps the top-level
+        organization that owns the Meshery Cloud deployment. Field shapes
+        mirror the `Organization` entity but are restricted to the subset
+        that may be supplied via boot configuration.
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Display name of the Provider Admin organization.
+          minLength: 1
+          maxLength: 255
+          x-order: 1
+        description:
+          type: string
+          description: Free-form description of the Provider Admin organization.
+          maxLength: 5000
+          x-order: 2
+        country:
+          type: string
+          description: Country associated with the Provider Admin organization.
+          maxLength: 500
+          x-order: 3
+        region:
+          type: string
+          description: Region associated with the Provider Admin organization.
+          maxLength: 500
+          x-order: 4
+
+    ProviderUser:
+      type: object
+      additionalProperties: false
+      description: >-
+        Provider Admin user configuration. Bootstraps the initial platform
+        administrator account associated with the Provider Admin organization.
+        The user is created in the configured identity provider (Ory Kratos)
+        and persisted in the application database during server boot.
+      required:
+        - firstName
+        - lastName
+        - email
+        - password
+      properties:
+        firstName:
+          type: string
+          description: Given name of the Provider Admin user.
+          minLength: 1
+          maxLength: 255
+          x-order: 1
+        lastName:
+          type: string
+          description: Family name of the Provider Admin user.
+          minLength: 1
+          maxLength: 255
+          x-order: 2
+        email:
+          type: string
+          format: email
+          description: Email address of the Provider Admin user. Used as the unique identity in Kratos.
+          minLength: 3
+          maxLength: 320
+          x-order: 3
+        username:
+          type: string
+          description: >-
+            Username of the Provider Admin user. Optional; defaults to the
+            user's email address when omitted from the boot configuration.
+          minLength: 1
+          maxLength: 255
+          x-order: 4
+        password:
+          type: string
+          format: password
+          description: >-
+            Initial password for the Provider Admin user. Provided only at
+            boot time; never stored in plaintext or returned in API
+            responses.
+          minLength: 8
+          maxLength: 255
+          x-order: 5

--- a/schemas/constructs/v1beta1/provider/provider.yaml
+++ b/schemas/constructs/v1beta1/provider/provider.yaml
@@ -1,0 +1,25 @@
+$id: https://schemas.meshery.io/provider.yaml
+$schema: http://json-schema.org/draft-07/schema#
+description: >-
+  Configuration for initializing the Provider Admin organization and user
+  during Meshery Cloud server boot-time. The Provider Admin is the top-level
+  platform tenant that owns and manages the deployment. This configuration
+  is loaded once at server startup from the path supplied via the
+  INIT_CONFIG environment variable; the operation is idempotent and is
+  skipped when the Provider Admin organization already exists.
+type: object
+additionalProperties: false
+required:
+  - organization
+  - user
+properties:
+  organization:
+    description: Provider Admin organization configuration.
+    x-go-type: ProviderOrganization
+    $ref: ./api.yml#/components/schemas/ProviderOrganization
+    x-order: 1
+  user:
+    description: Provider Admin user configuration.
+    x-go-type: ProviderUser
+    $ref: ./api.yml#/components/schemas/ProviderUser
+    x-order: 2

--- a/schemas/constructs/v1beta1/provider/templates/provider_template.json
+++ b/schemas/constructs/v1beta1/provider/templates/provider_template.json
@@ -1,0 +1,15 @@
+{
+  "organization": {
+    "name": "Layer5",
+    "description": "Provider Admin organization for the Meshery Cloud deployment.",
+    "country": "United States",
+    "region": "North America"
+  },
+  "user": {
+    "firstName": "Provider",
+    "lastName": "Admin",
+    "email": "admin@example.com",
+    "username": "admin@example.com",
+    "password": ""
+  }
+}

--- a/schemas/constructs/v1beta1/provider/templates/provider_template.yaml
+++ b/schemas/constructs/v1beta1/provider/templates/provider_template.yaml
@@ -1,0 +1,11 @@
+organization:
+  name: Layer5
+  description: Provider Admin organization for the Meshery Cloud deployment.
+  country: United States
+  region: North America
+user:
+  firstName: Provider
+  lastName: Admin
+  email: admin@example.com
+  username: admin@example.com
+  password: ""


### PR DESCRIPTION
## Summary

- Authors a new canonical-casing OpenAPI schema for the **Provider Admin initialization configuration** consumed by Meshery Cloud at server boot, replacing the inline anonymous structs in `layer5io/meshery-cloud/server/init/provider_init.go` (`ProviderInitConfig`).
- Schema lives at `schemas/constructs/v1beta1/provider/` and defines `Provider`, `ProviderOrganization`, and `ProviderUser` with full descriptions, length constraints, and `format: email` / `format: password` annotations.
- No HTTP paths — the construct represents boot-time YAML configuration, not an API surface — so `api.yml` exposes only component schemas. Both `provider_template.json` and `provider_template.yaml` are included to document the canonical config-file shape.

### Wire form

- camelCase JSON property names everywhere, matching the existing `json:` tags on the downstream struct (`firstName`, `lastName`, `email`, `username`, `password`).
- The auto-generated Go `yaml:` tags follow camelCase along with the JSON tags, retiring the snake_case `yaml:` tags in the legacy inline struct. A coordinated `meshery-cloud` follow-up will adopt the generated type and migrate any in-tree config files; the existing snake_case `yaml:` keys (`first_name`, `last_name`) on `ProviderInitConfig.User` are the only behavior-affecting change for operators of `INIT_CONFIG`.

### What this enables

- `Provider`, `ProviderOrganization`, and `ProviderUser` Go types become the source of truth for the Provider Admin bootstrap, removing the duplicated anonymous-struct definition in meshery-cloud.
- TypeScript types are also published so any future admin UI surfacing the Provider Admin status has a generated contract to consume.

## Verification

Ran locally on this branch:

- `make validate-schemas` — clean (no blocking violations).
- `make audit-schemas` — no findings on `schemas/constructs/v1beta1/provider/**`.
- `make bundle-openapi` — Provider construct bundles cleanly into `_openapi_build/constructs/v1beta1/provider/merged-openapi.json`.
- `make generate-golang` — produces `models/v1beta1/provider/{provider.go, zz_generated.helpers.go}` with camelCase JSON + camelCase YAML tags as expected; `go build ./...` and `go test ./models/v1beta1/provider/...` pass.
- `make generate-ts` + `npm run build` — produces `typescript/generated/v1beta1/provider/` and `dist/constructs/v1beta1/provider/` cleanly.
- `make consumer-audit MESHERY_REPO=../meshery CLOUD_REPO=../meshery-cloud` — no new findings; Provider has no HTTP endpoints so it does not appear in the per-endpoint counts.

The pre-existing `TestConsumerTS_IntegrationAgainstMesheryExtensions` failure on `master` is unrelated to this change (the same failure reproduces on a clean `master` checkout).

## Test plan

- [x] `make validate-schemas`
- [x] `make audit-schemas` (no Provider-specific findings)
- [x] `make bundle-openapi`
- [x] `make generate-golang` + `go build ./...` + `go test ./models/v1beta1/provider/...`
- [x] `make generate-ts`
- [x] `npm run build`
- [x] `make consumer-audit MESHERY_REPO=../meshery CLOUD_REPO=../meshery-cloud`
- [ ] CI green on PR (Schema Audit blocking validation, advisory audit, consumer audit)
- [ ] Generated `models/v1beta1/provider/` and `typescript/generated/v1beta1/provider/` land via the post-merge `generate-artifacts-from-schemas.yml` workflow on master
- [ ] Follow-up PR in `layer5io/meshery-cloud` adopts `github.com/meshery/schemas/models/v1beta1/provider.Provider` in place of the inline `ProviderInitConfig` (will reference this PR)

## Cross-repo coordination

- **Downstream consumer**: `layer5io/meshery-cloud/server/init/provider_init.go` will be updated in a follow-up PR to import the generated type. That PR will also document the `INIT_CONFIG` YAML key migration from `first_name`/`last_name` to `firstName`/`lastName` for operators who maintain config files outside the repo.

Refs: [`docs/identifier-naming-contributor-guide.md`](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md)