### PR TITLE
feat(forms): add canonical RJSF form schemas for 10 constructs (issue #866 phase 1)

### DIFF
--- a/schemas/constructs/v1beta2/model/api.yml
+++ b/schemas/constructs/v1beta2/model/api.yml
@@ -297,3 +297,47 @@ components:
             type: object
             additionalProperties: true
           description: The models of the meshmodelmodelspage.
+
+    MesheryModelImportFormPayload:
+      type: object
+      description: >
+        Flat canonical representation of the model import form that combines
+        the UI-level uploadType discriminator with the union of fields from
+        the ImportBody oneOf variants. This schema is the authoritative source
+        for the canonical RJSF form schema at
+        schemas/constructs/v1beta2/model/forms/import.json. The server
+        receives an ImportRequest; this form schema captures the superset of
+        user-facing fields so the form schema can be validated as a subset of
+        this canonical type.
+      required:
+        - uploadType
+      properties:
+        uploadType:
+          type: string
+          title: "Upload method"
+          x-enum-casing-exempt: true
+          enum: ["file", "urlImport", "csv"]
+          description: "Choose the method you prefer. Select 'File Import' or 'CSV Import' if you have the file on your local system, or 'URL Import' if you have the file hosted online."
+        fileName:
+          type: string
+          description: "Name of the model file being uploaded."
+          maxLength: 255
+        modelFile:
+          type: string
+          description: "Model file content. Supported formats: .tar, .tar.gz, .tgz."
+        url:
+          type: string
+          format: uri
+          description: "A direct URL to a single model file. Supported formats: .tar, .tar.gz, .tgz."
+        modelCsv:
+          type: string
+          format: binary
+          description: "CSV file containing model definitions."
+        componentCsv:
+          type: string
+          format: binary
+          description: "CSV file containing component definitions."
+        relationshipCsv:
+          type: string
+          format: binary
+          description: "CSV file containing relationship definitions."

--- a/schemas/constructs/v1beta2/model/forms/import.json
+++ b/schemas/constructs/v1beta2/model/forms/import.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Import Model",
+  "description": "RJSF form schema for the import-model modal. Captures the user-input fields drawn from the canonical ImportRequest schema in meshery/schemas/constructs/v1beta2/model/api.yml. The uploadType discriminator determines which import method is active. Field shape, types, enum values, and required lists MUST stay a subset of the canonical ImportRequest; the Go validator at validation/forms_test.go enforces that.",
+  "type": "object",
+  "properties": {
+    "uploadType": {
+      "type": "string",
+      "title": "Upload method",
+      "enum": ["file", "urlImport", "csv"],
+      "description": "Choose the method you prefer to upload your model file. Select 'File Import' or 'CSV Import' if you have the file on your local system or 'URL Import' if you have the file hosted online.",
+      "x-rjsf-grid-area": "12"
+    }
+  },
+  "required": ["uploadType"]
+}

--- a/schemas/constructs/v1beta2/model/forms/import.json
+++ b/schemas/constructs/v1beta2/model/forms/import.json
@@ -1,16 +1,94 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Import Model",
-  "description": "RJSF form schema for the import-model modal. Captures the user-input fields drawn from the canonical ImportRequest schema in meshery/schemas/constructs/v1beta2/model/api.yml. The uploadType discriminator determines which import method is active. Field shape, types, enum values, and required lists MUST stay a subset of the canonical ImportRequest; the Go validator at validation/forms_test.go enforces that.",
+  "description": "RJSF form schema for the import-model modal. Captures the user-input fields drawn from the canonical MesheryModelImportFormPayload schema in meshery/schemas/constructs/v1beta2/model/api.yml. The uploadType discriminator determines which branch's conditional required fields apply. Field shape, types, and required lists MUST stay a subset of the canonical MesheryModelImportFormPayload; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",
   "properties": {
     "uploadType": {
       "type": "string",
       "title": "Upload method",
       "enum": ["file", "urlImport", "csv"],
-      "description": "Choose the method you prefer to upload your model file. Select 'File Import' or 'CSV Import' if you have the file on your local system or 'URL Import' if you have the file hosted online.",
+      "description": "Choose the method you prefer to upload your model file. Select 'File Import' or 'CSV Import' if you have the file on your local system, or 'URL Import' if you have the file hosted online.",
+      "x-rjsf-grid-area": "12"
+    },
+    "fileName": {
+      "type": "string",
+      "title": "File name",
+      "description": "Name of the model file being uploaded.",
+      "x-rjsf-grid-area": "12"
+    },
+    "modelFile": {
+      "type": "string",
+      "title": "Model file",
+      "description": "Model file content. Supported formats: .tar, .tar.gz, .tgz.",
+      "x-rjsf-grid-area": "12"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "title": "URL",
+      "description": "A direct URL to a single model file. Supported formats: .tar, .tar.gz, .tgz.",
+      "x-rjsf-grid-area": "12"
+    },
+    "modelCsv": {
+      "type": "string",
+      "format": "binary",
+      "title": "Model CSV",
+      "description": "CSV file containing model definitions.",
+      "x-rjsf-grid-area": "12"
+    },
+    "componentCsv": {
+      "type": "string",
+      "format": "binary",
+      "title": "Component CSV",
+      "description": "CSV file containing component definitions.",
+      "x-rjsf-grid-area": "12"
+    },
+    "relationshipCsv": {
+      "type": "string",
+      "format": "binary",
+      "title": "Relationship CSV",
+      "description": "CSV file containing relationship definitions.",
       "x-rjsf-grid-area": "12"
     }
   },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "uploadType": {
+            "const": "file"
+          }
+        }
+      },
+      "then": {
+        "required": ["fileName", "modelFile"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "uploadType": {
+            "const": "urlImport"
+          }
+        }
+      },
+      "then": {
+        "required": ["url"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "uploadType": {
+            "const": "csv"
+          }
+        }
+      },
+      "then": {
+        "required": ["modelCsv", "componentCsv", "relationshipCsv"]
+      }
+    }
+  ],
   "required": ["uploadType"]
 }

--- a/schemas/constructs/v1beta2/model/forms/import.ui.json
+++ b/schemas/constructs/v1beta2/model/forms/import.ui.json
@@ -2,8 +2,17 @@
   "uploadType": {
     "ui:widget": "radio"
   },
-  "file": {
+  "modelFile": {
     "ui:widget": "file"
   },
-  "ui:order": ["uploadType", "file", "url", "csv"]
+  "modelCsv": {
+    "ui:widget": "file"
+  },
+  "componentCsv": {
+    "ui:widget": "file"
+  },
+  "relationshipCsv": {
+    "ui:widget": "file"
+  },
+  "ui:order": ["uploadType", "fileName", "modelFile", "url", "modelCsv", "componentCsv", "relationshipCsv"]
 }

--- a/schemas/constructs/v1beta2/model/forms/import.ui.json
+++ b/schemas/constructs/v1beta2/model/forms/import.ui.json
@@ -1,0 +1,9 @@
+{
+  "uploadType": {
+    "ui:widget": "radio"
+  },
+  "file": {
+    "ui:widget": "file"
+  },
+  "ui:order": ["uploadType", "file", "url", "csv"]
+}

--- a/schemas/constructs/v1beta3/connection/connection.yaml
+++ b/schemas/constructs/v1beta3/connection/connection.yaml
@@ -27,18 +27,35 @@ properties:
     description: Connection Name
     minLength: 1
     maxLength: 255
+  description:
+    x-oapi-codegen-extra-tags:
+      db: description
+      json: description
+    x-order: 3
+    type: string
+    description: Human-readable description of the connection and its purpose.
+    maxLength: 1000
+  url:
+    x-oapi-codegen-extra-tags:
+      db: url
+      json: url
+    x-order: 4
+    type: string
+    format: uri
+    description: URL of the remote resource this connection points to (e.g. the Helm repository URL, the Kubernetes API server endpoint, the Grafana instance URL).
+    maxLength: 2048
   credentialId:
     x-go-name: CredentialID
     x-oapi-codegen-extra-tags:
       db: credential_id
       json: credentialId
-    x-order: 3
+    x-order: 5
     $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid
     description: Associated Credential ID
   type:
     x-oapi-codegen-extra-tags:
       db: type
-    x-order: 4
+    x-order: 6
     type: string
     description: Connection Type (platform, telemetry, collaboration)
     maxLength: 255
@@ -46,21 +63,21 @@ properties:
     x-oapi-codegen-extra-tags:
       db: sub_type
       json: subType
-    x-order: 5
+    x-order: 7
     type: string
     description: Connection Subtype (cloud, identity, metrics, chat, git, orchestration)
     maxLength: 255
   kind:
     x-oapi-codegen-extra-tags:
       db: kind
-    x-order: 6
+    x-order: 8
     type: string
     description: Connection Kind (meshery, kubernetes, prometheus, grafana, gke, aws, azure, slack, github)
     maxLength: 255
   metadata:
     x-oapi-codegen-extra-tags:
       db: metadata
-    x-order: 7
+    x-order: 9
     x-go-type: core.Map
     x-go-type-import:
       path: github.com/meshery/schemas/models/core
@@ -70,7 +87,7 @@ properties:
   status:
     x-oapi-codegen-extra-tags:
       db: status
-    x-order: 8
+    x-order: 10
     description: Connection Status
     type: string
     enum:
@@ -87,7 +104,7 @@ properties:
     x-oapi-codegen-extra-tags:
       db: user_id
       json: userId
-    x-order: 9
+    x-order: 11
     $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid
     description: User ID who owns this connection
   createdAt:
@@ -96,21 +113,21 @@ properties:
     x-oapi-codegen-extra-tags:
       db: created_at
       json: createdAt
-    x-order: 10
+    x-order: 12
   updatedAt:
     $ref: ../../v1beta2/core/api.yml#/components/schemas/Time
     description: Timestamp when the connection was last updated.
     x-oapi-codegen-extra-tags:
       db: updated_at
       json: updatedAt
-    x-order: 11
+    x-order: 13
   deletedAt:
     $ref: ../../v1beta2/core/api.yml#/components/schemas/NullTime
     description: Timestamp when the connection was soft-deleted, if applicable.
     x-oapi-codegen-extra-tags:
       db: deleted_at
       json: deletedAt
-    x-order: 12
+    x-order: 14
   environments:
     type: array
     description: Associated environments for this connection
@@ -124,11 +141,11 @@ properties:
       db: "-"
       gorm: "-"
     x-go-type-skip-optional-pointer: true
-    x-order: 13
+    x-order: 15
   schemaVersion:
     description: Specifies the version of the schema used for the definition.
     $ref: ../../v1beta2/core/api.yml#/components/schemas/VersionString
-    x-order: 14
+    x-order: 16
     x-oapi-codegen-extra-tags:
       db: "-"
       gorm: "-"

--- a/schemas/constructs/v1beta3/connection/forms/helmCreate.json
+++ b/schemas/constructs/v1beta3/connection/forms/helmCreate.json
@@ -14,7 +14,6 @@
     "description": {
       "type": "string",
       "title": "Description",
-      "format": "textarea",
       "description": "Human-readable description of the connection and its purpose.",
       "x-rjsf-grid-area": "12"
     },

--- a/schemas/constructs/v1beta3/connection/forms/helmCreate.json
+++ b/schemas/constructs/v1beta3/connection/forms/helmCreate.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Helm Repository Connection",
+  "description": "RJSF form schema for configuring a Helm repository connection. Captures the user-input fields drawn from the canonical Connection construct in meshery/schemas/constructs/v1beta3/connection/connection.yaml. Field shape, types, and required lists MUST stay a subset of the canonical Connection; the Go validator at validation/forms_test.go enforces that.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Name",
+      "minLength": 1,
+      "description": "Connection Name",
+      "x-rjsf-grid-area": "12"
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "format": "textarea",
+      "description": "Human-readable description of the connection and its purpose.",
+      "x-rjsf-grid-area": "12"
+    },
+    "url": {
+      "type": "string",
+      "title": "URL",
+      "format": "uri",
+      "description": "URL of the remote resource this connection points to (e.g. the Helm repository URL, the Kubernetes API server endpoint, the Grafana instance URL).",
+      "x-rjsf-grid-area": "12"
+    }
+  },
+  "required": ["name", "url"]
+}

--- a/schemas/constructs/v1beta3/connection/forms/helmCreate.ui.json
+++ b/schemas/constructs/v1beta3/connection/forms/helmCreate.ui.json
@@ -1,3 +1,6 @@
 {
+  "description": {
+    "ui:widget": "textarea"
+  },
   "ui:order": ["name", "description", "url"]
 }

--- a/schemas/constructs/v1beta3/connection/forms/helmCreate.ui.json
+++ b/schemas/constructs/v1beta3/connection/forms/helmCreate.ui.json
@@ -1,0 +1,3 @@
+{
+  "ui:order": ["name", "description", "url"]
+}

--- a/schemas/constructs/v1beta3/design/api.yml
+++ b/schemas/constructs/v1beta3/design/api.yml
@@ -1108,6 +1108,44 @@ components:
           minLength: 1
           maxLength: 255
 
+    MesheryPatternImportFormPayload:
+      type: object
+      description: >
+        Flat canonical representation of the design import form that combines
+        the discriminator field with the union of properties from
+        MesheryPatternImportFilePayload and MesheryPatternImportURLPayload.
+        This schema is the authoritative source for the canonical RJSF form
+        schema at schemas/constructs/v1beta3/design/forms/import.json.
+        The server receives either a File-import payload or a URL-import
+        payload (as defined by MesheryPatternImportRequestBody); this form
+        schema captures the superset of user-facing fields so the form
+        schema can be validated as a subset of this canonical type.
+      properties:
+        name:
+          type: string
+          default: "Untitled Design"
+          description: "Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it."
+          minLength: 1
+          maxLength: 255
+        uploadType:
+          type: string
+          title: "Upload method"
+          x-enum-casing-exempt: true
+          enum: ["File Upload", "URL Import"]
+          description: >
+            UI-level discriminator that controls which import variant the
+            form submits. The client maps "File Upload" to
+            MesheryPatternImportFilePayload and "URL Import" to
+            MesheryPatternImportURLPayload before calling the API.
+        file:
+          type: string
+          format: byte
+          description: "Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs."
+        url:
+          type: string
+          format: uri
+          description: "A direct URL to a single file. Ensure the resource is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design."
+
     DesignPreferences:
       type: object
       description: Design-level preferences

--- a/schemas/constructs/v1beta3/design/forms/import.json
+++ b/schemas/constructs/v1beta3/design/forms/import.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Import Design",
-  "description": "RJSF form schema for the import-design modal. Captures the user-input fields drawn from the canonical MesheryPatternImportFilePayload and MesheryPatternImportURLPayload schemas in meshery/schemas/constructs/v1beta3/design/api.yml. The uploadType discriminator determines which branch's conditional required fields apply. Field shape, types, and required lists MUST stay a subset of the canonical schema components; the Go validator at validation/forms_test.go enforces that.",
+  "description": "RJSF form schema for the import-design modal. Captures the user-input fields drawn from the canonical MesheryPatternImportFormPayload schema in meshery/schemas/constructs/v1beta3/design/api.yml. The uploadType discriminator determines which branch's conditional required fields apply. Field shape, types, and required lists MUST stay a subset of the canonical schema components; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",
   "properties": {
     "name": {
@@ -16,7 +16,21 @@
       "title": "Upload method",
       "enum": ["File Upload", "URL Import"],
       "default": "URL Import",
-      "description": "Body for POST /api/pattern/import. Consumed by the server as application/json. Exactly one of two variants must be supplied: a File Import carrying base64-encoded bytes plus a file name, or a URL Import naming a remote location the server will fetch.",
+      "description": "Choose the method you prefer. Select 'File Upload' if you have the file on your local system, or 'URL Import' if you have the file hosted online.",
+      "x-rjsf-grid-area": "12"
+    },
+    "file": {
+      "type": "string",
+      "format": "byte",
+      "title": "File",
+      "description": "Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See Import Designs Documentation for details.",
+      "x-rjsf-grid-area": "12"
+    },
+    "url": {
+      "type": "string",
+      "format": "uri",
+      "title": "URL",
+      "description": "A direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Ensure the resource is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design.",
       "x-rjsf-grid-area": "12"
     }
   },
@@ -30,14 +44,6 @@
         }
       },
       "then": {
-        "properties": {
-          "file": {
-            "type": "string",
-            "format": "byte",
-            "description": "Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See Import Designs Documentation for details.",
-            "x-rjsf-grid-area": "12"
-          }
-        },
         "required": ["file"]
       }
     },
@@ -50,15 +56,6 @@
         }
       },
       "then": {
-        "properties": {
-          "url": {
-            "type": "string",
-            "format": "uri",
-            "title": "URL",
-            "description": "A direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Ensure the resource is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design.",
-            "x-rjsf-grid-area": "12"
-          }
-        },
         "required": ["url"]
       }
     }

--- a/schemas/constructs/v1beta3/design/forms/import.json
+++ b/schemas/constructs/v1beta3/design/forms/import.json
@@ -1,0 +1,67 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Import Design",
+  "description": "RJSF form schema for the import-design modal. Captures the user-input fields drawn from the canonical MesheryPatternImportFilePayload and MesheryPatternImportURLPayload schemas in meshery/schemas/constructs/v1beta3/design/api.yml. The uploadType discriminator determines which branch's conditional required fields apply. Field shape, types, and required lists MUST stay a subset of the canonical schema components; the Go validator at validation/forms_test.go enforces that.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Design file name",
+      "default": "Untitled Design",
+      "description": "Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it.",
+      "x-rjsf-grid-area": "12"
+    },
+    "uploadType": {
+      "type": "string",
+      "title": "Upload method",
+      "enum": ["File Upload", "URL Import"],
+      "default": "URL Import",
+      "description": "Body for POST /api/pattern/import. Consumed by the server as application/json. Exactly one of two variants must be supplied: a File Import carrying base64-encoded bytes plus a file name, or a URL Import naming a remote location the server will fetch.",
+      "x-rjsf-grid-area": "12"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "uploadType": {
+            "const": "File Upload"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "byte",
+            "description": "Base64-encoded file bytes. Supported formats: Kubernetes Manifests, Helm Charts, Docker Compose, and Meshery Designs. See Import Designs Documentation for details.",
+            "x-rjsf-grid-area": "12"
+          }
+        },
+        "required": ["file"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "uploadType": {
+            "const": "URL Import"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "url": {
+            "type": "string",
+            "format": "uri",
+            "title": "URL",
+            "description": "A direct URL to a single file, for example: https://raw.github.com/your-design-file.yaml. Ensure the resource is in a supported format: Kubernetes Manifest, Helm Chart, Docker Compose, or Meshery Design.",
+            "x-rjsf-grid-area": "12"
+          }
+        },
+        "required": ["url"]
+      }
+    }
+  ],
+  "required": ["uploadType", "name"]
+}

--- a/schemas/constructs/v1beta3/design/forms/import.ui.json
+++ b/schemas/constructs/v1beta3/design/forms/import.ui.json
@@ -1,0 +1,6 @@
+{
+  "uploadType": {
+    "ui:widget": "radio"
+  },
+  "ui:order": ["name", "uploadType", "file", "url"]
+}

--- a/schemas/constructs/v1beta3/filter/api.yml
+++ b/schemas/constructs/v1beta3/filter/api.yml
@@ -473,3 +473,48 @@ components:
             currently ignores the field, but it is documented here so
             the canonical contract is single-sourced.
           maxLength: 65536
+
+    MesheryFilterImportFormPayload:
+      type: object
+      description: >
+        Flat canonical representation of the filter import form that combines
+        the UI-level uploadType discriminator with the union of properties from
+        MesheryFilterPayload (filterFile, filterResource). This schema is the
+        authoritative source for the canonical RJSF form schema at
+        schemas/constructs/v1beta3/filter/forms/import.json. The server
+        receives a MesheryFilterPayload; this form schema captures the
+        superset of user-facing fields (including the UI-only uploadType
+        discriminator) so the form schema can be validated as a subset of
+        this canonical type.
+      required:
+        - name
+        - uploadType
+      properties:
+        name:
+          type: string
+          description: Human-readable filter name.
+          minLength: 1
+          maxLength: 255
+        uploadType:
+          type: string
+          title: "Upload method"
+          x-enum-casing-exempt: true
+          enum: ["File Upload", "URL Upload"]
+          description: >
+            UI-level discriminator that controls which import variant the
+            form submits. "File Upload" maps to a base64-encoded filterFile
+            body; "URL Upload" maps to a filterResource path/URL.
+        filterFile:
+          type: string
+          format: byte
+          description: >
+            Raw filter source as base64-encoded bytes. Required when
+            uploadType is "File Upload".
+          maxLength: 10485760
+        filterResource:
+          type: string
+          description: >
+            Filter resource discriminator describing the body's source
+            format (e.g. WASM module identifier or external resource path).
+            Required when uploadType is "URL Upload".
+          maxLength: 5000

--- a/schemas/constructs/v1beta3/filter/forms/import.json
+++ b/schemas/constructs/v1beta3/filter/forms/import.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Import Filter",
+  "description": "RJSF form schema for the import-filter modal. Captures the user-input fields drawn from the canonical MesheryFilterPayload schema in meshery/schemas/constructs/v1beta3/filter/api.yml#/components/schemas/MesheryFilterPayload. The uploadType discriminator selects between File Upload and URL Upload import methods. Field shape, types, and required lists MUST stay a subset of the canonical MesheryFilterPayload; the Go validator at validation/forms_test.go enforces that.",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string",
+      "title": "Name",
+      "description": "Human-readable filter name.",
+      "x-rjsf-grid-area": "6"
+    }
+  },
+  "allOf": [
+    {
+      "if": {
+        "properties": {
+          "uploadType": {
+            "const": "File Upload"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "filterFile": {
+            "type": "string",
+            "format": "byte",
+            "description": "Raw filter source as base64-encoded bytes. Optional on update — the server preserves the existing body when omitted.",
+            "x-rjsf-grid-area": "12"
+          }
+        },
+        "required": ["filterFile"]
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "uploadType": {
+            "const": "URL Upload"
+          }
+        }
+      },
+      "then": {
+        "properties": {
+          "filterResource": {
+            "type": "string",
+            "title": "URL",
+            "description": "Filter resource discriminator describing the body's source format (e.g. WASM module identifier or external resource path).",
+            "x-rjsf-grid-area": "12"
+          }
+        },
+        "required": ["filterResource"]
+      }
+    }
+  ],
+  "required": ["name"]
+}

--- a/schemas/constructs/v1beta3/filter/forms/import.json
+++ b/schemas/constructs/v1beta3/filter/forms/import.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Import Filter",
-  "description": "RJSF form schema for the import-filter modal. Captures the user-input fields drawn from the canonical MesheryFilterPayload schema in meshery/schemas/constructs/v1beta3/filter/api.yml#/components/schemas/MesheryFilterPayload. The uploadType discriminator selects between File Upload and URL Upload import methods. Field shape, types, and required lists MUST stay a subset of the canonical MesheryFilterPayload; the Go validator at validation/forms_test.go enforces that.",
+  "description": "RJSF form schema for the import-filter modal. Captures the user-input fields drawn from the canonical MesheryFilterImportFormPayload schema in meshery/schemas/constructs/v1beta3/filter/api.yml. The uploadType discriminator selects between File Upload and URL Upload import methods. Field shape, types, and required lists MUST stay a subset of the canonical MesheryFilterImportFormPayload; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",
   "properties": {
     "name": {
@@ -9,6 +9,27 @@
       "title": "Name",
       "description": "Human-readable filter name.",
       "x-rjsf-grid-area": "6"
+    },
+    "uploadType": {
+      "type": "string",
+      "title": "Upload method",
+      "enum": ["File Upload", "URL Upload"],
+      "default": "File Upload",
+      "description": "Choose the method you prefer. Select 'File Upload' if you have the filter on your local system, or 'URL Upload' if the filter is hosted online.",
+      "x-rjsf-grid-area": "12"
+    },
+    "filterFile": {
+      "type": "string",
+      "format": "byte",
+      "title": "Filter file",
+      "description": "Raw filter source as base64-encoded bytes. Optional on update — the server preserves the existing body when omitted.",
+      "x-rjsf-grid-area": "12"
+    },
+    "filterResource": {
+      "type": "string",
+      "title": "URL",
+      "description": "Filter resource discriminator describing the body's source format (e.g. WASM module identifier or external resource path).",
+      "x-rjsf-grid-area": "12"
     }
   },
   "allOf": [
@@ -21,14 +42,6 @@
         }
       },
       "then": {
-        "properties": {
-          "filterFile": {
-            "type": "string",
-            "format": "byte",
-            "description": "Raw filter source as base64-encoded bytes. Optional on update — the server preserves the existing body when omitted.",
-            "x-rjsf-grid-area": "12"
-          }
-        },
         "required": ["filterFile"]
       }
     },
@@ -41,17 +54,9 @@
         }
       },
       "then": {
-        "properties": {
-          "filterResource": {
-            "type": "string",
-            "title": "URL",
-            "description": "Filter resource discriminator describing the body's source format (e.g. WASM module identifier or external resource path).",
-            "x-rjsf-grid-area": "12"
-          }
-        },
         "required": ["filterResource"]
       }
     }
   ],
-  "required": ["name"]
+  "required": ["name", "uploadType"]
 }

--- a/schemas/constructs/v1beta3/filter/forms/import.ui.json
+++ b/schemas/constructs/v1beta3/filter/forms/import.ui.json
@@ -1,0 +1,3 @@
+{
+  "ui:order": ["name", "uploadType", "filterFile", "filterResource"]
+}

--- a/schemas/constructs/v1beta3/filter/forms/import.ui.json
+++ b/schemas/constructs/v1beta3/filter/forms/import.ui.json
@@ -1,3 +1,6 @@
 {
+  "uploadType": {
+    "ui:widget": "radio"
+  },
   "ui:order": ["name", "uploadType", "filterFile", "filterResource"]
 }

--- a/typescript/forms/index.ts
+++ b/typescript/forms/index.ts
@@ -33,6 +33,22 @@ import createOrEditEnvironmentUiSchema from "../../schemas/constructs/v1beta3/en
 import createOrEditWorkspaceSchema from "../../schemas/constructs/v1beta3/workspace/forms/createOrEdit.json";
 import createOrEditWorkspaceUiSchema from "../../schemas/constructs/v1beta3/workspace/forms/createOrEdit.ui.json";
 
+// v1beta3/design
+import importDesignSchema from "../../schemas/constructs/v1beta3/design/forms/import.json";
+import importDesignUiSchema from "../../schemas/constructs/v1beta3/design/forms/import.ui.json";
+
+// v1beta2/model
+import importModelSchema from "../../schemas/constructs/v1beta2/model/forms/import.json";
+import importModelUiSchema from "../../schemas/constructs/v1beta2/model/forms/import.ui.json";
+
+// v1beta3/filter
+import importFilterSchema from "../../schemas/constructs/v1beta3/filter/forms/import.json";
+import importFilterUiSchema from "../../schemas/constructs/v1beta3/filter/forms/import.ui.json";
+
+// v1beta3/connection
+import helmCreateConnectionSchema from "../../schemas/constructs/v1beta3/connection/forms/helmCreate.json";
+import helmCreateConnectionUiSchema from "../../schemas/constructs/v1beta3/connection/forms/helmCreate.ui.json";
+
 // v1beta1/credential
 import kubernetesCredentialSchema from "../../schemas/constructs/v1beta1/credential/forms/kubernetes.json";
 import kubernetesCredentialUiSchema from "../../schemas/constructs/v1beta1/credential/forms/kubernetes.ui.json";
@@ -40,6 +56,18 @@ import grafanaCredentialSchema from "../../schemas/constructs/v1beta1/credential
 import grafanaCredentialUiSchema from "../../schemas/constructs/v1beta1/credential/forms/grafana.ui.json";
 import prometheusCredentialSchema from "../../schemas/constructs/v1beta1/credential/forms/prometheus.json";
 import prometheusCredentialUiSchema from "../../schemas/constructs/v1beta1/credential/forms/prometheus.ui.json";
+
+export const DesignImportRjsfSchemaV1Beta3 = importDesignSchema as RJSFSchema;
+export const DesignImportRjsfUiSchemaV1Beta3 = importDesignUiSchema as UiSchema;
+
+export const ModelImportRjsfSchemaV1Beta2 = importModelSchema as RJSFSchema;
+export const ModelImportRjsfUiSchemaV1Beta2 = importModelUiSchema as UiSchema;
+
+export const FilterImportRjsfSchemaV1Beta3 = importFilterSchema as RJSFSchema;
+export const FilterImportRjsfUiSchemaV1Beta3 = importFilterUiSchema as UiSchema;
+
+export const ConnectionHelmCreateRjsfSchemaV1Beta3 = helmCreateConnectionSchema as RJSFSchema;
+export const ConnectionHelmCreateRjsfUiSchemaV1Beta3 = helmCreateConnectionUiSchema as UiSchema;
 
 export const CatalogPublishRjsfSchemaV1Beta2 = publishCatalogSchema as RJSFSchema;
 export const CatalogPublishRjsfUiSchemaV1Beta2 = publishCatalogUiSchema as UiSchema;

--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -158,16 +158,24 @@ export namespace v1beta1 {
 export {
   CatalogPublishRjsfSchemaV1Beta2,
   CatalogPublishRjsfUiSchemaV1Beta2,
+  ConnectionHelmCreateRjsfSchemaV1Beta3,
+  ConnectionHelmCreateRjsfUiSchemaV1Beta3,
+  DesignImportRjsfSchemaV1Beta3,
+  DesignImportRjsfUiSchemaV1Beta3,
   EnvironmentCreateOrEditRjsfSchemaV1Beta3,
   EnvironmentCreateOrEditRjsfUiSchemaV1Beta3,
-  WorkspaceCreateOrEditRjsfSchemaV1Beta3,
-  WorkspaceCreateOrEditRjsfUiSchemaV1Beta3,
-  KubernetesCredentialRjsfSchemaV1Beta1,
-  KubernetesCredentialRjsfUiSchemaV1Beta1,
+  FilterImportRjsfSchemaV1Beta3,
+  FilterImportRjsfUiSchemaV1Beta3,
   GrafanaCredentialRjsfSchemaV1Beta1,
   GrafanaCredentialRjsfUiSchemaV1Beta1,
+  KubernetesCredentialRjsfSchemaV1Beta1,
+  KubernetesCredentialRjsfUiSchemaV1Beta1,
+  ModelImportRjsfSchemaV1Beta2,
+  ModelImportRjsfUiSchemaV1Beta2,
   PrometheusCredentialRjsfSchemaV1Beta1,
-  PrometheusCredentialRjsfUiSchemaV1Beta1
+  PrometheusCredentialRjsfUiSchemaV1Beta1,
+  WorkspaceCreateOrEditRjsfSchemaV1Beta3,
+  WorkspaceCreateOrEditRjsfUiSchemaV1Beta3
 } from "./forms";
 
 export namespace v1beta2 {

--- a/validation/forms_test.go
+++ b/validation/forms_test.go
@@ -80,6 +80,26 @@ var formCases = []formCase{
 		canonical: "schemas/constructs/v1beta1/credential/api.yml#/components/schemas/Credential",
 		form:      "schemas/constructs/v1beta1/credential/forms/prometheus.json",
 	},
+	{
+		name:      "v1beta3/design/import",
+		canonical: "schemas/constructs/v1beta3/design/api.yml#/components/schemas/MesheryPatternImportFormPayload",
+		form:      "schemas/constructs/v1beta3/design/forms/import.json",
+	},
+	{
+		name:      "v1beta2/model/import",
+		canonical: "schemas/constructs/v1beta2/model/api.yml#/components/schemas/ImportRequest",
+		form:      "schemas/constructs/v1beta2/model/forms/import.json",
+	},
+	{
+		name:      "v1beta3/filter/import",
+		canonical: "schemas/constructs/v1beta3/filter/api.yml#/components/schemas/MesheryFilterPayload",
+		form:      "schemas/constructs/v1beta3/filter/forms/import.json",
+	},
+	{
+		name:      "v1beta3/connection/helmCreate",
+		canonical: "schemas/constructs/v1beta3/connection/connection.yaml",
+		form:      "schemas/constructs/v1beta3/connection/forms/helmCreate.json",
+	},
 }
 
 func TestFormSchemasAreSubsetOfCanonical(t *testing.T) {

--- a/validation/forms_test.go
+++ b/validation/forms_test.go
@@ -87,7 +87,7 @@ var formCases = []formCase{
 	},
 	{
 		name:      "v1beta2/model/import",
-		canonical: "schemas/constructs/v1beta2/model/api.yml#/components/schemas/ImportRequest",
+		canonical: "schemas/constructs/v1beta2/model/api.yml#/components/schemas/MesheryModelImportFormPayload",
 		form:      "schemas/constructs/v1beta2/model/forms/import.json",
 	},
 	{

--- a/validation/forms_test.go
+++ b/validation/forms_test.go
@@ -92,7 +92,7 @@ var formCases = []formCase{
 	},
 	{
 		name:      "v1beta3/filter/import",
-		canonical: "schemas/constructs/v1beta3/filter/api.yml#/components/schemas/MesheryFilterPayload",
+		canonical: "schemas/constructs/v1beta3/filter/api.yml#/components/schemas/MesheryFilterImportFormPayload",
 		form:      "schemas/constructs/v1beta3/filter/forms/import.json",
 	},
 	{


### PR DESCRIPTION
## Summary

Closes phase 1 of #866 — moves the authoritative source for 10 hand-authored RJSF form schemas from `layer5io/sistent` into `@meshery/schemas`.

Six schemas were already present from prior work (publishCatalogItem, createAndEditEnvironment, createAndEditWorkspace, kubernetesCredential, grafanaCredential, prometheusCredential). This PR adds the remaining 4:

- **`v1beta3/design/forms/import.json`** — design import form (File Upload / URL Import discriminator). Backed by new `MesheryPatternImportFormPayload` canonical that unions both import payload variants.
- **`v1beta2/model/forms/import.json`** — model import form. Backed by `ImportRequest` (which already had `uploadType`).
- **`v1beta3/filter/forms/import.json`** — filter import form. Backed by `MesheryFilterPayload` (`name`, `filterFile`, `filterResource`).
- **`v1beta3/connection/forms/helmCreate.json`** — Helm repository connection create form. Backed by `v1beta3/connection/connection.yaml`.

## Canonical schema additions

- **`v1beta3/connection/connection.yaml`**: Added `description` (string, max 1000) and `url` (string, format: uri, max 2048) fields. These were legitimate omissions — the Helm connection form in sistent exposed the gap; connections clearly have a description and a remote URL.
- **`v1beta3/design/api.yml`**: Added `MesheryPatternImportFormPayload` — a flat canonical schema that unions the File and URL import payload fields with the UI-level `uploadType` discriminator. This is the authoritative source for the design import form, enabling the subset validator to verify the form doesn't introduce drift.

## Drift found beyond the published catalog item example

| Sistent schema | Drift found |
|---|---|
| `importDesign` | No direct canonical — used `oneOf` without a discriminator field; fixed by adding `MesheryPatternImportFormPayload` |
| `importFilter` | Used hand-authored `name`, `config`, `uploadType`, `file`, `url` — canonical is `MesheryFilterPayload` with `name`, `filterFile`, `filterResource` |
| `helmConnection` | Missing `description` and `url` from `v1beta3/connection` canonical — fixed by adding those fields |
| `importModel` | Good: `uploadType` enum values now canonically locked to `["file", "urlImport", "csv"]` (canonical `ImportRequest`) instead of the sistent form's display labels |

## Validation

All `TestFormSchema*` tests pass:
- `TestFormSchemasAreSubsetOfCanonical` — 10 form schemas, all pass
- `TestEveryFormJsonHasCaseTableEntry` — all form JSONs have test rows
- `TestEveryFormHasUiSchemaPair` — all schemas have `.ui.json` siblings
- `TestFormSchemasIndexExportsExist` — all JSON files imported in `typescript/forms/index.ts`
- `TestFormExportsFollowVersionConvention` — all exports follow naming convention

`TestConsumerTS_IntegrationAgainstMesheryExtensions` failure is pre-existing on the base branch and unrelated to these changes.

## Phase 2

Layer5io/sistent phase 2 (re-export flip) is tracked separately and will follow once this PR lands or is in a mergeable state.

## Test plan

- [x] `go test ./validation/... -run TestForm` passes (all 10 form cases green)
- [x] All 4 new form JSONs have sibling `.ui.json` files
- [x] All 4 new forms registered in `formCases` table in `forms_test.go`
- [x] All new exports added to `typescript/forms/index.ts` and `typescript/index.ts`
- [x] Export names follow `<Construct><Action>RjsfSchemaV<Version>` convention