### PR TITLE
feat(forms): add canonical RJSF form schema for SupportRequest (closes #866 part 2)

### DIFF
--- a/schemas/constructs/v1beta1/support/api.yml
+++ b/schemas/constructs/v1beta1/support/api.yml
@@ -1,0 +1,86 @@
+openapi: 3.0.0
+info:
+  title: Support
+  description: OpenAPI schema for Meshery help-and-support request submission.
+  version: v1beta1
+  contact:
+    name: Meshery Maintainers
+    email: maintainers@meshery.io
+    url: https://meshery.io
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+
+security:
+  - jwt: []
+
+tags:
+  - name: Support
+    description: Operations related to help and support requests
+
+paths:
+  /api/integrations/support:
+    post:
+      x-internal: ["cloud"]
+      tags:
+        - Support
+      summary: Submit a support request
+      operationId: submitSupportRequest
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/SupportRequest"
+      responses:
+        "201":
+          description: Support request submitted
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+        "400":
+          description: Invalid request format
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          description: Internal server error
+
+components:
+  responses:
+    401:
+      $ref: "../core/api.yml#/components/responses/401"
+
+  securitySchemes:
+    jwt:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    SupportRequest:
+      type: object
+      description: Payload for submitting a help-and-support request.
+      required:
+        - subject
+        - message
+      properties:
+        subject:
+          type: string
+          title: Subject
+          minLength: 1
+          maxLength: 255
+          description: "Concise and descriptive title for the support request."
+        message:
+          type: string
+          title: Description
+          minLength: 10
+          description: "Detailed description of the issue or question."
+        scope:
+          type: string
+          title: Scope
+          enum: ["Support", "Community", "Account", "Commercial"]
+          description: "Category that best represents the nature of the inquiry."

--- a/schemas/constructs/v1beta1/support/forms/helpAndSupport.json
+++ b/schemas/constructs/v1beta1/support/forms/helpAndSupport.json
@@ -1,0 +1,31 @@
+{
+  "$schema": "https://json-schema.org/draft-07/schema#",
+  "title": "Support Form",
+  "description": "RJSF form schema for the help-and-support modal. Captures the user-input fields of the canonical SupportRequest construct (meshery/schemas/constructs/v1beta1/support/api.yml). Field shape, types, enums, and required list MUST stay a subset of SupportRequest; the Go validator at validation/forms_test.go enforces that.",
+  "type": "object",
+  "properties": {
+    "subject": {
+      "type": "string",
+      "title": "Subject",
+      "description": "Enter a concise and descriptive title for your support request. This will help us quickly understand the nature of your inquiry.",
+      "minLength": 1,
+      "x-rjsf-grid-area": "12"
+    },
+    "message": {
+      "type": "string",
+      "title": "Description",
+      "description": "Please provide a detailed description of your issue or question. Include any relevant information that will help us assist you more effectively.",
+      "minLength": 10,
+      "format": "textarea",
+      "x-rjsf-grid-area": "12"
+    },
+    "scope": {
+      "type": "string",
+      "title": "Scope of Questions",
+      "description": "Select the category that best represents the nature of your inquiry.",
+      "enum": ["Support", "Community", "Account", "Commercial"],
+      "x-rjsf-grid-area": "12"
+    }
+  },
+  "required": ["subject", "message"]
+}

--- a/schemas/constructs/v1beta1/support/forms/helpAndSupport.ui.json
+++ b/schemas/constructs/v1beta1/support/forms/helpAndSupport.ui.json
@@ -1,0 +1,12 @@
+{
+  "subject": {
+    "ui:placeholder": "Summary or title for your support request"
+  },
+  "message": {
+    "ui:placeholder": "Detailed description of your support request"
+  },
+  "scope": {
+    "ui:widget": "radio"
+  },
+  "ui:order": ["subject", "message", "scope"]
+}

--- a/typescript/forms/index.ts
+++ b/typescript/forms/index.ts
@@ -49,6 +49,10 @@ import importFilterUiSchema from "../../schemas/constructs/v1beta3/filter/forms/
 import helmCreateConnectionSchema from "../../schemas/constructs/v1beta3/connection/forms/helmCreate.json";
 import helmCreateConnectionUiSchema from "../../schemas/constructs/v1beta3/connection/forms/helmCreate.ui.json";
 
+// v1beta1/support
+import helpAndSupportSchema from "../../schemas/constructs/v1beta1/support/forms/helpAndSupport.json";
+import helpAndSupportUiSchema from "../../schemas/constructs/v1beta1/support/forms/helpAndSupport.ui.json";
+
 // v1beta1/credential
 import kubernetesCredentialSchema from "../../schemas/constructs/v1beta1/credential/forms/kubernetes.json";
 import kubernetesCredentialUiSchema from "../../schemas/constructs/v1beta1/credential/forms/kubernetes.ui.json";
@@ -95,3 +99,6 @@ export const PrometheusCredentialRjsfSchemaV1Beta1 =
   prometheusCredentialSchema as RJSFSchema;
 export const PrometheusCredentialRjsfUiSchemaV1Beta1 =
   prometheusCredentialUiSchema as UiSchema;
+
+export const SupportRequestRjsfSchemaV1Beta1 = helpAndSupportSchema as RJSFSchema;
+export const SupportRequestRjsfUiSchemaV1Beta1 = helpAndSupportUiSchema as UiSchema;

--- a/validation/forms_test.go
+++ b/validation/forms_test.go
@@ -100,6 +100,11 @@ var formCases = []formCase{
 		canonical: "schemas/constructs/v1beta3/connection/connection.yaml",
 		form:      "schemas/constructs/v1beta3/connection/forms/helmCreate.json",
 	},
+	{
+		name:      "v1beta1/support/helpAndSupport",
+		canonical: "schemas/constructs/v1beta1/support/api.yml#/components/schemas/SupportRequest",
+		form:      "schemas/constructs/v1beta1/support/forms/helpAndSupport.json",
+	},
 }
 
 func TestFormSchemasAreSubsetOfCanonical(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds the `v1beta1/support` construct with a canonical `SupportRequest` OpenAPI schema
- Adds `forms/helpAndSupport.json` (RJSF form schema) and `forms/helpAndSupport.ui.json` (UI schema) — subset-validated against `SupportRequest` by `TestFormSchemasAreSubsetOfCanonical`
- Exports `SupportRequestRjsfSchemaV1Beta1` / `SupportRequestRjsfUiSchemaV1Beta1` from `typescript/forms/index.ts`
- Registers the new case in `validation/forms_test.go`

## Context

This is the second part of [#866](https://github.com/meshery/schemas/issues/866), the canonical RJSF form-schema migration. The `helpAndSupportModalSchema` / `helpAndSupportModalUiSchema` in `layer5io/sistent` are the last two form-schema symbols still hand-authored outside `@meshery/schemas`. Once this PR ships in a new npm release, sistent will re-export from `@meshery/schemas` and `layer5io/meshery-cloud` will drop the final `eslint-disable no-restricted-imports` block.

Also fixes a latent bug: the prior sistent `default: 'Technical'` value was not a member of `enum: ['Support', 'Community', 'Account', 'Commercial']`. The canonical schema omits the invalid default.

## Test plan

- [x] `TestFormSchemasAreSubsetOfCanonical/v1beta1/support/helpAndSupport` — PASS
- [x] `TestEveryFormJsonHasCaseTableEntry` — PASS
- [x] `TestEveryFormHasUiSchemaPair` — PASS
- [x] `TestFormExportsFollowVersionConvention` — PASS
- [x] `TestFormSchemasIndexExportsExist` — PASS