### PR TITLE
fix(build): reduce Node.js heap limit from 8192 to 3584 MB to fit CI runner

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "NODE_OPTIONS=--max-old-space-size=8192 tsup",
+    "build": "NODE_OPTIONS=--max-old-space-size=3584 tsup",
     "build:bundle": "node ./build/bundle-openapi.js",
     "build:golang": "node ./build/generate-golang.js",
     "build:rtk": "node ./build/generate-rtk.js",


### PR DESCRIPTION
## Root cause

The ubuntu-24.04 GitHub Actions runner has 7 GB of total RAM. With
`NODE_OPTIONS=--max-old-space-size=8192`, the tsup DTS worker defers
garbage collection until it can try to claim 8 GB of heap, exceeding
the physical limit and crashing with `ERR_WORKER_OUT_OF_MEMORY` in the
`make build-ts` step of the Generate Artifacts workflow.

PR #873 (feat/v1beta3-academy-cut) added ~50 K lines of generated
TypeScript (`AcademySchema.ts`, `Academy.ts`), pushing the total
generated corpus from ~447 K to ~497 K lines. This tipped the lazy-GC
peak past the available physical memory on the CI runner, causing the
Generate Artifacts workflow to fail on every push to master since then.

## Fix

Reduce `--max-old-space-size` from 8192 to 3584 MB (3.5 GB).

V8 defers GC until the heap reaches the configured limit. At 8192 MB,
V8 accumulates dead heap until it hits the OS out-of-memory boundary
on a 7 GB runner. At 3584 MB, V8 collects garbage aggressively enough
to keep peak memory within the runner's budget — the live DTS data is
well under 3.5 GB at any point.

## Test plan

- [x] `grep max-old-space package.json` — confirms 3584
- [ ] Generate Artifacts workflow passes on merge to master (primary validation)