### PR TITLE
fix(build): split tsup config to prevent DTS worker OOM on CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ generate-ts:
 
 ## Bundle Typescript library, json templates, yaml templates
 build-ts: generate-ts
+	rm -rf dist/
 	npm run build
 	node build/generate-schema-dts.js
 

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ generate-ts:
 ## Bundle Typescript library, json templates, yaml templates
 build-ts: generate-ts
 	npm run build
+	node build/generate-schema-dts.js
 
 ## Publish schemas package to @meshery/schemas on npmjs.com
 publish-ts: build-ts

--- a/build/generate-schema-dts.js
+++ b/build/generate-schema-dts.js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Generates minimal TypeScript declaration (.d.ts) files for the generated
+ * construct schemas under dist/constructs/.
+ *
+ * Why this exists
+ * ---------------
+ * tsup's DTS worker loads ALL entry-point files into a single in-memory
+ * TypeScript program before emitting declarations. With 144 generated
+ * construct files totalling ~497 K lines (DesignSchema.ts alone is 55 K
+ * lines), the worker exhausts the 7 GB available on the ubuntu-24.04 CI
+ * runner. To avoid this, the generated entries are built with `dts: false`
+ * in tsup, and this script emits their declarations directly — no
+ * TypeScript compiler invocation needed.
+ *
+ * Declaration shapes
+ * ------------------
+ * *Schema.ts  — `const X: Record<string, unknown>` + `export default X`
+ *   DTS: `declare const X: Record<string, unknown>;\nexport default X;\n`
+ *
+ * *.ts (API types) — pure `export interface` / `export type` blocks,
+ *   no value declarations, no imports.
+ *   DTS: copy the source file verbatim (interface declarations are
+ *   identical in .ts and .d.ts).
+ */
+
+const fs = require("fs");
+const path = require("path");
+const { globSync } = require("glob");
+
+const generatedFiles = globSync("typescript/generated/**/*.ts");
+
+let count = 0;
+for (const src of generatedFiles) {
+  // Map typescript/generated/v1beta3/academy/AcademySchema.ts
+  //  → dist/constructs/v1beta3/academy/AcademySchema.d.ts
+  const dtsPath = src
+    .replace("typescript/generated", "dist/constructs")
+    .replace(/\.ts$/, ".d.ts");
+
+  fs.mkdirSync(path.dirname(dtsPath), { recursive: true });
+
+  if (src.endsWith("Schema.ts")) {
+    // All generated *Schema.ts files are:
+    //   const XSchema: Record<string, unknown> = { ... };
+    //   export default XSchema;
+    // The declaration is two lines regardless of the value's size.
+    const name = path.basename(src, ".ts");
+    fs.writeFileSync(
+      dtsPath,
+      `declare const ${name}: Record<string, unknown>;\nexport default ${name};\n`,
+    );
+  } else {
+    // Generated API-types files (Academy.ts, Design.ts, …) contain only
+    // `export interface` and `export type` declarations — no implementations.
+    // They are valid .d.ts content verbatim.
+    fs.copyFileSync(src, dtsPath);
+  }
+
+  count++;
+}
+
+console.log(`generate-schema-dts: wrote ${count} .d.ts files`);

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "NODE_OPTIONS=--max-old-space-size=3584 tsup",
+    "build": "NODE_OPTIONS=--max-old-space-size=8192 tsup",
     "build:bundle": "node ./build/bundle-openapi.js",
     "build:golang": "node ./build/generate-golang.js",
     "build:rtk": "node ./build/generate-rtk.js",

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -19,21 +19,39 @@ const generatedEntries = generatedFiles.reduce(
   {} as Record<string, string>,
 );
 
-export default defineConfig({
-  entry: {
-    index: "typescript/index.ts",
-    cloudApi: "typescript/rtk/cloud.ts",
-    mesheryApi: "typescript/rtk/meshery.ts",
-    api: "typescript/rtk/api.ts",
-    permissions: "typescript/permissions.ts",
-    ...generatedEntries,
-  },
-  format: ["cjs", "esm"],
+const sharedOptions = {
+  format: ["cjs", "esm"] as const,
   external: ["react", "react-dom", "react-redux", "@reduxjs/toolkit"],
-  dts: true,
   splitting: false,
   sourcemap: false,
   treeshake: true,
   minify: true,
-  clean: true,
-});
+};
+
+export default defineConfig([
+  {
+    // Main API surface — small files, full DTS via tsup's rollup worker.
+    // Keep this set small: the worker processes all entry files in one
+    // in-memory TypeScript program; adding large generated constructs here
+    // causes ERR_WORKER_OUT_OF_MEMORY on the 7 GB ubuntu-24.04 CI runner.
+    ...sharedOptions,
+    entry: {
+      index: "typescript/index.ts",
+      cloudApi: "typescript/rtk/cloud.ts",
+      mesheryApi: "typescript/rtk/meshery.ts",
+      api: "typescript/rtk/api.ts",
+      permissions: "typescript/permissions.ts",
+    },
+    dts: true,
+    clean: true,
+  },
+  {
+    // Generated construct schemas — large files (497 K lines total), JS only.
+    // DTS for these is emitted by build/generate-schema-dts.js which writes
+    // minimal declarations without running the full TypeScript type-checker.
+    ...sharedOptions,
+    entry: generatedEntries,
+    dts: false,
+    clean: false,
+  },
+]);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,14 +1,16 @@
 import { defineConfig } from "tsup";
 import { globSync } from "glob";
 
-// Get all TypeScript Schema files under generated folder (exclude .d.ts files)
-const generatedFiles = globSync("typescript/generated/**/*.ts");
+// Exclude any pre-existing .d.ts files; only process .ts source files.
+const generatedFiles = globSync("typescript/generated/**/*.ts", {
+  ignore: ["**/*.d.ts"],
+});
 
 // Create entry points for each generated file
 const generatedEntries = generatedFiles.reduce(
   (acc, file) => {
     // Convert path like "typescript/generated/v1beta1/model/ModelSchema.ts"
-    // to entry name like "generated/v1beta1/model/ModelSchema"
+    // to entry name like "constructs/v1beta1/model/ModelSchema"
     const entryName = file
       .replace("typescript/", "")
       .replace("generated", "constructs")
@@ -26,6 +28,10 @@ const sharedOptions = {
   sourcemap: false,
   treeshake: true,
   minify: true,
+  // clean is handled by the Makefile (rm -rf dist/) before invoking tsup so
+  // that both configs can write to dist/ without a parallel-clean race.
+  // See build-ts target in Makefile.
+  clean: false,
 };
 
 export default defineConfig([
@@ -43,7 +49,6 @@ export default defineConfig([
       permissions: "typescript/permissions.ts",
     },
     dts: true,
-    clean: true,
   },
   {
     // Generated construct schemas — large files (497 K lines total), JS only.
@@ -52,6 +57,5 @@ export default defineConfig([
     ...sharedOptions,
     entry: generatedEntries,
     dts: false,
-    clean: false,
   },
 ]);


### PR DESCRIPTION
## Root cause

tsup's DTS worker loads ALL entry-point files into a single in-memory
TypeScript program before emitting declarations. The generated construct
corpus is ~497 K lines across 144 files (DesignSchema.ts is 55 K lines,
PatternSchema.ts 54 K, AcademySchema.ts 17 K × 3 versions). The full V8
AST for this exceeds the 7 GB physical RAM of the ubuntu-24.04 CI runner,
causing `ERR_WORKER_OUT_OF_MEMORY` in `make build-ts` on every push to
master since PR #873 added the v1beta3 academy construct.

Reducing `--max-old-space-size` (PR #879) doesn't help: the **live** AST
data is ~5 GB, and no GC schedule can reduce live objects below their
actual size.

## Fix

**Split `tsup.config.ts` into two configs:**

| Config | Entries | DTS |
|---|---|---|
| 1 | `index`, `cloudApi`, `mesheryApi`, `api`, `permissions` | `true` — five small files, worker has ample headroom |
| 2 | 144 generated construct schemas | `false` — JS/MJS only |

**Add `build/generate-schema-dts.js`** — a lightweight Node.js script
(no TypeScript compiler invocation) that writes minimal `.d.ts` files for
each generated construct:

- `*Schema.ts` → `declare const X: Record<string, unknown>;\nexport default X;`
- `*.ts` (API types: `Academy.ts`, `Design.ts`, …) → copy verbatim;
  these contain only `export interface` / `export type` blocks which are
  valid `.d.ts` content as-is.

**Update `Makefile` `build-ts`** to run the DTS generator after tsup.

**Restore `package.json` heap limit to 8192 MB** — the DTS worker now
handles only five entries, well within the runner's budget.

## Verification

```
npm run build && node build/generate-schema-dts.js
# → build succeeds in ~13 s, no OOM
# → 144 .d.ts files written under dist/constructs/
```

Sample output:
```
dist/constructs/v1beta3/academy/AcademySchema.d.ts:
  declare const AcademySchema: Record<string, unknown>;
  export default AcademySchema;

dist/constructs/v1beta3/academy/Academy.d.ts:
  (copy of Academy.ts — pure interface declarations)
```

## Test plan

- [x] `npm run build` completes without OOM locally
- [x] `node build/generate-schema-dts.js` writes 144 `.d.ts` files
- [x] `dist/constructs/v1beta3/academy/AcademySchema.d.ts` is correct
- [ ] Generate Artifacts workflow passes on merge (primary CI gate)