### PR TITLE
feat(forms): export RJSFSchema / UiSchema types (#871)

### DIFF
--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -180,6 +180,13 @@ export {
   WorkspaceCreateOrEditRjsfUiSchemaV1Beta3
 } from "./forms";
 
+// Public types for the canonical RJSF form-schema artifacts. Exported so
+// downstream consumers (sistent, meshery, meshery-cloud) can name the
+// shape when they spread or otherwise derive variants from a canonical
+// schema — without that, tsup's DTS bundler errors on emitted .d.ts
+// references to a type declared but never re-exported. See #871.
+export type { RJSFSchema, UiSchema } from "./forms/types";
+
 export namespace v1beta2 {
   export type Academy =
     V1Beta2AcademyComponents["schemas"]["AcademyCurricula"];


### PR DESCRIPTION
## Summary

Adds `export type { RJSFSchema, UiSchema } from "./forms/types"` to the top-level `typescript/index.ts` so downstream consumers can name the form-schema shape when they spread or otherwise derive variants from a canonical schema.

Closes #871.

## Why

The `RJSFSchema` and `UiSchema` types have existed since v1.2.8 but only as internal types backing the `as RJSFSchema` casts in `typescript/forms/index.ts`. tsup's DTS bundler included the type declarations in the emitted `dist/index.d.ts` but never put them in the public `export { ... }` clause, so consumer code that infers the type via spread errored at DTS bundling with `TS4023`:

```
src/schemas/createAndEditWorkspace/schema.tsx(35,7): error TS4023:
  Exported variable 'editWorkspace' has or is using name 'RJSFSchema'
  from external module ".../@meshery/schemas/dist/index" but cannot
  be named.
```

Sistent v0.21.4 worked around this by typing the affected derivation as `Record<string, unknown>`, which loses precision. This PR removes the need for that workaround.

## After this change

```ts
import type { RJSFSchema } from "@meshery/schemas";

const editWorkspace: RJSFSchema = {
  ...WorkspaceCreateOrEditRjsfSchemaV1Beta3,
  required: ["organizationId"],
};
```

…compiles cleanly across consumers.

## Test plan

- [x] `go test ./validation/ -run TestFormSchemas` — still passes (no Go surface change; this is a TS-only addition).
- [x] `npm run build` — tsup ESM/CJS + DTS green.
- [x] `dist/index.d.ts` now includes `type RJSFSchema` and `type UiSchema` in the top-level `export { ... }` clause (verified via grep).
- [ ] Follow-up in sistent: replace the `Record<string, unknown>` workaround in `editWorkspace` with `RJSFSchema` once a `@meshery/schemas` release including this change ships and sistent bumps its dep.

Refs: [#866](https://github.com/meshery/schemas/issues/866), [#867](https://github.com/meshery/schemas/pull/867).