### PR TITLE
feat(forms): add enumNames to MesheryModelImportFormPayload uploadType

### DIFF
--- a/schemas/constructs/v1beta2/model/api.yml
+++ b/schemas/constructs/v1beta2/model/api.yml
@@ -317,6 +317,10 @@ components:
           title: "Upload method"
           x-enum-casing-exempt: true
           enum: ["file", "urlImport", "csv"]
+          # Human-readable labels for the upload-type discriminator. RJSF
+          # consumers (e.g. the meshery UI radio group) surface these instead
+          # of the raw lowercase tokens.
+          enumNames: ["File Import", "URL Import", "CSV Import"]
           description: "Choose the method you prefer. Select 'File Import' or 'CSV Import' if you have the file on your local system, or 'URL Import' if you have the file hosted online."
         fileName:
           type: string

--- a/schemas/constructs/v1beta2/model/forms/import.json
+++ b/schemas/constructs/v1beta2/model/forms/import.json
@@ -8,6 +8,7 @@
       "type": "string",
       "title": "Upload method",
       "enum": ["file", "urlImport", "csv"],
+      "enumNames": ["File Import", "URL Import", "CSV Import"],
       "description": "Choose the method you prefer to upload your model file. Select 'File Import' or 'CSV Import' if you have the file on your local system, or 'URL Import' if you have the file hosted online.",
       "x-rjsf-grid-area": "12"
     },


### PR DESCRIPTION
## Summary

The canonical RJSF form schema for import-model (`schemas/constructs/v1beta2/model/forms/import.json`) and its authoritative OpenAPI source (`schemas/constructs/v1beta2/model/api.yml#MesheryModelImportFormPayload`) declared `uploadType.enum` as the lowercase tokens `["file", "urlImport", "csv"]` with no `enumNames`. RJSF consumers (meshery UI, meshery-extensions) had no human-readable label to surface, so the radio group rendered the raw tokens — even though the field's own description refers to "File Import" / "URL Import" / "CSV Import" labels the schema didn't expose.

Add `enumNames: ["File Import", "URL Import", "CSV Import"]` to both the canonical and the form, in the same order as the enum tokens. RJSF's `enumOptions` will now surface the friendly label as `option.label` while the tokens remain the wire values, matching the copy already in the field description.

## Validation

- `go test ./validation/... -run TestForm -count=1` ✅ — the subset validator's `schemaNode` doesn't parse `enumNames` (it isn't a JSON-Schema validation keyword), so the existing strict subset rules continue to pass.

## Companion PR

Companion to [meshery/meshery#19146](https://github.com/meshery/meshery/pull/19146) — the meshery UI imports this schema directly via `ModelImportRjsfSchemaV1Beta2` and will surface the friendly labels automatically once a published version ships these enumNames.

## Test plan

- [ ] Subset validator passes (verified locally).
- [ ] Once published and consumed by meshery UI, radio group shows "File Import" / "URL Import" / "CSV Import".
- [ ] Once that lands, simplify meshery's e2e test selectors back to the friendly headings.