### PR TITLE
chore(forms): drop `$schema: draft-07` from canonical RJSF form schemas

### DIFF
--- a/schemas/constructs/v1beta1/credential/forms/grafana.json
+++ b/schemas/constructs/v1beta1/credential/forms/grafana.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Grafana",
   "description": "RJSF form schema for creating a Grafana credential. Captures the user-input fields of the canonical Credential construct; the `secret` object is the grafana-specific shape persisted under the canonical free-form `secret` map. Field shape, types, enums, and required list MUST stay a subset of meshery/schemas/constructs/v1beta1/credential/api.yml#/components/schemas/Credential; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",

--- a/schemas/constructs/v1beta1/credential/forms/kubernetes.json
+++ b/schemas/constructs/v1beta1/credential/forms/kubernetes.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Kubernetes",
   "description": "RJSF form schema for creating a Kubernetes credential. Captures the user-input fields of the canonical Credential construct; the `secret` object is the kubernetes-specific shape persisted under the canonical free-form `secret` map. Field shape, types, enums, and required list MUST stay a subset of meshery/schemas/constructs/v1beta1/credential/api.yml#/components/schemas/Credential; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",

--- a/schemas/constructs/v1beta1/credential/forms/prometheus.json
+++ b/schemas/constructs/v1beta1/credential/forms/prometheus.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Prometheus",
   "description": "RJSF form schema for creating a Prometheus credential. Captures the user-input fields of the canonical Credential construct; the `secret` object is the prometheus-specific shape persisted under the canonical free-form `secret` map. Field shape, types, enums, and required list MUST stay a subset of meshery/schemas/constructs/v1beta1/credential/api.yml#/components/schemas/Credential; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",

--- a/schemas/constructs/v1beta1/support/forms/helpAndSupport.json
+++ b/schemas/constructs/v1beta1/support/forms/helpAndSupport.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Support Form",
   "description": "RJSF form schema for the help-and-support modal. Captures the user-input fields of the canonical SupportRequest construct (meshery/schemas/constructs/v1beta1/support/api.yml). Field shape, types, enums, and required list MUST stay a subset of SupportRequest; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",

--- a/schemas/constructs/v1beta2/catalog/forms/publish.json
+++ b/schemas/constructs/v1beta2/catalog/forms/publish.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Publish Catalog Item",
   "description": "RJSF form schema for the catalog publishing modal. Captures the user-input fields of the canonical Catalog construct (publishedVersion / class / snapshotURL are server-generated and intentionally absent). Field shape, types, enums, and required list MUST stay a subset of meshery/schemas/constructs/v1beta2/catalog/catalog.yaml; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",

--- a/schemas/constructs/v1beta2/model/forms/import.json
+++ b/schemas/constructs/v1beta2/model/forms/import.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Import Model",
   "description": "RJSF form schema for the import-model modal. Captures the user-input fields drawn from the canonical MesheryModelImportFormPayload schema in meshery/schemas/constructs/v1beta2/model/api.yml. The uploadType discriminator determines which branch's conditional required fields apply. Field shape, types, and required lists MUST stay a subset of the canonical MesheryModelImportFormPayload; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",

--- a/schemas/constructs/v1beta3/connection/forms/helmCreate.json
+++ b/schemas/constructs/v1beta3/connection/forms/helmCreate.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Helm Repository Connection",
   "description": "RJSF form schema for configuring a Helm repository connection. Captures the user-input fields drawn from the canonical Connection construct in meshery/schemas/constructs/v1beta3/connection/connection.yaml. Field shape, types, and required lists MUST stay a subset of the canonical Connection; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",

--- a/schemas/constructs/v1beta3/design/forms/import.json
+++ b/schemas/constructs/v1beta3/design/forms/import.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Import Design",
   "description": "RJSF form schema for the import-design modal. Captures the user-input fields drawn from the canonical MesheryPatternImportFormPayload schema in meshery/schemas/constructs/v1beta3/design/api.yml. The uploadType discriminator determines which branch's conditional required fields apply. Field shape, types, and required lists MUST stay a subset of the canonical schema components; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",

--- a/schemas/constructs/v1beta3/environment/forms/createOrEdit.json
+++ b/schemas/constructs/v1beta3/environment/forms/createOrEdit.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Environment",
   "description": "RJSF form schema for the create-or-edit environment modal. Captures the user-input fields of the canonical Environment construct (id / schemaVersion / owner / createdAt / updatedAt / deletedAt are server-generated and intentionally absent). Field shape, types, enums, and required list MUST stay a subset of meshery/schemas/constructs/v1beta3/environment/environment.yaml; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",

--- a/schemas/constructs/v1beta3/filter/forms/import.json
+++ b/schemas/constructs/v1beta3/filter/forms/import.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Import Filter",
   "description": "RJSF form schema for the import-filter modal. Captures the user-input fields drawn from the canonical MesheryFilterImportFormPayload schema in meshery/schemas/constructs/v1beta3/filter/api.yml. The uploadType discriminator selects between File Upload and URL Upload import methods. Field shape, types, and required lists MUST stay a subset of the canonical MesheryFilterImportFormPayload; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",

--- a/schemas/constructs/v1beta3/workspace/forms/createOrEdit.json
+++ b/schemas/constructs/v1beta3/workspace/forms/createOrEdit.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://json-schema.org/draft-07/schema#",
   "title": "Workspace",
   "description": "RJSF form schema for the create-or-edit workspace modal. Captures the user-input fields of the canonical Workspace construct (id / owner / metadata / createdAt / updatedAt / deletedAt are server-generated and intentionally absent). Field shape, types, enums, and required list MUST stay a subset of meshery/schemas/constructs/v1beta3/workspace/workspace.yaml; the Go validator at validation/forms_test.go enforces that.",
   "type": "object",


### PR DESCRIPTION
Closes #892.

## Summary

Strips `"$schema": "https://json-schema.org/draft-07/schema#"` from 11 canonical RJSF form schemas under `schemas/constructs/**/forms/*.json`. The declaration was a footgun for every downstream consumer: `@rjsf/validator-ajv8` defaults to Ajv2020, which doesn't ship the draft-07 metaschema, so any schema declaring `$schema: draft-07` triggers `Error: no schema with key or ref "https://json-schema.org/draft-07/schema#"` at compile time and consumer forms silently fail validation on submit.

Without the declaration, Ajv2020 uses its built-in default metaschema and validates these forms correctly (all features in use — object/string/enum, `allOf`, `if/then/else`, `const`, `format` — match between draft-07 and draft-2020-12).

## Files changed

`$schema` line removed from 11 form schemas:

- `v1beta1/credential/forms/grafana.json`
- `v1beta1/credential/forms/kubernetes.json`
- `v1beta1/credential/forms/prometheus.json`
- `v1beta1/support/forms/helpAndSupport.json`
- `v1beta2/catalog/forms/publish.json`
- `v1beta2/model/forms/import.json`
- `v1beta3/connection/forms/helmCreate.json`
- `v1beta3/design/forms/import.json`
- `v1beta3/environment/forms/createOrEdit.json`
- `v1beta3/filter/forms/import.json`
- `v1beta3/workspace/forms/createOrEdit.json`

## Test plan

- [x] `go test ./validation/...` — clean
- [x] `npm run build` — clean; rebuilt dist exports `DesignImportRjsfSchemaV1Beta3` with no `$schema` key
- [x] Standalone smoke test (vanilla `validator-ajv8` default + the rebuilt schema) — File Upload branch validates with 0 errors; URL Import branch validates with 0 errors; missing-field cases produce the correct conditional `required` errors
- [x] meshery-cloud `make ui-tests` (99 suites / 702 tests / tsc) — green against this build linked in via `npm pack` + tarball install

## Out-of-scope follow-ups

- **layer5io/sistent#1533** — centralize the RJSF wrapper component so cloud / meshery / meshery-extensions stop maintaining parallel validator setups.
- **layer5io/meshery-cloud#5272** — once a `@meshery/schemas` patch release ships with this change and consumers bump, the `customizeValidator(...)` workaround in that PR can be reverted.
- **layer5io/meshery-cloud#5273** — surface RJSF validation failures in the UI instead of the current silent dead-button behavior.