### PR TITLE
chore(rtk): rename CURRENT_ORG_KEY value from Layer5-Current-Orgid to X-Current-Orgid

### DIFF
--- a/typescript/rtk/api.ts
+++ b/typescript/rtk/api.ts
@@ -11,7 +11,7 @@ interface RootState {
 
 export const SUPPORTED_SOCIAL_ACCOUNTS = ["github", "google"];
 
-export const CURRENT_ORG_KEY = "Layer5-Current-Orgid";
+export const CURRENT_ORG_KEY = "X-Current-Orgid";
 export const DEFAULT_DESIGN_VERSION = "0.0.1";
 export const MESHERY_PROD_URL = "https://playground.meshery.io/";
 


### PR DESCRIPTION
## Summary

Strips the product-coupled \`Layer5-\` prefix from the cookie/header name used to convey the current organisation context across the \`mesheryApi\` RTK Query base. The JS identifier \`CURRENT_ORG_KEY\` is unchanged; only the string value changes.

| Before | After |
|---|---|
| \`"Layer5-Current-Orgid"\` | \`"X-Current-Orgid"\` |

## Downstream impact (lockstep deploy required)

- **meshery-cloud server**: reads cookies / inbound headers under the canonical name. Three constants in \`server/utils/context.go\` (\`Layer5-Current-Orgid\`, \`Layer5-Current-Org-Name\`, \`Layer5-Program\`) renamed in the cloud PR landing alongside this release.
- **meshery-cloud UI**: imports \`CURRENT_ORG_KEY\` (and currently duplicates the string in \`ui/utility/constants.ts\`); the duplicate is removed in the cloud PR.
- **layer5io/sistent**: re-exports \`CURRENT_ORG_KEY\` from this package as a pass-through (no source change needed; just bumping the \`@meshery/schemas\` dep).
- **meshery/meshery** (server): no direct refs (verified).
- **meshery/meshery** (UI): inherits via \`@meshery/schemas\` — dep bump in next release.
- **layer5labs/meshery-extensions**: inherits via \`@meshery/schemas\` — dep bump in next release.

No backwards-compat shim per maintainer direction. Lockstep deploy of all consumers is required; brief org-context loss during rollout is acceptable.

## Test plan

- [x] \`make validate-schemas\` — no blocking violations
- [x] \`go run ./cmd/consumer-audit --cloud-repo ../meshery-cloud --meshery-repo ../meshery\` — 2 pre-existing snake_case findings in \`ui/api/catalog.ts\` (unrelated to this rename)
- [ ] After release: meshery-cloud PR bumps the dep + renames its server-side constants