### PR TITLE
[schemas] Migrate model/component wire format to canonical camelCase (v1beta2/v1beta3)

### DIFF
--- a/models/v1beta2/component/component.go
+++ b/models/v1beta2/component/component.go
@@ -9,7 +9,7 @@ import (
 
 	core "github.com/meshery/schemas/models/core"
 	capabilityv1beta1 "github.com/meshery/schemas/models/v1beta1/capability"
-	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
+	modelv1beta2 "github.com/meshery/schemas/models/v1beta2/model"
 )
 
 // Defines values for ComponentDefinitionFormat.
@@ -60,10 +60,10 @@ type ComponentDefinition struct {
 	Format ComponentDefinitionFormat `json:"format" yaml:"format"`
 
 	// Model Meshery Models serve as a portable unit of packaging to define managed entities, their relationships, and capabilities.
-	Model *modelv1beta1.ModelDefinition `gorm:"foreignKey:ModelId;references:ID" json:"model" yaml:"model"`
+	Model *modelv1beta2.ModelDefinition `gorm:"foreignKey:ModelId;references:ID" json:"model" yaml:"model"`
 
 	// ModelReference Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models
-	ModelReference modelv1beta1.ModelReference `gorm:"-" json:"modelReference" yaml:"modelReference"`
+	ModelReference modelv1beta2.ModelReference `gorm:"-" json:"modelReference" yaml:"modelReference"`
 
 	// Styles Visualization styles for a component
 	Styles *core.ComponentStyles `gorm:"type:bytes;serializer:json" json:"styles" yaml:"styles"`

--- a/models/v1beta2/model/model.go
+++ b/models/v1beta2/model/model.go
@@ -10,8 +10,8 @@ import (
 	core "github.com/meshery/schemas/models/core"
 	capabilityv1beta1 "github.com/meshery/schemas/models/v1beta1/capability"
 	categoryv1beta1 "github.com/meshery/schemas/models/v1beta1/category"
-	connectionv1beta1 "github.com/meshery/schemas/models/v1beta1/connection"
 	subcategoryv1beta1 "github.com/meshery/schemas/models/v1beta1/subcategory"
+	connectionv1beta3 "github.com/meshery/schemas/models/v1beta3/connection"
 	"github.com/oapi-codegen/runtime"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
@@ -169,7 +169,7 @@ type ModelDefinition struct {
 	CategoryId core.Uuid `gorm:"categoryID" json:"-" yaml:"-"`
 
 	// Registrant Meshery Connections are managed and unmanaged resources that either through discovery or manual entry are tracked by Meshery. Learn more at https://docs.meshery.io/concepts/logical/connections
-	Registrant connectionv1beta1.Connection `gorm:"foreignKey:RegistrantId;references:ID" json:"registrant" yaml:"registrant"`
+	Registrant connectionv1beta3.Connection `gorm:"foreignKey:RegistrantId;references:ID" json:"registrant" yaml:"registrant"`
 
 	// RegistrantId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
 	RegistrantId core.Uuid `gorm:"column:connection_id" json:"registrantId" yaml:"registrantId"`

--- a/models/v1beta3/component/component.go
+++ b/models/v1beta3/component/component.go
@@ -9,7 +9,7 @@ import (
 
 	core "github.com/meshery/schemas/models/core"
 	capabilityv1beta1 "github.com/meshery/schemas/models/v1beta1/capability"
-	modelv1beta1 "github.com/meshery/schemas/models/v1beta1/model"
+	modelv1beta2 "github.com/meshery/schemas/models/v1beta2/model"
 )
 
 // Defines values for ComponentDefinitionFormat.
@@ -60,10 +60,10 @@ type ComponentDefinition struct {
 	Format ComponentDefinitionFormat `json:"format" yaml:"format"`
 
 	// Model Meshery Models serve as a portable unit of packaging to define managed entities, their relationships, and capabilities.
-	Model *modelv1beta1.ModelDefinition `gorm:"foreignKey:ModelID;references:ID" json:"model" yaml:"model"`
+	Model *modelv1beta2.ModelDefinition `gorm:"foreignKey:ModelID;references:ID" json:"model" yaml:"model"`
 
 	// ModelReference Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models
-	ModelReference modelv1beta1.ModelReference `gorm:"-" json:"modelReference" yaml:"modelReference"`
+	ModelReference modelv1beta2.ModelReference `gorm:"-" json:"modelReference" yaml:"modelReference"`
 
 	// Styles Visualization styles for a component
 	Styles *core.ComponentStyles `gorm:"type:bytes;serializer:json" json:"styles" yaml:"styles"`

--- a/models/v1beta3/const.go
+++ b/models/v1beta3/const.go
@@ -6,12 +6,11 @@ package v1beta3
 // callers (meshkit, meshery) can construct fixtures without hard-coding
 // the version literal.
 //
-// Note: the design itself is v1beta3, but the components and model
-// definitions nested inside a v1beta3 design are v1beta2 — that matches
-// the Go import graph of the generated types in this package tree
-// (v1beta3/design.PatternFile.Components references v1beta2/component).
+// Note: ComponentSchemaVersion uses v1beta3 because v1beta3/component.ComponentDefinition
+// is the canonical generated type (component.yaml default = "components.meshery.io/v1beta3").
+// ModelSchemaVersion remains v1beta2 — no v1beta3/model exists by design.
 const (
 	DesignSchemaVersion    = "designs.meshery.io/v1beta3"
-	ComponentSchemaVersion = "components.meshery.io/v1beta2"
+	ComponentSchemaVersion = "components.meshery.io/v1beta3"
 	ModelSchemaVersion     = "models.meshery.io/v1beta2"
 )

--- a/models/v1beta3/design/design_conversion.go
+++ b/models/v1beta3/design/design_conversion.go
@@ -14,7 +14,7 @@ import (
 	"github.com/meshery/schemas/models/conversion"
 	"github.com/meshery/schemas/models/v1alpha2"
 	"github.com/meshery/schemas/models/v1beta3"
-	model "github.com/meshery/schemas/models/v1beta1/model"
+	model "github.com/meshery/schemas/models/v1beta2/model"
 	component "github.com/meshery/schemas/models/v1beta2/component"
 	relationship "github.com/meshery/schemas/models/v1beta2/relationship"
 	"github.com/pkg/errors"

--- a/schemas/constructs/v1beta2/component/component.yaml
+++ b/schemas/constructs/v1beta2/component/component.yaml
@@ -55,11 +55,11 @@ properties:
       yaml: format
       json: format
   model:
-    $ref: ../../v1beta1/model/api.yml#/components/schemas/ModelDefinition
-    x-go-type: '*modelv1beta1.ModelDefinition'
+    $ref: ../../v1beta2/model/api.yml#/components/schemas/ModelDefinition
+    x-go-type: '*modelv1beta2.ModelDefinition'
     x-go-type-import:
-      path: github.com/meshery/schemas/models/v1beta1/model
-      name: modelv1beta1
+      path: github.com/meshery/schemas/models/v1beta2/model
+      name: modelv1beta2
     x-order: 7
     description: Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models
     x-oapi-codegen-extra-tags:
@@ -67,11 +67,11 @@ properties:
       json: model
       yaml: model
   modelReference:
-    $ref: ../../v1beta1/model/api.yml#/components/schemas/ModelReference
-    x-go-type: modelv1beta1.ModelReference
+    $ref: ../../v1beta2/model/api.yml#/components/schemas/ModelReference
+    x-go-type: modelv1beta2.ModelReference
     x-go-type-import:
-      path: github.com/meshery/schemas/models/v1beta1/model
-      name: modelv1beta1
+      path: github.com/meshery/schemas/models/v1beta2/model
+      name: modelv1beta2
     x-order: 8
     description: Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models
     x-oapi-codegen-extra-tags:

--- a/schemas/constructs/v1beta2/model/model.yaml
+++ b/schemas/constructs/v1beta2/model/model.yaml
@@ -79,11 +79,11 @@ properties:
       json: registrant
       gorm: foreignKey:RegistrantId;references:ID
     x-order: 8
-    x-go-type: connectionv1beta1.Connection
+    x-go-type: connectionv1beta3.Connection
     x-go-type-import:
-      path: github.com/meshery/schemas/models/v1beta1/connection
-      name: connectionv1beta1
-    $ref: ../../v1beta1/connection/api.yml#/components/schemas/Connection
+      path: github.com/meshery/schemas/models/v1beta3/connection
+      name: connectionv1beta3
+    $ref: ../../v1beta3/connection/api.yml#/components/schemas/Connection
   registrantId:
     description: ID of the registrant.
     $ref: ../core/api.yml#/components/schemas/Uuid

--- a/schemas/constructs/v1beta3/component/component.yaml
+++ b/schemas/constructs/v1beta3/component/component.yaml
@@ -55,11 +55,11 @@ properties:
       yaml: format
       json: format
   model:
-    $ref: ../../v1beta1/model/api.yml#/components/schemas/ModelDefinition
-    x-go-type: '*modelv1beta1.ModelDefinition'
+    $ref: ../../v1beta2/model/api.yml#/components/schemas/ModelDefinition
+    x-go-type: '*modelv1beta2.ModelDefinition'
     x-go-type-import:
-      path: github.com/meshery/schemas/models/v1beta1/model
-      name: modelv1beta1
+      path: github.com/meshery/schemas/models/v1beta2/model
+      name: modelv1beta2
     x-order: 7
     description: Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models
     x-oapi-codegen-extra-tags:
@@ -67,11 +67,11 @@ properties:
       json: model
       yaml: model
   modelReference:
-    $ref: ../../v1beta1/model/api.yml#/components/schemas/ModelReference
-    x-go-type: modelv1beta1.ModelReference
+    $ref: ../../v1beta2/model/api.yml#/components/schemas/ModelReference
+    x-go-type: modelv1beta2.ModelReference
     x-go-type-import:
-      path: github.com/meshery/schemas/models/v1beta1/model
-      name: modelv1beta1
+      path: github.com/meshery/schemas/models/v1beta2/model
+      name: modelv1beta2
     x-order: 8
     description: Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models
     x-oapi-codegen-extra-tags:


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #913 

This is **PR 1 of 3** in a coordinated cross-repo migration:

| PR | Repo | Scope |
|---|---|---|
| **PR 1 (this)** | `meshery/schemas` | Struct type + constant updates |
| PR 2 | `meshery/meshkit` | Registry bridge adapters |
| PR 3 | `meshery/meshery` | Server handler + UI field name fixes |

---

### Changes

#### 1. Component model fields: `v1beta1` → `v1beta2`

**Files:** `schemas/constructs/v1beta2/component/component.yaml`, `schemas/constructs/v1beta3/component/component.yaml`, `models/v1beta2/component/component.go`, `models/v1beta3/component/component.go`, `models/v1beta3/design/design_conversion.go`

Updated the `model` and `modelReference` properties in both v1beta2 and v1beta3 component schemas from `v1beta1/model` → `v1beta2/model`:

```diff
- $ref: ../../v1beta1/model/api.yml#/components/schemas/ModelDefinition
- x-go-type: '*modelv1beta1.ModelDefinition'
+ $ref: ../../v1beta2/model/api.yml#/components/schemas/ModelDefinition
+ x-go-type: '*modelv1beta2.ModelDefinition'
```

#### 2. Registrant field: `v1beta1/connection` → `v1beta3/connection`

**Files:** `schemas/constructs/v1beta2/model/model.yaml`, `models/v1beta2/model/model.go`

Updated the `registrant` property in the v1beta2 model schema to reference `v1beta3/connection`. The v1beta3 Connection struct has full camelCase JSON tags:

```diff
 "registrant": {
-  "user_id": null,
-  "created_at": "2024-01-01T00:00:00Z",
-  "updated_at": "2024-01-01T00:00:00Z",
-  "deleted_at": null
+  "userId": null,
+  "createdAt": "2024-01-01T00:00:00Z",
+  "updatedAt": "2024-01-01T00:00:00Z",
+  "deletedAt": null
 }
```

> **DB Safety:** All `gorm:` and `db:` column tags are byte-for-byte identical between v1beta1 and v1beta3 (`db:"user_id"`, `db:"created_at"`, `gorm:"column:connection_id"`, etc.). No AutoMigrate changes required.

#### 3. Fix `ComponentSchemaVersion` constant: `v1beta2` → `v1beta3`

**File:** `models/v1beta3/const.go`

```diff
-ComponentSchemaVersion = "components.meshery.io/v1beta2"
+ComponentSchemaVersion = "components.meshery.io/v1beta3"
```

The constant was written before `v1beta3/component.ComponentDefinition` existed. The `component.yaml` default field and `mesheryctl model init` templates already emit `v1beta3` — the constant now matches. All downstream callers pick up the new value automatically.

---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
