### PR TITLE
feat(forms): hide duplicative RJSF root-object title via ui:options.label

### DIFF
--- a/schemas/constructs/v1beta1/credential/forms/grafana.ui.json
+++ b/schemas/constructs/v1beta1/credential/forms/grafana.ui.json
@@ -1,1 +1,3 @@
-{}
+{
+  "ui:options": { "label": false }
+}

--- a/schemas/constructs/v1beta1/credential/forms/kubernetes.ui.json
+++ b/schemas/constructs/v1beta1/credential/forms/kubernetes.ui.json
@@ -1,1 +1,3 @@
-{}
+{
+  "ui:options": { "label": false }
+}

--- a/schemas/constructs/v1beta1/credential/forms/prometheus.ui.json
+++ b/schemas/constructs/v1beta1/credential/forms/prometheus.ui.json
@@ -1,1 +1,3 @@
-{}
+{
+  "ui:options": { "label": false }
+}

--- a/schemas/constructs/v1beta1/support/forms/helpAndSupport.ui.json
+++ b/schemas/constructs/v1beta1/support/forms/helpAndSupport.ui.json
@@ -1,4 +1,5 @@
 {
+  "ui:options": { "label": false },
   "subject": {
     "ui:placeholder": "Summary or title for your support request"
   },

--- a/schemas/constructs/v1beta2/catalog/forms/publish.ui.json
+++ b/schemas/constructs/v1beta2/catalog/forms/publish.ui.json
@@ -1,3 +1,4 @@
 {
+  "ui:options": { "label": false },
   "ui:order": ["type", "compatibility", "patternInfo", "patternCaveats"]
 }

--- a/schemas/constructs/v1beta2/model/forms/import.ui.json
+++ b/schemas/constructs/v1beta2/model/forms/import.ui.json
@@ -1,4 +1,5 @@
 {
+  "ui:options": { "label": false },
   "uploadType": {
     "ui:widget": "radio"
   },

--- a/schemas/constructs/v1beta3/connection/forms/helmCreate.ui.json
+++ b/schemas/constructs/v1beta3/connection/forms/helmCreate.ui.json
@@ -1,4 +1,5 @@
 {
+  "ui:options": { "label": false },
   "description": {
     "ui:widget": "textarea"
   },

--- a/schemas/constructs/v1beta3/design/forms/import.ui.json
+++ b/schemas/constructs/v1beta3/design/forms/import.ui.json
@@ -1,4 +1,5 @@
 {
+  "ui:options": { "label": false },
   "uploadType": {
     "ui:widget": "radio"
   },

--- a/schemas/constructs/v1beta3/environment/forms/createOrEdit.ui.json
+++ b/schemas/constructs/v1beta3/environment/forms/createOrEdit.ui.json
@@ -1,4 +1,5 @@
 {
+  "ui:options": { "label": false },
   "organizationId": {
     "ui:disabled": false
   },

--- a/schemas/constructs/v1beta3/filter/forms/import.ui.json
+++ b/schemas/constructs/v1beta3/filter/forms/import.ui.json
@@ -1,4 +1,5 @@
 {
+  "ui:options": { "label": false },
   "uploadType": {
     "ui:widget": "radio"
   },

--- a/schemas/constructs/v1beta3/workspace/forms/createOrEdit.ui.json
+++ b/schemas/constructs/v1beta3/workspace/forms/createOrEdit.ui.json
@@ -1,4 +1,5 @@
 {
+  "ui:options": { "label": false },
   "organizationId": {
     "ui:disabled": false,
     "ui:widget": "select"


### PR DESCRIPTION
## Description

RJSF modals (e.g. **Import Design**) render forms from the canonical `@meshery/schemas` form schemas whose **root object carries a `title`** (e.g. "Import Design"). Inside a titled modal RJSF draws that root title a *second* time — a duplicate heading in `@rjsf/mui`, and a **collapsed** accordion the user must expand in the custom collapsible `ObjectFieldTemplate`s downstream. The goal: render the root object's **contents** directly, drop the duplicate title, and keep the canonical JSON schema unmodified.

## What changed

Set `ui:options.label = false` on the **root** of every titled-modal form UI schema (`*.ui.json`) under `schemas/constructs/.../forms/`:

- `v1beta3/design/forms/import.ui.json` — **Import Design**, the primary case
- `v1beta2/model/forms/import.ui.json`, `v1beta3/filter/forms/import.ui.json`
- `v1beta3/environment/forms/createOrEdit.ui.json`, `v1beta3/workspace/forms/createOrEdit.ui.json`
- `v1beta1/credential/forms/{kubernetes,grafana,prometheus}.ui.json`
- `v1beta2/catalog/forms/publish.ui.json`, `v1beta1/support/forms/helpAndSupport.ui.json`
- `v1beta3/connection/forms/helmCreate.ui.json`

Per `@rjsf/core`'s `ObjectField`, `label === false` forces the title handed to **any** `ObjectFieldTemplate` to `''` and the description to `undefined`, so the header is skipped and child fields render inline — template-agnostic, with the JSON schema untouched.

This is the schema-driven source of truth: every consumer rendering these `*RjsfUiSchema*` exports (Sistent's re-export, meshery, meshery-cloud, meshery-extensions) inherits the suppression with **zero per-consumer code**. The JSON schemas keep their root `title`/`description` (valid metadata) — `ui:options.label` in the UI schema is the correct, cleaner presentation lever (no `schema.title` deletion).

## Verification

- `go test ./validation/...` green — the form subset, `*.ui.json`-pairing, and index-export guards all pass. The validators inspect the JSON schemas (and the ui-schema pairing); the additive `ui:options` key is ignored by the schema-node parser.
- All 11 `*.ui.json` files parse and declare `ui:options.label = false` at the root.

## Notes for reviewers

No generated artifacts change: `typescript/forms/index.ts` imports the raw `*.ui.json` directly (no codegen produces their contents), and the OpenAPI→Go/TS generators do not read the `forms/` tree.

- [x] Signed commits (DCO)
