### PR TITLE
fix(core): parse string/[]byte timestamps in NullTime.Scan

### DIFF
--- a/models/core/datatype_null_time.go
+++ b/models/core/datatype_null_time.go
@@ -51,21 +51,25 @@ func (nt *NullTime) Scan(value any) error {
 	return nil
 }
 
-// scanString parses the time layouts SQL drivers emit when handing back
-// timestamps as text. An empty or unparseable string yields Valid=false.
+// scanLayouts are the timestamp formats SQL drivers emit when handing back
+// values as text, tried in order. Package-level to avoid re-allocating on
+// every Scan (called per row).
+var scanLayouts = []string{
+	"2006-01-02 15:04:05.999999999-07:00", // SQLite, with offset
+	"2006-01-02 15:04:05.999999999",       // SQLite, fractional seconds
+	"2006-01-02 15:04:05",                  // SQLite DATETIME()
+	time.RFC3339Nano,
+	time.RFC3339,
+}
+
+// scanString parses a textual timestamp into the receiver. An empty or
+// unparseable string yields Valid=false.
 func (nt *NullTime) scanString(s string) {
 	if s == "" {
 		nt.Time, nt.Valid = time.Time{}, false
 		return
 	}
-	layouts := []string{
-		"2006-01-02 15:04:05.999999999-07:00", // SQLite, with offset
-		"2006-01-02 15:04:05.999999999",       // SQLite, fractional seconds
-		"2006-01-02 15:04:05",                  // SQLite DATETIME()
-		time.RFC3339Nano,
-		time.RFC3339,
-	}
-	for _, layout := range layouts {
+	for _, layout := range scanLayouts {
 		if t, err := time.Parse(layout, s); err == nil {
 			nt.Time, nt.Valid = t, true
 			return

--- a/models/core/datatype_null_time.go
+++ b/models/core/datatype_null_time.go
@@ -24,15 +24,54 @@ func NewTime(t time.Time) NullTime {
 }
 
 // Scan implements the Scanner interface.
+//
+// Besides the time.Time most drivers return, it also parses string/[]byte
+// timestamps. Some SQL drivers surface timestamps as text rather than
+// time.Time — notably SQLite, which returns a computed column such as
+// DATETIME(MAX(...)) as a string. Without the string handling those values
+// silently scanned as NULL (Valid=false), even though the predecessor type
+// (meshery's sql.Time) parsed them.
+//
+// The conversion is intentionally additive: any value that previously scanned
+// successfully behaves identically, and any unrecognized value (including an
+// unparseable string) still falls back to Valid=false without returning an
+// error — matching the prior lenient behavior, so no existing consumer can
+// newly fail.
 func (nt *NullTime) Scan(value any) error {
-	if value == nil {
+	switch v := value.(type) {
+	case time.Time:
+		nt.Time, nt.Valid = v, true
+	case string:
+		nt.scanString(v)
+	case []byte:
+		nt.scanString(string(v))
+	default: // nil or any unexpected type
 		nt.Time, nt.Valid = time.Time{}, false
-		return nil
 	}
-	t, ok := value.(time.Time)
-	nt.Time = t
-	nt.Valid = ok
 	return nil
+}
+
+// scanString parses the time layouts SQL drivers emit when handing back
+// timestamps as text. An empty or unparseable string yields Valid=false.
+func (nt *NullTime) scanString(s string) {
+	if s == "" {
+		nt.Time, nt.Valid = time.Time{}, false
+		return
+	}
+	layouts := []string{
+		"2006-01-02 15:04:05.999999999-07:00", // SQLite, with offset
+		"2006-01-02 15:04:05.999999999",       // SQLite, fractional seconds
+		"2006-01-02 15:04:05",                  // SQLite DATETIME()
+		time.RFC3339Nano,
+		time.RFC3339,
+	}
+	for _, layout := range layouts {
+		if t, err := time.Parse(layout, s); err == nil {
+			nt.Time, nt.Valid = t, true
+			return
+		}
+	}
+	nt.Time, nt.Valid = time.Time{}, false
 }
 
 // Value implements the driver Valuer interface.

--- a/models/core/datatype_null_time_test.go
+++ b/models/core/datatype_null_time_test.go
@@ -30,7 +30,37 @@ func TestNullTime(t *testing.T) {
 
 		// Invalid scan
 		err = nt.Scan("not a time")
-		assert.NoError(t, err) // type assertion fails, but no error
+		assert.NoError(t, err) // unparseable string, but no error
+		assert.False(t, nt.Valid)
+	})
+
+	t.Run("ScanString", func(t *testing.T) {
+		// Drivers such as SQLite return computed timestamp columns (e.g.
+		// DATETIME(MAX(...))) as strings/[]byte rather than time.Time. These
+		// must scan to a Valid time, not silently NULL.
+		want := time.Date(2026, 6, 3, 17, 27, 54, 0, time.UTC)
+
+		cases := []struct {
+			name  string
+			value any
+		}{
+			{"sqlite datetime string", "2026-06-03 17:27:54"},
+			{"sqlite datetime bytes", []byte("2026-06-03 17:27:54")},
+			{"rfc3339 string", "2026-06-03T17:27:54Z"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.name, func(t *testing.T) {
+				nt := &NullTime{}
+				err := nt.Scan(tc.value)
+				assert.NoError(t, err)
+				assert.True(t, nt.Valid)
+				assert.True(t, want.Equal(nt.Time))
+			})
+		}
+
+		// Empty string is NULL, not an error.
+		nt := &NullTime{}
+		assert.NoError(t, nt.Scan(""))
 		assert.False(t, nt.Valid)
 	})
 


### PR DESCRIPTION
**Notes for Reviewers**

NullTime.Scan only accepted time.Time, so timestamps that drivers hand back as strings were silently dropped to NULL. SQLite does this for computed columns like DATETIME(MAX(...)), which is how Meshery's performance-profile list reads last_run, so it always came back null on the local provider. The predecessor type (sql.Time) parsed these strings; this restores that.
  
 Additive: time.Time still scans exactly as before (Postgres path unchanged), and unparseable input still yields Valid=false with no error. Just adds string/[]byte parsing.




**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
