### PR TITLE
Upgrade schemas Go toolchain to Go 1.26.4

### DIFF
--- a/.github/workflows/generate-artifacts-from-schemas.yml
+++ b/.github/workflows/generate-artifacts-from-schemas.yml
@@ -24,7 +24,7 @@ jobs:
           ref: 'master'
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.25'   # match your local version
+          go-version-file: go.mod
 
       - name: Install build dependencies
         uses: actions/setup-node@v6

--- a/.github/workflows/publish-openapi-docs.yml
+++ b/.github/workflows/publish-openapi-docs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.25'
+          go-version-file: go.mod
 
       - name: Validate schemas
         run: make validate-schemas

--- a/Makefile
+++ b/Makefile
@@ -251,13 +251,13 @@ dep-check:
 # golang
 ifeq (,$(findstring $(GOVERSION), $(INSTALLED_GO_VERSION)))
 # Only send a warning.
-	@echo "Dependency missing: go$(GOVERSION). Ensure 'go$(GOVERSION).x' is installed and available in your 'PATH'"
+	@echo "Dependency missing: go$(GOVERSION). Ensure 'go$(GOVERSION)' is installed and available in your 'PATH'"
 	@echo "GOVERSION: " $(GOVERSION)
 	@echo "INSTALLED_GO_VERSION: " $(INSTALLED_GO_VERSION)
 # Force error and stop.
 #	$(error Found $(INSTALLED_GO_VERSION). \
-#	 Required golang version is: 'go$(GOVERSION).x'. \
-#	 Ensure go '$(GOVERSION).x' is installed and available in your 'PATH'.)
+#	 Required golang version is: 'go$(GOVERSION)'. \
+#	 Ensure go '$(GOVERSION)' is installed and available in your 'PATH'.)
 endif
 
 # oapi-codegen

--- a/build/Makefile.core.mk
+++ b/build/Makefile.core.mk
@@ -47,7 +47,7 @@ GIT_COMMITSHA = $(shell git rev-list -1 HEAD)
 GIT_STRIPPED_VERSION=$(shell git describe --tags `git rev-list --tags --max-count=1` | cut -c 2-)
 REMOTE_PROVIDER="Meshery"
 LOCAL_PROVIDER="None"
-GOVERSION = 1.25
+GOVERSION = 1.26.4
 GOPATH = $(shell go env GOPATH)
 GOBIN  = $(GOPATH)/bin
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/meshery/schemas
 
-go 1.25.8
+go 1.26.4
 
 require (
 	github.com/getkin/kin-openapi v0.133.0


### PR DESCRIPTION
## Summary
- bump the schemas module Go directive to Go 1.26.4
- update the Makefile Go version check to the exact patch release
- switch hardcoded CI setup-go pins to read from go.mod

Refs meshery/meshery#19875.

## Validation
- go mod tidy
- go build ./...
- go test ./...
- go vet ./...
- make validate-schemas