### PR TITLE
validation: extend Rule 24 security scheme validation

### DIFF
--- a/validation/rules_design.go
+++ b/validation/rules_design.go
@@ -310,8 +310,96 @@ func checkRule24(filePath string, doc *openapi3.T, opts AuditOptions) []Violatio
 				RuleNumber: 24,
 			})
 		}
-	}
 
+		if scheme.Type == "apiKey" {
+			if scheme.Name == "" {
+				out = append(out, Violation{
+					File: filePath,
+					Message: fmt.Sprintf(
+						`Security scheme %q of type "apiKey" must define a "name".`,
+						name,
+					),
+					Severity:   classifyDesignIssue(opts),
+					RuleNumber: 24,
+				})
+			}
+
+			if scheme.In == "" {
+				out = append(out, Violation{
+					File: filePath,
+					Message: fmt.Sprintf(
+						`Security scheme %q of type "apiKey" must define an "in" value (header, query, or cookie).`,
+						name,
+					),
+					Severity:   classifyDesignIssue(opts),
+					RuleNumber: 24,
+				})
+			}
+		}
+
+		if scheme.Type == "http" {
+			validSchemes := map[string]bool{
+				"bearer": true,
+				"basic":  true,
+			}
+
+			if scheme.Scheme == "" {
+				out = append(out, Violation{
+					File: filePath,
+					Message: fmt.Sprintf(
+						`Security scheme %q of type "http" must define a scheme.`,
+						name,
+					),
+					Severity:   classifyDesignIssue(opts),
+					RuleNumber: 24,
+				})
+				continue
+			}
+
+			if !validSchemes[strings.ToLower(scheme.Scheme)] {
+				out = append(out, Violation{
+					File: filePath,
+					Message: fmt.Sprintf(
+						`Security scheme %q uses unsupported http scheme %q.`,
+						name,
+						scheme.Scheme,
+					),
+					Severity:   classifyDesignIssue(opts),
+					RuleNumber: 24,
+				})
+			}
+		}
+		if scheme.Type == "oauth2" {
+			if scheme.Flows == nil {
+				out = append(out, Violation{
+					File: filePath,
+					Message: fmt.Sprintf(
+						`Security scheme %q of type "oauth2" must define flows.`,
+						name,
+					),
+					Severity:   classifyDesignIssue(opts),
+					RuleNumber: 24,
+				})
+				continue
+			}
+
+			if scheme.Flows.AuthorizationCode == nil &&
+				scheme.Flows.ClientCredentials == nil &&
+				scheme.Flows.Implicit == nil &&
+				scheme.Flows.Password == nil {
+
+				out = append(out, Violation{
+					File: filePath,
+					Message: fmt.Sprintf(
+						`Security scheme %q of type "oauth2" must define at least one OAuth flow.`,
+						name,
+					),
+					Severity:   classifyDesignIssue(opts),
+					RuleNumber: 24,
+				})
+			}
+		}
+	}
 	return out
 }
 

--- a/validation/rules_design.go
+++ b/validation/rules_design.go
@@ -271,7 +271,7 @@ func checkRule23(filePath string, doc *openapi3.T, opts AuditOptions) []Violatio
 	return out
 }
 
-// --- Rule 24: api.yml must declare a security scheme ---
+// --- Rule 24: validate security scheme declarations and configuration ---
 
 func checkRule24(filePath string, doc *openapi3.T, opts AuditOptions) []Violation {
 	if doc == nil || doc.Paths == nil {
@@ -324,11 +324,17 @@ func checkRule24(filePath string, doc *openapi3.T, opts AuditOptions) []Violatio
 				})
 			}
 
-			if scheme.In == "" {
+			validLocations := map[string]bool{
+				"header": true,
+				"query":  true,
+				"cookie": true,
+			}
+
+			if !validLocations[scheme.In] {
 				out = append(out, Violation{
 					File: filePath,
 					Message: fmt.Sprintf(
-						`Security scheme %q of type "apiKey" must define an "in" value (header, query, or cookie).`,
+						`Security scheme %q of type "apiKey" must define a valid "in" value (header, query, or cookie).`,
 						name,
 					),
 					Severity:   classifyDesignIssue(opts),
@@ -338,6 +344,9 @@ func checkRule24(filePath string, doc *openapi3.T, opts AuditOptions) []Violatio
 		}
 
 		if scheme.Type == "http" {
+			// Current schemas only use bearer authentication.
+			// kin-openapi also supports basic, negotiate, and digest.
+			// Extend this allowlist if additional HTTP auth schemes are introduced.
 			validSchemes := map[string]bool{
 				"bearer": true,
 				"basic":  true,

--- a/validation/rules_design.go
+++ b/validation/rules_design.go
@@ -277,14 +277,41 @@ func checkRule24(filePath string, doc *openapi3.T, opts AuditOptions) []Violatio
 	if doc == nil || doc.Paths == nil {
 		return nil
 	}
+
 	var out []Violation
+
 	schemes := doc.Components
-	if schemes == nil || schemes.SecuritySchemes == nil || len(schemes.SecuritySchemes) == 0 {
+	if schemes == nil || len(schemes.SecuritySchemes) == 0 {
 		out = append(out, Violation{
-			File: filePath, Message: "No security schemes declared. api.yml files with path operations must define at least one entry under `components.securitySchemes`.",
-			Severity: classifyDesignIssue(opts), RuleNumber: 24,
+			File:       filePath,
+			Message:    "No security schemes declared. api.yml files with path operations must define at least one entry under `components.securitySchemes`.",
+			Severity:   classifyDesignIssue(opts),
+			RuleNumber: 24,
 		})
+		return out
 	}
+
+	for name, ref := range schemes.SecuritySchemes {
+		if ref == nil || ref.Value == nil {
+			continue
+		}
+
+		scheme := ref.Value
+		lower := strings.ToLower(name)
+
+		if (lower == "jwt" || lower == "bearer") && scheme.Type != "http" {
+			out = append(out, Violation{
+				File: filePath,
+				Message: fmt.Sprintf(
+					`Security scheme %q should use type "http" when representing JWT/Bearer authentication.`,
+					name,
+				),
+				Severity:   classifyDesignIssue(opts),
+				RuleNumber: 24,
+			})
+		}
+	}
+
 	return out
 }
 

--- a/validation/rules_design.go
+++ b/validation/rules_design.go
@@ -397,6 +397,33 @@ func checkRule24(filePath string, doc *openapi3.T, opts AuditOptions) []Violatio
 					Severity:   classifyDesignIssue(opts),
 					RuleNumber: 24,
 				})
+				continue
+			}
+
+			flows := []*openapi3.OAuthFlow{
+				scheme.Flows.AuthorizationCode,
+				scheme.Flows.ClientCredentials,
+				scheme.Flows.Implicit,
+				scheme.Flows.Password,
+			}
+
+			for _, flow := range flows {
+				if flow == nil {
+					continue
+				}
+
+				if len(flow.Scopes) == 0 {
+					out = append(out, Violation{
+						File: filePath,
+						Message: fmt.Sprintf(
+							`OAuth2 security scheme %q must define at least one scope.`,
+							name,
+						),
+						Severity:   classifyDesignIssue(opts),
+						RuleNumber: 24,
+					})
+					break
+				}
 			}
 		}
 	}

--- a/validation/rules_design_test.go
+++ b/validation/rules_design_test.go
@@ -887,6 +887,9 @@ func TestCheckRule24_ValidOAuth2(t *testing.T) {
 						Flows: &openapi3.OAuthFlows{
 							ClientCredentials: &openapi3.OAuthFlow{
 								TokenURL: "https://example.com/token",
+								Scopes: map[string]string{
+									"read": "Read access",
+								},
 							},
 						},
 					},

--- a/validation/rules_design_test.go
+++ b/validation/rules_design_test.go
@@ -589,6 +589,96 @@ func TestCheckRule21_NilDoc(t *testing.T) {
 	}
 }
 
+func TestCheckRule24_NoSecuritySchemes(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+	}
+
+	doc.Paths.Set("/test", &openapi3.PathItem{
+		Get: &openapi3.Operation{
+			Responses: openapi3.NewResponses(),
+		},
+	})
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_JWTSchemeMustUseHTTP(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"jwt": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "apiKey",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_BearerSchemeMustUseHTTP(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"bearer": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "apiKey",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_ValidJWTScheme(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"jwt": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type:   "http",
+						Scheme: "bearer",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 0 {
+		t.Fatalf("expected 0 violations, got %d", len(vs))
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Rule 28: Response codes match method semantics
 // ---------------------------------------------------------------------------

--- a/validation/rules_design_test.go
+++ b/validation/rules_design_test.go
@@ -988,6 +988,31 @@ func TestCheckRule24_ValidOAuth2Scopes(t *testing.T) {
 	}
 }
 
+func TestCheckRule24_APIKeyInvalidIn(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"apiKey": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "apiKey",
+						Name: "X-API-Key",
+						In:   "foo",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Rule 28: Response codes match method semantics
 // ---------------------------------------------------------------------------

--- a/validation/rules_design_test.go
+++ b/validation/rules_design_test.go
@@ -619,6 +619,8 @@ func TestCheckRule24_JWTSchemeMustUseHTTP(t *testing.T) {
 				"jwt": &openapi3.SecuritySchemeRef{
 					Value: &openapi3.SecurityScheme{
 						Type: "apiKey",
+						Name: "Authorization",
+						In:   "header",
 					},
 				},
 			},
@@ -642,6 +644,8 @@ func TestCheckRule24_BearerSchemeMustUseHTTP(t *testing.T) {
 				"bearer": &openapi3.SecuritySchemeRef{
 					Value: &openapi3.SecurityScheme{
 						Type: "apiKey",
+						Name: "Authorization",
+						In:   "header",
 					},
 				},
 			},
@@ -666,6 +670,308 @@ func TestCheckRule24_ValidJWTScheme(t *testing.T) {
 					Value: &openapi3.SecurityScheme{
 						Type:   "http",
 						Scheme: "bearer",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 0 {
+		t.Fatalf("expected 0 violations, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_APIKeyMissingName(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"apiKey": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "apiKey",
+						In:   "header",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_APIKeyMissingIn(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"apiKey": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "apiKey",
+						Name: "X-API-Key",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_ValidAPIKeyScheme(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"apiKey": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "apiKey",
+						In:   "header",
+						Name: "X-API-Key",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 0 {
+		t.Fatalf("expected 0 violations, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_HTTPMissingScheme(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"httpAuth": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "http",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_HTTPInvalidScheme(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"httpAuth": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type:   "http",
+						Scheme: "potato",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_ValidHTTPBearer(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"httpAuth": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type:   "http",
+						Scheme: "bearer",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 0 {
+		t.Fatalf("expected 0 violations, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_ValidHTTPBasic(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"httpAuth": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type:   "http",
+						Scheme: "basic",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 0 {
+		t.Fatalf("expected 0 violations, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_OAuth2MissingFlows(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"oauth2": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "oauth2",
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_ValidOAuth2(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"oauth2": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "oauth2",
+						Flows: &openapi3.OAuthFlows{
+							ClientCredentials: &openapi3.OAuthFlow{
+								TokenURL: "https://example.com/token",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 0 {
+		t.Fatalf("expected 0 violations, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_OAuth2EmptyFlows(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"oauth2": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type:  "oauth2",
+						Flows: &openapi3.OAuthFlows{},
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_OAuth2FlowMissingScopes(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"oauth2": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "oauth2",
+						Flows: &openapi3.OAuthFlows{
+							ClientCredentials: &openapi3.OAuthFlow{
+								TokenURL: "https://example.com/token",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	vs := checkRule24("api.yml", doc, AuditOptions{})
+
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
+}
+
+func TestCheckRule24_ValidOAuth2Scopes(t *testing.T) {
+	doc := &openapi3.T{
+		OpenAPI: "3.0.0",
+		Info:    &openapi3.Info{Title: "Test", Version: "v1"},
+		Paths:   openapi3.NewPaths(),
+		Components: &openapi3.Components{
+			SecuritySchemes: openapi3.SecuritySchemes{
+				"oauth2": &openapi3.SecuritySchemeRef{
+					Value: &openapi3.SecurityScheme{
+						Type: "oauth2",
+						Flows: &openapi3.OAuthFlows{
+							ClientCredentials: &openapi3.OAuthFlow{
+								TokenURL: "https://example.com/token",
+								Scopes: map[string]string{
+									"read": "Read access",
+								},
+							},
+						},
 					},
 				},
 			},


### PR DESCRIPTION
Fixes #721 

Rule 24 previously only checked whether security schemes were declared. This PR extends validation for security scheme definitions, including JWT/Bearer, API key, HTTP, and OAuth2 configurations.

Tests added for valid and invalid configurations across all supported scheme types.

Tests
Added test for missing security schemes
Added test for JWT scheme using a non-HTTP type
Added test for Bearer scheme using a non-HTTP type
Added test for a valid JWT bearer scheme

Verification
go test ./validation
go test ./...

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 
