### PR TITLE
[CI][Permissions] Shrink KNOWN_DUPLICATE_UUIDS allowlist now that collisions are resolved

### DIFF
--- a/build/lib/permissions.js
+++ b/build/lib/permissions.js
@@ -87,16 +87,7 @@ function parsePermissions(csvContent, options = {}) {
   // below. The allowlist is SHRINK-ONLY — remove an entry once the source
   // sheet assigns the colliding functions distinct UUIDs; never add a new one
   // (fix new collisions in the sheet). Tracked in meshery/schemas#930.
-  const KNOWN_DUPLICATE_UUIDS = new Set([
-    // GitOps: "Snapshots" and "ArgoEvents" share one UUID; no downstream
-    // consumer anchors the keep-side, so the split is a sheet-owner decision.
-    "81287ea7-5e3f-480c-8b2e-211d62d08797",
-    // GitOps Pipeline: BitBucket/GitHub/GitLab share one UUID (sheet decision).
-    "9f236c99-b2ec-4474-9ec8-7c3f8a09e63e",
-    // Performance: Analysis/Nighthawk/Distributed Tests/Performance Profiles
-    // share one UUID (sheet decision).
-    "72066352-d09b-494a-b02e-846676bd7a0a",
-  ]);
+  const KNOWN_DUPLICATE_UUIDS = new Set([]);
   const uuidToNames = new Map();
   for (const p of permissions) {
     const u = p.uuid.toLowerCase();


### PR DESCRIPTION
**Notes for Reviewers**

Part of #939 — this implements the **meshery/schemas (code)** checklist item only (the hard blocker). The Google Sheet (data) and downstream re-key items remain tracked in the issue, so this PR intentionally does **not** use a closing keyword.

### What

Remove the three resolved entries from the shrink-only `KNOWN_DUPLICATE_UUIDS` allowlist in `build/lib/permissions.js`, leaving it empty:

- `81287ea7-5e3f-480c-8b2e-211d62d08797` — GitOps: Snapshots / ArgoEvents
- `9f236c99-b2ec-4474-9ec8-7c3f8a09e63e` — GitOps Pipeline: BitBucket / GitHub / GitLab
- `72066352-d09b-494a-b02e-846676bd7a0a` — Performance: Analysis / Nighthawk / Distributed Tests / Performance Profiles

### Why

The canonical published "Features & Permissions" sheet now assigns each of these collisions a distinct UUID. Because they no longer collide, the allowlist's shrink-only guard fails generation:

```
KNOWN_DUPLICATE_UUIDS is shrink-only: these entries no longer collide
and must be removed from the allowlist:
   81287ea7-5e3f-480c-8b2e-211d62d08797
   9f236c99-b2ec-4474-9ec8-7c3f8a09e63e
   72066352-d09b-494a-b02e-846676bd7a0a
```

`make generate-permissions` exits 1 against the live sheet, so the #935 refresh workflow can neither regenerate nor commit. The allowlist is documented as SHRINK-ONLY (remove an entry once the sheet assigns distinct UUIDs; never add one), so removing these three is the prescribed action.

### ⚠️ Merge sequencing

This change must land **together with the resolved sheet content** (`build/permissions.csv`). The committed CSV in `master` still contains the three collisions, so on its own:

- `make generate-permissions` against the **resolved/published sheet** → exits **0** ✅ (the fix)
- `make generate-permissions` / `make build` against the **currently committed `build/permissions.csv`** → exits **1** ❌ with the duplicate-UUID error, because that snapshot is stale.

Concretely, after merge the `generate-artifacts-from-schemas.yml` workflow (which runs `make build` on `master` against the committed CSV) will fail until `build/permissions.csv` is refreshed from the resolved sheet. Recommended: merge this alongside the CSV refresh, or land it as part of the #935 refresh flow once the sheet (data) items in #939 are reconciled.

### Testing

- `node -e "require('./build/lib/permissions.js')"` — module loads, no syntax errors.
- Verified the guard logic: against a collision-free source the empty allowlist produces no stale-allowlist error and no false duplicate errors; against the stale committed CSV it correctly reports the three remaining collisions (expected, see sequencing note).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
