### PR TITLE
Migrate UUID library from gofrs/uuid to google/uuid

### DIFF
--- a/models/v1alpha3/relationship/relationship_helper.go
+++ b/models/v1alpha3/relationship/relationship_helper.go
@@ -40,7 +40,7 @@ func (r RelationshipDefinition) Type() entity.EntityType {
 }
 
 func (r *RelationshipDefinition) GenerateID() (uuid.UUID, error) {
-	return uuid.New(), nil
+	return uuid.NewRandom()
 }
 
 func (r RelationshipDefinition) GetID() uuid.UUID {

--- a/models/v1beta1/category/category_helper.go
+++ b/models/v1beta1/category/category_helper.go
@@ -4,7 +4,6 @@ package category
 
 import (
 	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"sync"
@@ -38,7 +37,7 @@ func (cat *CategoryDefinition) GenerateID() (uuid.UUID, error) {
 	}
 
 	hash := md5.Sum(byt)
-	return uuid.Parse(hex.EncodeToString(hash[:]))
+	return uuid.UUID(hash), nil
 }
 
 func (cat CategoryDefinition) GetID() uuid.UUID {

--- a/models/v1beta1/component/component_helper.go
+++ b/models/v1beta1/component/component_helper.go
@@ -26,7 +26,7 @@ func (c ComponentDefinition) Type() entity.EntityType {
 }
 
 func (c *ComponentDefinition) GenerateID() (uuid.UUID, error) {
-	return uuid.New(), nil
+	return uuid.NewRandom()
 }
 
 func (c ComponentDefinition) GetID() uuid.UUID {

--- a/models/v1beta1/connection/connection_helper.go
+++ b/models/v1beta1/connection/connection_helper.go
@@ -4,7 +4,6 @@ package connection
 
 import (
 	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
 	"sync"
 
@@ -23,7 +22,7 @@ func (h *Connection) GenerateID() (uuid.UUID, error) {
 	}
 
 	hash := md5.Sum(byt)
-	return uuid.Parse(hex.EncodeToString(hash[:]))
+	return uuid.UUID(hash), nil
 }
 
 func (h *Connection) Create(db *database.Handler) (uuid.UUID, error) {

--- a/models/v1beta1/model/model_helper.go
+++ b/models/v1beta1/model/model_helper.go
@@ -4,7 +4,6 @@ package model
 
 import (
 	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -58,7 +57,7 @@ func (m *ModelDefinition) GenerateID() (uuid.UUID, error) {
 	}
 
 	hash := md5.Sum(byt)
-	return uuid.Parse(hex.EncodeToString(hash[:]))
+	return uuid.UUID(hash), nil
 }
 
 func (m ModelDefinition) GetID() uuid.UUID {

--- a/models/v1beta2/model/model_helper.go
+++ b/models/v1beta2/model/model_helper.go
@@ -4,7 +4,6 @@ package model
 
 import (
 	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"path/filepath"
@@ -58,7 +57,7 @@ func (m *ModelDefinition) GenerateID() (uuid.UUID, error) {
 	}
 
 	hash := md5.Sum(byt)
-	return uuid.Parse(hex.EncodeToString(hash[:]))
+	return uuid.UUID(hash), nil
 }
 
 func (m ModelDefinition) GetID() uuid.UUID {

--- a/models/v1beta3/component/component_helper.go
+++ b/models/v1beta3/component/component_helper.go
@@ -26,7 +26,7 @@ func (c ComponentDefinition) Type() entity.EntityType {
 }
 
 func (c *ComponentDefinition) GenerateID() (uuid.UUID, error) {
-	return uuid.New(), nil
+	return uuid.NewRandom()
 }
 
 func (c ComponentDefinition) GetID() uuid.UUID {

--- a/models/v1beta3/connection/connection_definition_helper.go
+++ b/models/v1beta3/connection/connection_definition_helper.go
@@ -22,7 +22,7 @@ func (c ConnectionDefinition) Type() entity.EntityType {
 }
 
 func (c *ConnectionDefinition) GenerateID() (uuid.UUID, error) {
-	return uuid.New(), nil
+	return uuid.NewRandom()
 }
 
 func (c ConnectionDefinition) GetID() uuid.UUID {


### PR DESCRIPTION
## Overview

This PR migrates the codebase from the `github.com/gofrs/uuid` library to the standard `github.com/google/uuid` library across all schema definitions and Go helper files.

## Changes

### Schema Updates
- Updated all OpenAPI schema files (`api.yml`) in `schemas/constructs/v1alpha1/`, `v1beta1/`, `v1beta2/`, and `v1beta3/` to reference `github.com/google/uuid` instead of `github.com/gofrs/uuid` in `x-go-type-import` directives
- Updated event schema files to use the new UUID library

### Go Code Migration
- **Helper files**: Updated imports in all `*_helper.go` files across model versions to use `github.com/google/uuid`
- **API function updates**:
  - Replaced `uuid.NewV4()` with `uuid.New()` (returns `uuid.UUID` directly, no error)
  - Replaced `uuid.FromString()` with `uuid.Parse()`
  - Replaced `uuid.FromStringOrNil()` with custom `parseUUIDOrNil()` helper
  - Replaced `uuid.Must(uuid.FromString())` with `uuid.MustParse()`
- **Conversion files**: Added helper functions `parseUUIDOrNil()` and `parseLegacyUUIDOrNil()` in design conversion files to handle UUID parsing with fallback to `uuid.Nil`
- **Build tooling**: Updated `build/generate-golang.js` to inject `github.com/google/uuid` imports and updated `build/lib/permissions.js` to generate code using `uuid.MustParse()`

### Tests
- Added `tests/validate-schemas-uuid-migration.test.js` to verify that generated Go code correctly imports the google/uuid library and uses `uuid.MustParse()` for constants
- Added `models/v1beta1/pattern/design_conversion_test.go` to test the new `parseUUIDOrNil()` helper function
- Updated existing test files to use the new UUID library API

## Notes for Reviewers

This is a straightforward library migration that improves compatibility by using the standard Google UUID library instead of a third-party alternative. The API differences are minimal and well-handled through helper functions where needed.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.