### PR TITLE
fix(academy): map v1beta3 registration/test-submission owner to db column

### DIFF
--- a/models/v1beta3/academy/academy.go
+++ b/models/v1beta3/academy/academy.go
@@ -202,7 +202,7 @@ type AcademyRegistration struct {
 	UpdatedAt core.Time         `db:"updated_at" json:"updatedAt" yaml:"updatedAt"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId core.Uuid `db:"user_id" json:"userId" yaml:"userId"`
+	UserId core.Uuid `db:"owner" json:"userId" yaml:"userId"`
 }
 
 // AcademyRegistrationStatus Status of the user's course registration
@@ -708,7 +708,7 @@ type TestSubmission struct {
 	UpdatedAt *time.Time `db:"updated_at" json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId core.Uuid `db:"user_id" json:"userId" yaml:"userId"`
+	UserId core.Uuid `db:"owner" json:"userId" yaml:"userId"`
 }
 
 // TestSubmissionStatus defines model for TestSubmissionStatus.

--- a/schemas/constructs/v1beta3/academy/api.yml
+++ b/schemas/constructs/v1beta3/academy/api.yml
@@ -1151,7 +1151,7 @@ components:
           $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid
           description: ID of the user (foreign key to User)
           x-oapi-codegen-extra-tags:
-            db: user_id
+            db: owner
         status:
           $ref: '#/components/schemas/AcademyRegistrationStatus'
           x-go-type: AcademyRegistrationStatus
@@ -1711,7 +1711,7 @@ components:
         userId:
           $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid
           x-oapi-codegen-extra-tags:
-            db: user_id
+            db: owner
         createdAt:
           description: When the submission was created or started
           type: string


### PR DESCRIPTION
## Symptom

Academy enrollment is down in production. \`POST /api/academy/register\` and \`GET /api/academy/registrations/*\` return HTTP 500; the UI shows \"Failed to enroll to content.\" Captured error:

```
pq: column "user_id" of relation "academy_registrations" does not exist at column 147 (42703)
```

## Root cause

The owner-consolidation migration in meshery-cloud (\`20260620000000_consolidate_ownership_properties\`) renamed \`academy_registrations.user_id → owner\` and \`test_submissions.user_id → owner\`, consolidating ownership to a single \`owner\` column - the same treatment every other v1beta3 construct (connection, filter, view, performance_profile, …) received.

The **v1beta3 academy package was missed**: \`AcademyRegistration.userId\` and \`TestSubmission.userId\` still carried \`db: user_id\`. pop builds its INSERT/SELECT column lists from the \`db:\` tag, so it referenced a column that no longer exists - breaking the entire academy registration + test-submission DAO surface.

## Fix

Set \`db: owner\` on the two **table-backed** structs in \`schemas/constructs/v1beta3/academy/api.yml\` (regenerated into \`models/v1beta3/academy/academy.go\`):

- \`AcademyRegistration.userId\`
- \`TestSubmission.userId\`

The wire tag is unchanged (\`json:"userId"\`) - this is purely the ORM (DB) mapping; the published API contract and all consumers (which send/read \`userId\`) are unaffected. DB \`owner\` ↔ wire \`userId\` is canonical (the ORM is the translation boundary).

**Intentionally not changed:** \`UserRegistration.userId\` remains \`db: user_id\`. It is a JOIN DTO populated by a query that aliases \`users.id AS user_id\`, not the registration owner column; changing it would break that read.

## Test plan

- [x] \`make validate-schemas\` - no blocking violations
- [x] \`make consumer-audit\` (cloud + meshery) - **no new drift** (\`user_id\` wire warnings unchanged at 2, both pre-existing/unrelated to this change)
- [x] Generated Go verified: \`db:"owner"\` on AcademyRegistration/TestSubmission, \`db:"user_id"\` retained on UserRegistration, \`json:"userId"\` preserved on all three
- [x] meshery-cloud builds against this change (\`go build ./...\`)
- [x] **Real DB round-trip** against a prod-equivalent dev schema (academy_registrations.owner): \`CreateAcademyRegistration\` (the enroll INSERT) + \`GetAcademyRegistrationForContent\` (select *) + \`IsUserRegistered\` all pass
- [x] **Control**: reverting to \`db:"user_id"\` reproduces the exact prod error (\`column "user_id" does not exist at column 147\`), confirming causality

## Downstream

- Consumed by meshery-cloud (companion go.mod bump PR to follow).