### PR TITLE
feat(user): type per-organization and per-team assigned role names on User

### DIFF
--- a/models/v1beta2/user/user.go
+++ b/models/v1beta2/user/user.go
@@ -64,6 +64,35 @@ type LoadTestPreferences struct {
 	T *string `json:"t,omitempty" yaml:"t,omitempty"`
 }
 
+// OrganizationWithRoles An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).
+type OrganizationWithRoles struct {
+	// Id A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	ID core.Uuid `db:"id" json:"id,omitempty" yaml:"id"`
+
+	// Name Name of the organization.
+	Name string `db:"name" json:"name,omitempty" yaml:"name,omitempty"`
+
+	// Description Human readable description of the organization.
+	Description *string `db:"description" json:"description,omitempty" yaml:"description,omitempty"`
+
+	// Country Country associated with the organization.
+	Country *string `db:"country" json:"country,omitempty" yaml:"country,omitempty"`
+
+	// Region Region associated with the organization.
+	Region *string `db:"region" json:"region,omitempty" yaml:"region,omitempty"`
+
+	// Owner A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	Owner     *core.Uuid `db:"owner" json:"owner,omitempty" yaml:"owner,omitempty"`
+	CreatedAt core.Time  `db:"created_at" json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+	UpdatedAt core.Time  `db:"updated_at" json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// DeletedAt Timestamp when the organization was soft-deleted (null if not deleted).
+	DeletedAt *core.NullTime `db:"deleted_at" json:"deletedAt,omitempty" yaml:"deletedAt,omitempty"`
+
+	// RoleNames Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.
+	RoleNames []string `db:"role_names" json:"roleNames" yaml:"roleNames"`
+}
+
 // Panel Grafana panel structure imported from github.com/grafana-tools/sdk
 type Panel = map[string]interface{}
 
@@ -130,6 +159,32 @@ type Social struct {
 	Site string `json:"site" yaml:"site"`
 }
 
+// TeamWithRoles A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).
+type TeamWithRoles struct {
+	// Id A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	ID core.Uuid `db:"id" json:"id,omitempty" yaml:"id"`
+
+	// Name Name of the team.
+	Name string `db:"name" json:"name,omitempty" yaml:"name,omitempty"`
+
+	// Description Human readable description of the team.
+	Description *string `db:"description" json:"description,omitempty" yaml:"description,omitempty"`
+
+	// Owner A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	Owner *core.Uuid `db:"owner" json:"owner,omitempty" yaml:"owner,omitempty"`
+
+	// Metadata Free-form metadata associated with the team.
+	Metadata  core.Map          `db:"metadata" json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	CreatedAt core.Time `db:"created_at" json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+	UpdatedAt core.Time `db:"updated_at" json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// DeletedAt Timestamp when the team was soft-deleted (null if not deleted).
+	DeletedAt *core.NullTime `db:"deleted_at" json:"deletedAt,omitempty" yaml:"deletedAt,omitempty"`
+
+	// RoleNames Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.
+	RoleNames []string `db:"role_names" json:"roleNames" yaml:"roleNames"`
+}
+
 // User Represents a user
 type User struct {
 	AcceptedTermsAt core.Time `db:"accepted_terms_at" json:"acceptedTermsAt" yaml:"acceptedTermsAt,omitempty"`
@@ -164,7 +219,7 @@ type User struct {
 	// Organizations Organizations the user belongs to with role information
 	Organizations *struct {
 		// OrganizationsWithRoles Organization memberships for the user with their assigned roles.
-		OrganizationsWithRoles *[]map[string]interface{} `db:"organizations_with_roles" json:"organizationsWithRoles" yaml:"organizationsWithRoles"`
+		OrganizationsWithRoles *[]OrganizationWithRoles `db:"organizations_with_roles" json:"organizationsWithRoles" yaml:"organizationsWithRoles"`
 
 		// TotalCount Total number of organization memberships returned for the user.
 		TotalCount *int `db:"total_count" json:"totalCount" yaml:"totalCount"`
@@ -189,7 +244,7 @@ type User struct {
 	// Teams Teams the user belongs to with role information
 	Teams *struct {
 		// TeamsWithRoles Team memberships for the user with their assigned roles.
-		TeamsWithRoles *[]map[string]interface{} `db:"teams_with_roles" json:"teamsWithRoles" yaml:"teamsWithRoles"`
+		TeamsWithRoles *[]TeamWithRoles `db:"teams_with_roles" json:"teamsWithRoles" yaml:"teamsWithRoles"`
 
 		// TotalCount Total number of team memberships returned for the user.
 		TotalCount *int `db:"total_count" json:"totalCount" yaml:"totalCount"`

--- a/models/v1beta2/user/user.go
+++ b/models/v1beta2/user/user.go
@@ -12,18 +12,6 @@ import (
 	"github.com/gofrs/uuid"
 )
 
-// Defines values for UserRoleNames.
-const (
-	UserRoleNamesAdmin             UserRoleNames = "admin"
-	UserRoleNamesCurator           UserRoleNames = "curator"
-	UserRoleNamesMeshmap           UserRoleNames = "meshmap"
-	UserRoleNamesOrganizationAdmin UserRoleNames = "organization admin"
-	UserRoleNamesTeamAdmin         UserRoleNames = "team admin"
-	UserRoleNamesUser              UserRoleNames = "user"
-	UserRoleNamesWorkspaceAdmin    UserRoleNames = "workspace admin"
-	UserRoleNamesWorkspaceManager  UserRoleNames = "workspace manager"
-)
-
 // Defines values for UserStatus.
 const (
 	Active    UserStatus = "active"
@@ -233,8 +221,8 @@ type User struct {
 	// Region User's region information stored as JSONB
 	Region core.Map `db:"region" json:"region" yaml:"region"`
 
-	// RoleNames List of global roles assigned to the user
-	RoleNames *[]UserRoleNames `db:"role_names" json:"roleNames" yaml:"roleNames"`
+	// RoleNames Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
+	RoleNames pq.StringArray `db:"role_names" json:"roleNames" yaml:"roleNames"`
 
 	// Socials Various online profiles associated with the user account
 	Socials *UserSocials `db:"socials" json:"socials" yaml:"socials"`
@@ -255,9 +243,6 @@ type User struct {
 	// UserId User identifier (username or external ID)
 	UserId string `db:"user_id" json:"userId" yaml:"userId"`
 }
-
-// UserRoleNames defines model for User.RoleNames.
-type UserRoleNames string
 
 // UserStatus User account status
 type UserStatus string

--- a/models/v1beta2/user/user.go
+++ b/models/v1beta2/user/user.go
@@ -6,6 +6,7 @@ package user
 import (
 	"time"
 
+	"github.com/lib/pq"
 	"github.com/meshery/schemas/models/core"
 	openapi_types "github.com/oapi-codegen/runtime/types"
 	"github.com/gofrs/uuid"
@@ -90,7 +91,7 @@ type OrganizationWithRoles struct {
 	DeletedAt *core.NullTime `db:"deleted_at" json:"deletedAt,omitempty" yaml:"deletedAt,omitempty"`
 
 	// RoleNames Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.
-	RoleNames []string `db:"role_names" json:"roleNames" yaml:"roleNames"`
+	RoleNames pq.StringArray `db:"role_names" json:"roleNames" yaml:"roleNames"`
 }
 
 // Panel Grafana panel structure imported from github.com/grafana-tools/sdk
@@ -182,7 +183,7 @@ type TeamWithRoles struct {
 	DeletedAt *core.NullTime `db:"deleted_at" json:"deletedAt,omitempty" yaml:"deletedAt,omitempty"`
 
 	// RoleNames Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.
-	RoleNames []string `db:"role_names" json:"roleNames" yaml:"roleNames"`
+	RoleNames pq.StringArray `db:"role_names" json:"roleNames" yaml:"roleNames"`
 }
 
 // User Represents a user

--- a/schemas/constructs/v1beta2/role/api.yml
+++ b/schemas/constructs/v1beta2/role/api.yml
@@ -79,7 +79,14 @@ paths:
         - roles
       summary: Get organization roles
       operationId: getAllRoles
-      description: Returns all roles defined for the specified organization.
+      description: >-
+        Returns all roles defined for the specified organization — the seeded
+        system roles plus any custom roles the organization has created. This is
+        the canonical, drift-free source for surfacing roles to tooling (role
+        pickers, dropdown defaults, docs): role names are free-form, user-defined
+        strings (User.roleNames and Role.roleName are open arrays, not an
+        enumeration), so clients should list them here rather than hard-code a
+        fixed set.
       parameters:
         - $ref: "#/components/parameters/orgId"
         - $ref: "#/components/parameters/page"

--- a/schemas/constructs/v1beta2/user/api.yml
+++ b/schemas/constructs/v1beta2/user/api.yml
@@ -499,12 +499,14 @@ components:
             json: "deletedAt,omitempty"
         roleNames:
           type: array
+          x-go-type: pq.StringArray
+          x-go-type-import:
+            path: github.com/lib/pq
           description: >-
             Names of the roles assigned to the user within this organization.
             Free-form, user-generated role names; not a fixed enumeration.
           items:
             type: string
-          x-go-type-skip-optional-pointer: true
           x-order: 10
           x-oapi-codegen-extra-tags:
             db: "role_names"
@@ -588,12 +590,14 @@ components:
             json: "deletedAt,omitempty"
         roleNames:
           type: array
+          x-go-type: pq.StringArray
+          x-go-type-import:
+            path: github.com/lib/pq
           description: >-
             Names of the roles assigned to the user within this team.
             Free-form, user-generated role names; not a fixed enumeration.
           items:
             type: string
-          x-go-type-skip-optional-pointer: true
           x-order: 9
           x-oapi-codegen-extra-tags:
             db: "role_names"

--- a/schemas/constructs/v1beta2/user/api.yml
+++ b/schemas/constructs/v1beta2/user/api.yml
@@ -382,7 +382,7 @@ components:
               type: array
               description: Team memberships for the user with their assigned roles.
               items:
-                type: object
+                $ref: "#/components/schemas/TeamWithRoles"
               x-oapi-codegen-extra-tags:
                 db: "teams_with_roles"
                 json: "teamsWithRoles"
@@ -404,7 +404,7 @@ components:
               type: array
               description: Organization memberships for the user with their assigned roles.
               items:
-                type: object
+                $ref: "#/components/schemas/OrganizationWithRoles"
               x-oapi-codegen-extra-tags:
                 db: "organizations_with_roles"
                 json: "organizationsWithRoles"
@@ -416,6 +416,188 @@ components:
                 db: "total_count"
                 json: "totalCount"
       additionalProperties: false
+
+    OrganizationWithRoles:
+      type: object
+      additionalProperties: false
+      description: >-
+        An organization the user is a member of, together with the names of
+        the roles assigned to that user within the organization. Returned as
+        an item of User.organizations.organizationsWithRoles. The role names
+        are dynamic, user-generated values (no fixed enumeration).
+      required:
+        - id
+        - name
+        - roleNames
+      properties:
+        id:
+          $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: Unique identifier of the organization.
+          x-go-name: ID
+          x-order: 1
+          x-oapi-codegen-extra-tags:
+            db: "id"
+            json: "id,omitempty"
+        name:
+          type: string
+          description: Name of the organization.
+          x-order: 2
+          x-oapi-codegen-extra-tags:
+            db: "name"
+            json: "name,omitempty"
+        description:
+          type: string
+          description: Human readable description of the organization.
+          x-order: 3
+          x-oapi-codegen-extra-tags:
+            db: "description"
+            json: "description,omitempty"
+        country:
+          type: string
+          description: Country associated with the organization.
+          x-order: 4
+          x-oapi-codegen-extra-tags:
+            db: "country"
+            json: "country,omitempty"
+        region:
+          type: string
+          description: Region associated with the organization.
+          x-order: 5
+          x-oapi-codegen-extra-tags:
+            db: "region"
+            json: "region,omitempty"
+        owner:
+          $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: Identifier of the organization owner.
+          x-order: 6
+          x-oapi-codegen-extra-tags:
+            db: "owner"
+            json: "owner,omitempty"
+        createdAt:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the organization was created.
+          x-order: 7
+          x-oapi-codegen-extra-tags:
+            db: "created_at"
+            json: "createdAt,omitempty"
+        updatedAt:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the organization was last updated.
+          x-order: 8
+          x-oapi-codegen-extra-tags:
+            db: "updated_at"
+            json: "updatedAt,omitempty"
+        deletedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp when the organization was soft-deleted (null if not deleted).
+          x-go-type: "core.NullTime"
+          x-order: 9
+          x-oapi-codegen-extra-tags:
+            db: "deleted_at"
+            json: "deletedAt,omitempty"
+        roleNames:
+          type: array
+          description: >-
+            Names of the roles assigned to the user within this organization.
+            Free-form, user-generated role names; not a fixed enumeration.
+          items:
+            type: string
+          x-go-type-skip-optional-pointer: true
+          x-order: 10
+          x-oapi-codegen-extra-tags:
+            db: "role_names"
+            json: "roleNames"
+
+    TeamWithRoles:
+      type: object
+      additionalProperties: false
+      description: >-
+        A team the user is a member of, together with the names of the roles
+        assigned to that user within the team. Returned as an item of
+        User.teams.teamsWithRoles. The role names are dynamic, user-generated
+        values (no fixed enumeration).
+      required:
+        - id
+        - name
+        - roleNames
+      properties:
+        id:
+          $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: Unique identifier of the team.
+          x-go-name: ID
+          x-order: 1
+          x-oapi-codegen-extra-tags:
+            db: "id"
+            json: "id,omitempty"
+        name:
+          type: string
+          description: Name of the team.
+          x-order: 2
+          x-oapi-codegen-extra-tags:
+            db: "name"
+            json: "name,omitempty"
+        description:
+          type: string
+          description: Human readable description of the team.
+          x-order: 3
+          x-oapi-codegen-extra-tags:
+            db: "description"
+            json: "description,omitempty"
+        owner:
+          $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: Identifier of the team owner.
+          x-order: 4
+          x-oapi-codegen-extra-tags:
+            db: "owner"
+            json: "owner,omitempty"
+        metadata:
+          type: object
+          additionalProperties: true
+          description: Free-form metadata associated with the team.
+          x-go-type: "core.Map"
+          x-go-type-skip-optional-pointer: true
+          x-order: 5
+          x-oapi-codegen-extra-tags:
+            db: "metadata"
+            json: "metadata,omitempty"
+        createdAt:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the team was created.
+          x-order: 6
+          x-oapi-codegen-extra-tags:
+            db: "created_at"
+            json: "createdAt,omitempty"
+        updatedAt:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the team was last updated.
+          x-order: 7
+          x-oapi-codegen-extra-tags:
+            db: "updated_at"
+            json: "updatedAt,omitempty"
+        deletedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Timestamp when the team was soft-deleted (null if not deleted).
+          x-go-type: "core.NullTime"
+          x-order: 8
+          x-oapi-codegen-extra-tags:
+            db: "deleted_at"
+            json: "deletedAt,omitempty"
+        roleNames:
+          type: array
+          description: >-
+            Names of the roles assigned to the user within this team.
+            Free-form, user-generated role names; not a fixed enumeration.
+          items:
+            type: string
+          x-go-type-skip-optional-pointer: true
+          x-order: 9
+          x-oapi-codegen-extra-tags:
+            db: "role_names"
+            json: "roleNames"
 
     UsersPageForAdmin:
       type: object

--- a/schemas/constructs/v1beta2/user/api.yml
+++ b/schemas/constructs/v1beta2/user/api.yml
@@ -367,7 +367,7 @@ components:
             varchar, not a fixed enumeration); the seeded system roles such as
             "admin", "organization admin" and "user" are a subset, not the whole
             set.
-          example: ["admin", "organization admin"]
+          example: ["organization admin", "user"]
           x-oapi-codegen-extra-tags:
             db: "role_names"
             json: "roleNames"

--- a/schemas/constructs/v1beta2/user/api.yml
+++ b/schemas/constructs/v1beta2/user/api.yml
@@ -355,19 +355,19 @@ components:
             json: "deletedAt"
         roleNames:
           type: array
+          x-go-type: pq.StringArray
+          x-go-type-import:
+            path: github.com/lib/pq
+          x-go-type-skip-optional-pointer: true
           items:
             type: string
-            enum:
-              - admin
-              - meshmap
-              - curator
-              - team admin
-              - workspace admin
-              - workspace manager
-              - organization admin
-              - user
-          description: List of global roles assigned to the user
-          example: ["admin", "meshmap"]
+          description: >-
+            Names of the global roles assigned to the user. Free-form,
+            user-generated values sourced from the roles table (role_name is a
+            varchar, not a fixed enumeration); the seeded system roles such as
+            "admin", "organization admin" and "user" are a subset, not the whole
+            set.
+          example: ["admin", "organization admin"]
           x-oapi-codegen-extra-tags:
             db: "role_names"
             json: "roleNames"

--- a/typescript/generated/v1beta2/role/Role.ts
+++ b/typescript/generated/v1beta2/role/Role.ts
@@ -53,7 +53,7 @@ export interface paths {
         };
         /**
          * Get organization roles
-         * @description Returns all roles defined for the specified organization.
+         * @description Returns all roles defined for the specified organization — the seeded system roles plus any custom roles the organization has created. This is the canonical, drift-free source for surfacing roles to tooling (role pickers, dropdown defaults, docs): role names are free-form, user-defined strings (User.roleNames and Role.roleName are open arrays, not an enumeration), so clients should list them here rather than hard-code a fixed set.
          */
         get: operations["getAllRoles"];
         /**

--- a/typescript/generated/v1beta2/role/RoleSchema.ts
+++ b/typescript/generated/v1beta2/role/RoleSchema.ts
@@ -211,7 +211,7 @@ const RoleSchema: Record<string, unknown> = {
         ],
         "summary": "Get organization roles",
         "operationId": "getAllRoles",
-        "description": "Returns all roles defined for the specified organization.",
+        "description": "Returns all roles defined for the specified organization — the seeded system roles plus any custom roles the organization has created. This is the canonical, drift-free source for surfacing roles to tooling (role pickers, dropdown defaults, docs): role names are free-form, user-defined strings (User.roleNames and Role.roleName are open arrays, not an enumeration), so clients should list them here rather than hard-code a fixed set.",
         "parameters": [
           {
             "name": "orgId",

--- a/typescript/generated/v1beta2/user/User.ts
+++ b/typescript/generated/v1beta2/user/User.ts
@@ -247,13 +247,13 @@ export interface components {
              */
             deletedAt: string | null;
             /**
-             * @description List of global roles assigned to the user
+             * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
              * @example [
              *       "admin",
-             *       "meshmap"
+             *       "organization admin"
              *     ]
              */
-            roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+            roleNames?: string[];
             /** @description Teams the user belongs to with role information */
             teams?: {
                 /** @description Team memberships for the user with their assigned roles. */
@@ -590,13 +590,13 @@ export interface components {
                  */
                 deletedAt: string | null;
                 /**
-                 * @description List of global roles assigned to the user
+                 * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                  * @example [
                  *       "admin",
-                 *       "meshmap"
+                 *       "organization admin"
                  *     ]
                  */
-                roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                roleNames?: string[];
                 /** @description Teams the user belongs to with role information */
                 teams?: {
                     /** @description Team memberships for the user with their assigned roles. */
@@ -858,13 +858,13 @@ export interface components {
                  */
                 deletedAt: string | null;
                 /**
-                 * @description List of global roles assigned to the user
+                 * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                  * @example [
                  *       "admin",
-                 *       "meshmap"
+                 *       "organization admin"
                  *     ]
                  */
-                roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                roleNames?: string[];
                 /** @description Teams the user belongs to with role information */
                 teams?: {
                     /** @description Team memberships for the user with their assigned roles. */
@@ -1353,13 +1353,13 @@ export interface operations {
                              */
                             deletedAt: string | null;
                             /**
-                             * @description List of global roles assigned to the user
+                             * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                              * @example [
                              *       "admin",
-                             *       "meshmap"
+                             *       "organization admin"
                              *     ]
                              */
-                            roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                            roleNames?: string[];
                             /** @description Teams the user belongs to with role information */
                             teams?: {
                                 /** @description Team memberships for the user with their assigned roles. */
@@ -1686,13 +1686,13 @@ export interface operations {
                              */
                             deletedAt: string | null;
                             /**
-                             * @description List of global roles assigned to the user
+                             * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                              * @example [
                              *       "admin",
-                             *       "meshmap"
+                             *       "organization admin"
                              *     ]
                              */
-                            roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                            roleNames?: string[];
                             /** @description Teams the user belongs to with role information */
                             teams?: {
                                 /** @description Team memberships for the user with their assigned roles. */
@@ -1994,13 +1994,13 @@ export interface operations {
                          */
                         deletedAt: string | null;
                         /**
-                         * @description List of global roles assigned to the user
+                         * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                          * @example [
                          *       "admin",
-                         *       "meshmap"
+                         *       "organization admin"
                          *     ]
                          */
-                        roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                        roleNames?: string[];
                         /** @description Teams the user belongs to with role information */
                         teams?: {
                             /** @description Team memberships for the user with their assigned roles. */
@@ -2307,13 +2307,13 @@ export interface operations {
                          */
                         deletedAt: string | null;
                         /**
-                         * @description List of global roles assigned to the user
+                         * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                          * @example [
                          *       "admin",
-                         *       "meshmap"
+                         *       "organization admin"
                          *     ]
                          */
-                        roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                        roleNames?: string[];
                         /** @description Teams the user belongs to with role information */
                         teams?: {
                             /** @description Team memberships for the user with their assigned roles. */

--- a/typescript/generated/v1beta2/user/User.ts
+++ b/typescript/generated/v1beta2/user/User.ts
@@ -249,8 +249,8 @@ export interface components {
             /**
              * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
              * @example [
-             *       "admin",
-             *       "organization admin"
+             *       "organization admin",
+             *       "user"
              *     ]
              */
             roleNames?: string[];
@@ -592,8 +592,8 @@ export interface components {
                 /**
                  * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                  * @example [
-                 *       "admin",
-                 *       "organization admin"
+                 *       "organization admin",
+                 *       "user"
                  *     ]
                  */
                 roleNames?: string[];
@@ -860,8 +860,8 @@ export interface components {
                 /**
                  * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                  * @example [
-                 *       "admin",
-                 *       "organization admin"
+                 *       "organization admin",
+                 *       "user"
                  *     ]
                  */
                 roleNames?: string[];
@@ -1355,8 +1355,8 @@ export interface operations {
                             /**
                              * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                              * @example [
-                             *       "admin",
-                             *       "organization admin"
+                             *       "organization admin",
+                             *       "user"
                              *     ]
                              */
                             roleNames?: string[];
@@ -1688,8 +1688,8 @@ export interface operations {
                             /**
                              * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                              * @example [
-                             *       "admin",
-                             *       "organization admin"
+                             *       "organization admin",
+                             *       "user"
                              *     ]
                              */
                             roleNames?: string[];
@@ -1996,8 +1996,8 @@ export interface operations {
                         /**
                          * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                          * @example [
-                         *       "admin",
-                         *       "organization admin"
+                         *       "organization admin",
+                         *       "user"
                          *     ]
                          */
                         roleNames?: string[];
@@ -2309,8 +2309,8 @@ export interface operations {
                         /**
                          * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                          * @example [
-                         *       "admin",
-                         *       "organization admin"
+                         *       "organization admin",
+                         *       "user"
                          *     ]
                          */
                         roleNames?: string[];

--- a/typescript/generated/v1beta2/user/User.ts
+++ b/typescript/generated/v1beta2/user/User.ts
@@ -257,17 +257,165 @@ export interface components {
             /** @description Teams the user belongs to with role information */
             teams?: {
                 /** @description Team memberships for the user with their assigned roles. */
-                teamsWithRoles?: Record<string, never>[];
+                teamsWithRoles?: {
+                    /**
+                     * Format: uuid
+                     * @description Unique identifier of the team.
+                     */
+                    id: string;
+                    /** @description Name of the team. */
+                    name: string;
+                    /** @description Human readable description of the team. */
+                    description?: string;
+                    /**
+                     * Format: uuid
+                     * @description Identifier of the team owner.
+                     */
+                    owner?: string;
+                    /** @description Free-form metadata associated with the team. */
+                    metadata?: {
+                        [key: string]: unknown;
+                    };
+                    /**
+                     * Format: date-time
+                     * @description Timestamp when the team was created.
+                     */
+                    createdAt?: string;
+                    /**
+                     * Format: date-time
+                     * @description Timestamp when the team was last updated.
+                     */
+                    updatedAt?: string;
+                    /**
+                     * Format: date-time
+                     * @description Timestamp when the team was soft-deleted (null if not deleted).
+                     */
+                    deletedAt?: string | null;
+                    /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                    roleNames: string[];
+                }[];
                 /** @description Total number of team memberships returned for the user. */
                 totalCount?: number;
             };
             /** @description Organizations the user belongs to with role information */
             organizations?: {
                 /** @description Organization memberships for the user with their assigned roles. */
-                organizationsWithRoles?: Record<string, never>[];
+                organizationsWithRoles?: {
+                    /**
+                     * Format: uuid
+                     * @description Unique identifier of the organization.
+                     */
+                    id: string;
+                    /** @description Name of the organization. */
+                    name: string;
+                    /** @description Human readable description of the organization. */
+                    description?: string;
+                    /** @description Country associated with the organization. */
+                    country?: string;
+                    /** @description Region associated with the organization. */
+                    region?: string;
+                    /**
+                     * Format: uuid
+                     * @description Identifier of the organization owner.
+                     */
+                    owner?: string;
+                    /**
+                     * Format: date-time
+                     * @description Timestamp when the organization was created.
+                     */
+                    createdAt?: string;
+                    /**
+                     * Format: date-time
+                     * @description Timestamp when the organization was last updated.
+                     */
+                    updatedAt?: string;
+                    /**
+                     * Format: date-time
+                     * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                     */
+                    deletedAt?: string | null;
+                    /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                    roleNames: string[];
+                }[];
                 /** @description Total number of organization memberships returned for the user. */
                 totalCount?: number;
             };
+        };
+        /** @description An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration). */
+        OrganizationWithRoles: {
+            /**
+             * Format: uuid
+             * @description Unique identifier of the organization.
+             */
+            id: string;
+            /** @description Name of the organization. */
+            name: string;
+            /** @description Human readable description of the organization. */
+            description?: string;
+            /** @description Country associated with the organization. */
+            country?: string;
+            /** @description Region associated with the organization. */
+            region?: string;
+            /**
+             * Format: uuid
+             * @description Identifier of the organization owner.
+             */
+            owner?: string;
+            /**
+             * Format: date-time
+             * @description Timestamp when the organization was created.
+             */
+            createdAt?: string;
+            /**
+             * Format: date-time
+             * @description Timestamp when the organization was last updated.
+             */
+            updatedAt?: string;
+            /**
+             * Format: date-time
+             * @description Timestamp when the organization was soft-deleted (null if not deleted).
+             */
+            deletedAt?: string | null;
+            /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+            roleNames: string[];
+        };
+        /** @description A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration). */
+        TeamWithRoles: {
+            /**
+             * Format: uuid
+             * @description Unique identifier of the team.
+             */
+            id: string;
+            /** @description Name of the team. */
+            name: string;
+            /** @description Human readable description of the team. */
+            description?: string;
+            /**
+             * Format: uuid
+             * @description Identifier of the team owner.
+             */
+            owner?: string;
+            /** @description Free-form metadata associated with the team. */
+            metadata?: {
+                [key: string]: unknown;
+            };
+            /**
+             * Format: date-time
+             * @description Timestamp when the team was created.
+             */
+            createdAt?: string;
+            /**
+             * Format: date-time
+             * @description Timestamp when the team was last updated.
+             */
+            updatedAt?: string;
+            /**
+             * Format: date-time
+             * @description Timestamp when the team was soft-deleted (null if not deleted).
+             */
+            deletedAt?: string | null;
+            /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+            roleNames: string[];
         };
         /** @description Paginated list of users with organization and team role context */
         UsersPageForAdmin: {
@@ -452,14 +600,86 @@ export interface components {
                 /** @description Teams the user belongs to with role information */
                 teams?: {
                     /** @description Team memberships for the user with their assigned roles. */
-                    teamsWithRoles?: Record<string, never>[];
+                    teamsWithRoles?: {
+                        /**
+                         * Format: uuid
+                         * @description Unique identifier of the team.
+                         */
+                        id: string;
+                        /** @description Name of the team. */
+                        name: string;
+                        /** @description Human readable description of the team. */
+                        description?: string;
+                        /**
+                         * Format: uuid
+                         * @description Identifier of the team owner.
+                         */
+                        owner?: string;
+                        /** @description Free-form metadata associated with the team. */
+                        metadata?: {
+                            [key: string]: unknown;
+                        };
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the team was created.
+                         */
+                        createdAt?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the team was last updated.
+                         */
+                        updatedAt?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the team was soft-deleted (null if not deleted).
+                         */
+                        deletedAt?: string | null;
+                        /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                        roleNames: string[];
+                    }[];
                     /** @description Total number of team memberships returned for the user. */
                     totalCount?: number;
                 };
                 /** @description Organizations the user belongs to with role information */
                 organizations?: {
                     /** @description Organization memberships for the user with their assigned roles. */
-                    organizationsWithRoles?: Record<string, never>[];
+                    organizationsWithRoles?: {
+                        /**
+                         * Format: uuid
+                         * @description Unique identifier of the organization.
+                         */
+                        id: string;
+                        /** @description Name of the organization. */
+                        name: string;
+                        /** @description Human readable description of the organization. */
+                        description?: string;
+                        /** @description Country associated with the organization. */
+                        country?: string;
+                        /** @description Region associated with the organization. */
+                        region?: string;
+                        /**
+                         * Format: uuid
+                         * @description Identifier of the organization owner.
+                         */
+                        owner?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the organization was created.
+                         */
+                        createdAt?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the organization was last updated.
+                         */
+                        updatedAt?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                         */
+                        deletedAt?: string | null;
+                        /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                        roleNames: string[];
+                    }[];
                     /** @description Total number of organization memberships returned for the user. */
                     totalCount?: number;
                 };
@@ -648,14 +868,86 @@ export interface components {
                 /** @description Teams the user belongs to with role information */
                 teams?: {
                     /** @description Team memberships for the user with their assigned roles. */
-                    teamsWithRoles?: Record<string, never>[];
+                    teamsWithRoles?: {
+                        /**
+                         * Format: uuid
+                         * @description Unique identifier of the team.
+                         */
+                        id: string;
+                        /** @description Name of the team. */
+                        name: string;
+                        /** @description Human readable description of the team. */
+                        description?: string;
+                        /**
+                         * Format: uuid
+                         * @description Identifier of the team owner.
+                         */
+                        owner?: string;
+                        /** @description Free-form metadata associated with the team. */
+                        metadata?: {
+                            [key: string]: unknown;
+                        };
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the team was created.
+                         */
+                        createdAt?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the team was last updated.
+                         */
+                        updatedAt?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the team was soft-deleted (null if not deleted).
+                         */
+                        deletedAt?: string | null;
+                        /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                        roleNames: string[];
+                    }[];
                     /** @description Total number of team memberships returned for the user. */
                     totalCount?: number;
                 };
                 /** @description Organizations the user belongs to with role information */
                 organizations?: {
                     /** @description Organization memberships for the user with their assigned roles. */
-                    organizationsWithRoles?: Record<string, never>[];
+                    organizationsWithRoles?: {
+                        /**
+                         * Format: uuid
+                         * @description Unique identifier of the organization.
+                         */
+                        id: string;
+                        /** @description Name of the organization. */
+                        name: string;
+                        /** @description Human readable description of the organization. */
+                        description?: string;
+                        /** @description Country associated with the organization. */
+                        country?: string;
+                        /** @description Region associated with the organization. */
+                        region?: string;
+                        /**
+                         * Format: uuid
+                         * @description Identifier of the organization owner.
+                         */
+                        owner?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the organization was created.
+                         */
+                        createdAt?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the organization was last updated.
+                         */
+                        updatedAt?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                         */
+                        deletedAt?: string | null;
+                        /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                        roleNames: string[];
+                    }[];
                     /** @description Total number of organization memberships returned for the user. */
                     totalCount?: number;
                 };
@@ -1071,14 +1363,86 @@ export interface operations {
                             /** @description Teams the user belongs to with role information */
                             teams?: {
                                 /** @description Team memberships for the user with their assigned roles. */
-                                teamsWithRoles?: Record<string, never>[];
+                                teamsWithRoles?: {
+                                    /**
+                                     * Format: uuid
+                                     * @description Unique identifier of the team.
+                                     */
+                                    id: string;
+                                    /** @description Name of the team. */
+                                    name: string;
+                                    /** @description Human readable description of the team. */
+                                    description?: string;
+                                    /**
+                                     * Format: uuid
+                                     * @description Identifier of the team owner.
+                                     */
+                                    owner?: string;
+                                    /** @description Free-form metadata associated with the team. */
+                                    metadata?: {
+                                        [key: string]: unknown;
+                                    };
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was created.
+                                     */
+                                    createdAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was last updated.
+                                     */
+                                    updatedAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was soft-deleted (null if not deleted).
+                                     */
+                                    deletedAt?: string | null;
+                                    /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                                    roleNames: string[];
+                                }[];
                                 /** @description Total number of team memberships returned for the user. */
                                 totalCount?: number;
                             };
                             /** @description Organizations the user belongs to with role information */
                             organizations?: {
                                 /** @description Organization memberships for the user with their assigned roles. */
-                                organizationsWithRoles?: Record<string, never>[];
+                                organizationsWithRoles?: {
+                                    /**
+                                     * Format: uuid
+                                     * @description Unique identifier of the organization.
+                                     */
+                                    id: string;
+                                    /** @description Name of the organization. */
+                                    name: string;
+                                    /** @description Human readable description of the organization. */
+                                    description?: string;
+                                    /** @description Country associated with the organization. */
+                                    country?: string;
+                                    /** @description Region associated with the organization. */
+                                    region?: string;
+                                    /**
+                                     * Format: uuid
+                                     * @description Identifier of the organization owner.
+                                     */
+                                    owner?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was created.
+                                     */
+                                    createdAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was last updated.
+                                     */
+                                    updatedAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                                     */
+                                    deletedAt?: string | null;
+                                    /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                                    roleNames: string[];
+                                }[];
                                 /** @description Total number of organization memberships returned for the user. */
                                 totalCount?: number;
                             };
@@ -1332,14 +1696,86 @@ export interface operations {
                             /** @description Teams the user belongs to with role information */
                             teams?: {
                                 /** @description Team memberships for the user with their assigned roles. */
-                                teamsWithRoles?: Record<string, never>[];
+                                teamsWithRoles?: {
+                                    /**
+                                     * Format: uuid
+                                     * @description Unique identifier of the team.
+                                     */
+                                    id: string;
+                                    /** @description Name of the team. */
+                                    name: string;
+                                    /** @description Human readable description of the team. */
+                                    description?: string;
+                                    /**
+                                     * Format: uuid
+                                     * @description Identifier of the team owner.
+                                     */
+                                    owner?: string;
+                                    /** @description Free-form metadata associated with the team. */
+                                    metadata?: {
+                                        [key: string]: unknown;
+                                    };
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was created.
+                                     */
+                                    createdAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was last updated.
+                                     */
+                                    updatedAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was soft-deleted (null if not deleted).
+                                     */
+                                    deletedAt?: string | null;
+                                    /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                                    roleNames: string[];
+                                }[];
                                 /** @description Total number of team memberships returned for the user. */
                                 totalCount?: number;
                             };
                             /** @description Organizations the user belongs to with role information */
                             organizations?: {
                                 /** @description Organization memberships for the user with their assigned roles. */
-                                organizationsWithRoles?: Record<string, never>[];
+                                organizationsWithRoles?: {
+                                    /**
+                                     * Format: uuid
+                                     * @description Unique identifier of the organization.
+                                     */
+                                    id: string;
+                                    /** @description Name of the organization. */
+                                    name: string;
+                                    /** @description Human readable description of the organization. */
+                                    description?: string;
+                                    /** @description Country associated with the organization. */
+                                    country?: string;
+                                    /** @description Region associated with the organization. */
+                                    region?: string;
+                                    /**
+                                     * Format: uuid
+                                     * @description Identifier of the organization owner.
+                                     */
+                                    owner?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was created.
+                                     */
+                                    createdAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was last updated.
+                                     */
+                                    updatedAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                                     */
+                                    deletedAt?: string | null;
+                                    /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                                    roleNames: string[];
+                                }[];
                                 /** @description Total number of organization memberships returned for the user. */
                                 totalCount?: number;
                             };
@@ -1568,14 +2004,86 @@ export interface operations {
                         /** @description Teams the user belongs to with role information */
                         teams?: {
                             /** @description Team memberships for the user with their assigned roles. */
-                            teamsWithRoles?: Record<string, never>[];
+                            teamsWithRoles?: {
+                                /**
+                                 * Format: uuid
+                                 * @description Unique identifier of the team.
+                                 */
+                                id: string;
+                                /** @description Name of the team. */
+                                name: string;
+                                /** @description Human readable description of the team. */
+                                description?: string;
+                                /**
+                                 * Format: uuid
+                                 * @description Identifier of the team owner.
+                                 */
+                                owner?: string;
+                                /** @description Free-form metadata associated with the team. */
+                                metadata?: {
+                                    [key: string]: unknown;
+                                };
+                                /**
+                                 * Format: date-time
+                                 * @description Timestamp when the team was created.
+                                 */
+                                createdAt?: string;
+                                /**
+                                 * Format: date-time
+                                 * @description Timestamp when the team was last updated.
+                                 */
+                                updatedAt?: string;
+                                /**
+                                 * Format: date-time
+                                 * @description Timestamp when the team was soft-deleted (null if not deleted).
+                                 */
+                                deletedAt?: string | null;
+                                /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                                roleNames: string[];
+                            }[];
                             /** @description Total number of team memberships returned for the user. */
                             totalCount?: number;
                         };
                         /** @description Organizations the user belongs to with role information */
                         organizations?: {
                             /** @description Organization memberships for the user with their assigned roles. */
-                            organizationsWithRoles?: Record<string, never>[];
+                            organizationsWithRoles?: {
+                                /**
+                                 * Format: uuid
+                                 * @description Unique identifier of the organization.
+                                 */
+                                id: string;
+                                /** @description Name of the organization. */
+                                name: string;
+                                /** @description Human readable description of the organization. */
+                                description?: string;
+                                /** @description Country associated with the organization. */
+                                country?: string;
+                                /** @description Region associated with the organization. */
+                                region?: string;
+                                /**
+                                 * Format: uuid
+                                 * @description Identifier of the organization owner.
+                                 */
+                                owner?: string;
+                                /**
+                                 * Format: date-time
+                                 * @description Timestamp when the organization was created.
+                                 */
+                                createdAt?: string;
+                                /**
+                                 * Format: date-time
+                                 * @description Timestamp when the organization was last updated.
+                                 */
+                                updatedAt?: string;
+                                /**
+                                 * Format: date-time
+                                 * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                                 */
+                                deletedAt?: string | null;
+                                /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                                roleNames: string[];
+                            }[];
                             /** @description Total number of organization memberships returned for the user. */
                             totalCount?: number;
                         };
@@ -1809,14 +2317,86 @@ export interface operations {
                         /** @description Teams the user belongs to with role information */
                         teams?: {
                             /** @description Team memberships for the user with their assigned roles. */
-                            teamsWithRoles?: Record<string, never>[];
+                            teamsWithRoles?: {
+                                /**
+                                 * Format: uuid
+                                 * @description Unique identifier of the team.
+                                 */
+                                id: string;
+                                /** @description Name of the team. */
+                                name: string;
+                                /** @description Human readable description of the team. */
+                                description?: string;
+                                /**
+                                 * Format: uuid
+                                 * @description Identifier of the team owner.
+                                 */
+                                owner?: string;
+                                /** @description Free-form metadata associated with the team. */
+                                metadata?: {
+                                    [key: string]: unknown;
+                                };
+                                /**
+                                 * Format: date-time
+                                 * @description Timestamp when the team was created.
+                                 */
+                                createdAt?: string;
+                                /**
+                                 * Format: date-time
+                                 * @description Timestamp when the team was last updated.
+                                 */
+                                updatedAt?: string;
+                                /**
+                                 * Format: date-time
+                                 * @description Timestamp when the team was soft-deleted (null if not deleted).
+                                 */
+                                deletedAt?: string | null;
+                                /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                                roleNames: string[];
+                            }[];
                             /** @description Total number of team memberships returned for the user. */
                             totalCount?: number;
                         };
                         /** @description Organizations the user belongs to with role information */
                         organizations?: {
                             /** @description Organization memberships for the user with their assigned roles. */
-                            organizationsWithRoles?: Record<string, never>[];
+                            organizationsWithRoles?: {
+                                /**
+                                 * Format: uuid
+                                 * @description Unique identifier of the organization.
+                                 */
+                                id: string;
+                                /** @description Name of the organization. */
+                                name: string;
+                                /** @description Human readable description of the organization. */
+                                description?: string;
+                                /** @description Country associated with the organization. */
+                                country?: string;
+                                /** @description Region associated with the organization. */
+                                region?: string;
+                                /**
+                                 * Format: uuid
+                                 * @description Identifier of the organization owner.
+                                 */
+                                owner?: string;
+                                /**
+                                 * Format: date-time
+                                 * @description Timestamp when the organization was created.
+                                 */
+                                createdAt?: string;
+                                /**
+                                 * Format: date-time
+                                 * @description Timestamp when the organization was last updated.
+                                 */
+                                updatedAt?: string;
+                                /**
+                                 * Format: date-time
+                                 * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                                 */
+                                deletedAt?: string | null;
+                                /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                                roleNames: string[];
+                            }[];
                             /** @description Total number of organization memberships returned for the user. */
                             totalCount?: number;
                         };

--- a/typescript/generated/v1beta2/user/UserSchema.ts
+++ b/typescript/generated/v1beta2/user/UserSchema.ts
@@ -546,23 +546,18 @@ const UserSchema: Record<string, unknown> = {
                           },
                           "roleNames": {
                             "type": "array",
-                            "items": {
-                              "type": "string",
-                              "enum": [
-                                "admin",
-                                "meshmap",
-                                "curator",
-                                "team admin",
-                                "workspace admin",
-                                "workspace manager",
-                                "organization admin",
-                                "user"
-                              ]
+                            "x-go-type": "pq.StringArray",
+                            "x-go-type-import": {
+                              "path": "github.com/lib/pq"
                             },
-                            "description": "List of global roles assigned to the user",
+                            "x-go-type-skip-optional-pointer": true,
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                             "example": [
                               "admin",
-                              "meshmap"
+                              "organization admin"
                             ],
                             "x-oapi-codegen-extra-tags": {
                               "db": "role_names",
@@ -1420,23 +1415,18 @@ const UserSchema: Record<string, unknown> = {
                           },
                           "roleNames": {
                             "type": "array",
-                            "items": {
-                              "type": "string",
-                              "enum": [
-                                "admin",
-                                "meshmap",
-                                "curator",
-                                "team admin",
-                                "workspace admin",
-                                "workspace manager",
-                                "organization admin",
-                                "user"
-                              ]
+                            "x-go-type": "pq.StringArray",
+                            "x-go-type-import": {
+                              "path": "github.com/lib/pq"
                             },
-                            "description": "List of global roles assigned to the user",
+                            "x-go-type-skip-optional-pointer": true,
+                            "items": {
+                              "type": "string"
+                            },
+                            "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                             "example": [
                               "admin",
-                              "meshmap"
+                              "organization admin"
                             ],
                             "x-oapi-codegen-extra-tags": {
                               "db": "role_names",
@@ -2236,23 +2226,18 @@ const UserSchema: Record<string, unknown> = {
                     },
                     "roleNames": {
                       "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": [
-                          "admin",
-                          "meshmap",
-                          "curator",
-                          "team admin",
-                          "workspace admin",
-                          "workspace manager",
-                          "organization admin",
-                          "user"
-                        ]
+                      "x-go-type": "pq.StringArray",
+                      "x-go-type-import": {
+                        "path": "github.com/lib/pq"
                       },
-                      "description": "List of global roles assigned to the user",
+                      "x-go-type-skip-optional-pointer": true,
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                       "example": [
                         "admin",
-                        "meshmap"
+                        "organization admin"
                       ],
                       "x-oapi-codegen-extra-tags": {
                         "db": "role_names",
@@ -3041,23 +3026,18 @@ const UserSchema: Record<string, unknown> = {
                     },
                     "roleNames": {
                       "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": [
-                          "admin",
-                          "meshmap",
-                          "curator",
-                          "team admin",
-                          "workspace admin",
-                          "workspace manager",
-                          "organization admin",
-                          "user"
-                        ]
+                      "x-go-type": "pq.StringArray",
+                      "x-go-type-import": {
+                        "path": "github.com/lib/pq"
                       },
-                      "description": "List of global roles assigned to the user",
+                      "x-go-type-skip-optional-pointer": true,
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                       "example": [
                         "admin",
-                        "meshmap"
+                        "organization admin"
                       ],
                       "x-oapi-codegen-extra-tags": {
                         "db": "role_names",
@@ -3939,23 +3919,18 @@ const UserSchema: Record<string, unknown> = {
           },
           "roleNames": {
             "type": "array",
-            "items": {
-              "type": "string",
-              "enum": [
-                "admin",
-                "meshmap",
-                "curator",
-                "team admin",
-                "workspace admin",
-                "workspace manager",
-                "organization admin",
-                "user"
-              ]
+            "x-go-type": "pq.StringArray",
+            "x-go-type-import": {
+              "path": "github.com/lib/pq"
             },
-            "description": "List of global roles assigned to the user",
+            "x-go-type-skip-optional-pointer": true,
+            "items": {
+              "type": "string"
+            },
+            "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
             "example": [
               "admin",
-              "meshmap"
+              "organization admin"
             ],
             "x-oapi-codegen-extra-tags": {
               "db": "role_names",
@@ -4951,23 +4926,18 @@ const UserSchema: Record<string, unknown> = {
                 },
                 "roleNames": {
                   "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "admin",
-                      "meshmap",
-                      "curator",
-                      "team admin",
-                      "workspace admin",
-                      "workspace manager",
-                      "organization admin",
-                      "user"
-                    ]
+                  "x-go-type": "pq.StringArray",
+                  "x-go-type-import": {
+                    "path": "github.com/lib/pq"
                   },
-                  "description": "List of global roles assigned to the user",
+                  "x-go-type-skip-optional-pointer": true,
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                   "example": [
                     "admin",
-                    "meshmap"
+                    "organization admin"
                   ],
                   "x-oapi-codegen-extra-tags": {
                     "db": "role_names",
@@ -5719,23 +5689,18 @@ const UserSchema: Record<string, unknown> = {
                 },
                 "roleNames": {
                   "type": "array",
-                  "items": {
-                    "type": "string",
-                    "enum": [
-                      "admin",
-                      "meshmap",
-                      "curator",
-                      "team admin",
-                      "workspace admin",
-                      "workspace manager",
-                      "organization admin",
-                      "user"
-                    ]
+                  "x-go-type": "pq.StringArray",
+                  "x-go-type-import": {
+                    "path": "github.com/lib/pq"
                   },
-                  "description": "List of global roles assigned to the user",
+                  "x-go-type-skip-optional-pointer": true,
+                  "items": {
+                    "type": "string"
+                  },
+                  "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                   "example": [
                     "admin",
-                    "meshmap"
+                    "organization admin"
                   ],
                   "x-oapi-codegen-extra-tags": {
                     "db": "role_names",

--- a/typescript/generated/v1beta2/user/UserSchema.ts
+++ b/typescript/generated/v1beta2/user/UserSchema.ts
@@ -685,11 +685,14 @@ const UserSchema: Record<string, unknown> = {
                                     },
                                     "roleNames": {
                                       "type": "array",
+                                      "x-go-type": "pq.StringArray",
+                                      "x-go-type-import": {
+                                        "path": "github.com/lib/pq"
+                                      },
                                       "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "x-go-type-skip-optional-pointer": true,
                                       "x-order": 9,
                                       "x-oapi-codegen-extra-tags": {
                                         "db": "role_names",
@@ -836,11 +839,14 @@ const UserSchema: Record<string, unknown> = {
                                     },
                                     "roleNames": {
                                       "type": "array",
+                                      "x-go-type": "pq.StringArray",
+                                      "x-go-type-import": {
+                                        "path": "github.com/lib/pq"
+                                      },
                                       "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "x-go-type-skip-optional-pointer": true,
                                       "x-order": 10,
                                       "x-oapi-codegen-extra-tags": {
                                         "db": "role_names",
@@ -1553,11 +1559,14 @@ const UserSchema: Record<string, unknown> = {
                                     },
                                     "roleNames": {
                                       "type": "array",
+                                      "x-go-type": "pq.StringArray",
+                                      "x-go-type-import": {
+                                        "path": "github.com/lib/pq"
+                                      },
                                       "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "x-go-type-skip-optional-pointer": true,
                                       "x-order": 9,
                                       "x-oapi-codegen-extra-tags": {
                                         "db": "role_names",
@@ -1704,11 +1713,14 @@ const UserSchema: Record<string, unknown> = {
                                     },
                                     "roleNames": {
                                       "type": "array",
+                                      "x-go-type": "pq.StringArray",
+                                      "x-go-type-import": {
+                                        "path": "github.com/lib/pq"
+                                      },
                                       "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                                       "items": {
                                         "type": "string"
                                       },
-                                      "x-go-type-skip-optional-pointer": true,
                                       "x-order": 10,
                                       "x-oapi-codegen-extra-tags": {
                                         "db": "role_names",
@@ -2363,11 +2375,14 @@ const UserSchema: Record<string, unknown> = {
                               },
                               "roleNames": {
                                 "type": "array",
+                                "x-go-type": "pq.StringArray",
+                                "x-go-type-import": {
+                                  "path": "github.com/lib/pq"
+                                },
                                 "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "x-go-type-skip-optional-pointer": true,
                                 "x-order": 9,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "role_names",
@@ -2514,11 +2529,14 @@ const UserSchema: Record<string, unknown> = {
                               },
                               "roleNames": {
                                 "type": "array",
+                                "x-go-type": "pq.StringArray",
+                                "x-go-type-import": {
+                                  "path": "github.com/lib/pq"
+                                },
                                 "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "x-go-type-skip-optional-pointer": true,
                                 "x-order": 10,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "role_names",
@@ -3162,11 +3180,14 @@ const UserSchema: Record<string, unknown> = {
                               },
                               "roleNames": {
                                 "type": "array",
+                                "x-go-type": "pq.StringArray",
+                                "x-go-type-import": {
+                                  "path": "github.com/lib/pq"
+                                },
                                 "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "x-go-type-skip-optional-pointer": true,
                                 "x-order": 9,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "role_names",
@@ -3313,11 +3334,14 @@ const UserSchema: Record<string, unknown> = {
                               },
                               "roleNames": {
                                 "type": "array",
+                                "x-go-type": "pq.StringArray",
+                                "x-go-type-import": {
+                                  "path": "github.com/lib/pq"
+                                },
                                 "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "x-go-type-skip-optional-pointer": true,
                                 "x-order": 10,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "role_names",
@@ -4054,11 +4078,14 @@ const UserSchema: Record<string, unknown> = {
                     },
                     "roleNames": {
                       "type": "array",
+                      "x-go-type": "pq.StringArray",
+                      "x-go-type-import": {
+                        "path": "github.com/lib/pq"
+                      },
                       "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                       "items": {
                         "type": "string"
                       },
-                      "x-go-type-skip-optional-pointer": true,
                       "x-order": 9,
                       "x-oapi-codegen-extra-tags": {
                         "db": "role_names",
@@ -4205,11 +4232,14 @@ const UserSchema: Record<string, unknown> = {
                     },
                     "roleNames": {
                       "type": "array",
+                      "x-go-type": "pq.StringArray",
+                      "x-go-type-import": {
+                        "path": "github.com/lib/pq"
+                      },
                       "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                       "items": {
                         "type": "string"
                       },
-                      "x-go-type-skip-optional-pointer": true,
                       "x-order": 10,
                       "x-oapi-codegen-extra-tags": {
                         "db": "role_names",
@@ -4348,11 +4378,14 @@ const UserSchema: Record<string, unknown> = {
           },
           "roleNames": {
             "type": "array",
+            "x-go-type": "pq.StringArray",
+            "x-go-type-import": {
+              "path": "github.com/lib/pq"
+            },
             "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
             "items": {
               "type": "string"
             },
-            "x-go-type-skip-optional-pointer": true,
             "x-order": 10,
             "x-oapi-codegen-extra-tags": {
               "db": "role_names",
@@ -4466,11 +4499,14 @@ const UserSchema: Record<string, unknown> = {
           },
           "roleNames": {
             "type": "array",
+            "x-go-type": "pq.StringArray",
+            "x-go-type-import": {
+              "path": "github.com/lib/pq"
+            },
             "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
             "items": {
               "type": "string"
             },
-            "x-go-type-skip-optional-pointer": true,
             "x-order": 9,
             "x-oapi-codegen-extra-tags": {
               "db": "role_names",
@@ -5054,11 +5090,14 @@ const UserSchema: Record<string, unknown> = {
                           },
                           "roleNames": {
                             "type": "array",
+                            "x-go-type": "pq.StringArray",
+                            "x-go-type-import": {
+                              "path": "github.com/lib/pq"
+                            },
                             "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                             "items": {
                               "type": "string"
                             },
-                            "x-go-type-skip-optional-pointer": true,
                             "x-order": 9,
                             "x-oapi-codegen-extra-tags": {
                               "db": "role_names",
@@ -5205,11 +5244,14 @@ const UserSchema: Record<string, unknown> = {
                           },
                           "roleNames": {
                             "type": "array",
+                            "x-go-type": "pq.StringArray",
+                            "x-go-type-import": {
+                              "path": "github.com/lib/pq"
+                            },
                             "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                             "items": {
                               "type": "string"
                             },
-                            "x-go-type-skip-optional-pointer": true,
                             "x-order": 10,
                             "x-oapi-codegen-extra-tags": {
                               "db": "role_names",
@@ -5816,11 +5858,14 @@ const UserSchema: Record<string, unknown> = {
                           },
                           "roleNames": {
                             "type": "array",
+                            "x-go-type": "pq.StringArray",
+                            "x-go-type-import": {
+                              "path": "github.com/lib/pq"
+                            },
                             "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                             "items": {
                               "type": "string"
                             },
-                            "x-go-type-skip-optional-pointer": true,
                             "x-order": 9,
                             "x-oapi-codegen-extra-tags": {
                               "db": "role_names",
@@ -5967,11 +6012,14 @@ const UserSchema: Record<string, unknown> = {
                           },
                           "roleNames": {
                             "type": "array",
+                            "x-go-type": "pq.StringArray",
+                            "x-go-type-import": {
+                              "path": "github.com/lib/pq"
+                            },
                             "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                             "items": {
                               "type": "string"
                             },
-                            "x-go-type-skip-optional-pointer": true,
                             "x-order": 10,
                             "x-oapi-codegen-extra-tags": {
                               "db": "role_names",

--- a/typescript/generated/v1beta2/user/UserSchema.ts
+++ b/typescript/generated/v1beta2/user/UserSchema.ts
@@ -581,7 +581,122 @@ const UserSchema: Record<string, unknown> = {
                                 "type": "array",
                                 "description": "Team memberships for the user with their assigned roles.",
                                 "items": {
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                  "required": [
+                                    "id",
+                                    "name",
+                                    "roleNames"
+                                  ],
+                                  "properties": {
+                                    "id": {
+                                      "description": "Unique identifier of the team.",
+                                      "x-go-name": "ID",
+                                      "x-order": 1,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "id",
+                                        "json": "id,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "x-go-type": "uuid.UUID",
+                                      "x-go-type-import": {
+                                        "path": "github.com/gofrs/uuid"
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Name of the team.",
+                                      "x-order": 2,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "name",
+                                        "json": "name,omitempty"
+                                      }
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Human readable description of the team.",
+                                      "x-order": 3,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "description",
+                                        "json": "description,omitempty"
+                                      }
+                                    },
+                                    "owner": {
+                                      "description": "Identifier of the team owner.",
+                                      "x-order": 4,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "owner",
+                                        "json": "owner,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "x-go-type": "uuid.UUID",
+                                      "x-go-type-import": {
+                                        "path": "github.com/gofrs/uuid"
+                                      }
+                                    },
+                                    "metadata": {
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Free-form metadata associated with the team.",
+                                      "x-go-type": "core.Map",
+                                      "x-go-type-skip-optional-pointer": true,
+                                      "x-order": 5,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "metadata",
+                                        "json": "metadata,omitempty"
+                                      }
+                                    },
+                                    "createdAt": {
+                                      "description": "Timestamp when the team was created.",
+                                      "x-order": 6,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "created_at",
+                                        "json": "createdAt,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "x-go-type-skip-optional-pointer": true
+                                    },
+                                    "updatedAt": {
+                                      "description": "Timestamp when the team was last updated.",
+                                      "x-order": 7,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "updated_at",
+                                        "json": "updatedAt,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "x-go-type-skip-optional-pointer": true
+                                    },
+                                    "deletedAt": {
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "nullable": true,
+                                      "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                                      "x-go-type": "core.NullTime",
+                                      "x-order": 8,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "deleted_at",
+                                        "json": "deletedAt,omitempty"
+                                      }
+                                    },
+                                    "roleNames": {
+                                      "type": "array",
+                                      "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-go-type-skip-optional-pointer": true,
+                                      "x-order": 9,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "role_names",
+                                        "json": "roleNames"
+                                      }
+                                    }
+                                  }
                                 },
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "teams_with_roles",
@@ -611,7 +726,128 @@ const UserSchema: Record<string, unknown> = {
                                 "type": "array",
                                 "description": "Organization memberships for the user with their assigned roles.",
                                 "items": {
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                  "required": [
+                                    "id",
+                                    "name",
+                                    "roleNames"
+                                  ],
+                                  "properties": {
+                                    "id": {
+                                      "description": "Unique identifier of the organization.",
+                                      "x-go-name": "ID",
+                                      "x-order": 1,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "id",
+                                        "json": "id,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "x-go-type": "uuid.UUID",
+                                      "x-go-type-import": {
+                                        "path": "github.com/gofrs/uuid"
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Name of the organization.",
+                                      "x-order": 2,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "name",
+                                        "json": "name,omitempty"
+                                      }
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Human readable description of the organization.",
+                                      "x-order": 3,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "description",
+                                        "json": "description,omitempty"
+                                      }
+                                    },
+                                    "country": {
+                                      "type": "string",
+                                      "description": "Country associated with the organization.",
+                                      "x-order": 4,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "country",
+                                        "json": "country,omitempty"
+                                      }
+                                    },
+                                    "region": {
+                                      "type": "string",
+                                      "description": "Region associated with the organization.",
+                                      "x-order": 5,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "region",
+                                        "json": "region,omitempty"
+                                      }
+                                    },
+                                    "owner": {
+                                      "description": "Identifier of the organization owner.",
+                                      "x-order": 6,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "owner",
+                                        "json": "owner,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "x-go-type": "uuid.UUID",
+                                      "x-go-type-import": {
+                                        "path": "github.com/gofrs/uuid"
+                                      }
+                                    },
+                                    "createdAt": {
+                                      "description": "Timestamp when the organization was created.",
+                                      "x-order": 7,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "created_at",
+                                        "json": "createdAt,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "x-go-type-skip-optional-pointer": true
+                                    },
+                                    "updatedAt": {
+                                      "description": "Timestamp when the organization was last updated.",
+                                      "x-order": 8,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "updated_at",
+                                        "json": "updatedAt,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "x-go-type-skip-optional-pointer": true
+                                    },
+                                    "deletedAt": {
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "nullable": true,
+                                      "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                                      "x-go-type": "core.NullTime",
+                                      "x-order": 9,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "deleted_at",
+                                        "json": "deletedAt,omitempty"
+                                      }
+                                    },
+                                    "roleNames": {
+                                      "type": "array",
+                                      "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-go-type-skip-optional-pointer": true,
+                                      "x-order": 10,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "role_names",
+                                        "json": "roleNames"
+                                      }
+                                    }
+                                  }
                                 },
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "organizations_with_roles",
@@ -1213,7 +1449,122 @@ const UserSchema: Record<string, unknown> = {
                                 "type": "array",
                                 "description": "Team memberships for the user with their assigned roles.",
                                 "items": {
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                  "required": [
+                                    "id",
+                                    "name",
+                                    "roleNames"
+                                  ],
+                                  "properties": {
+                                    "id": {
+                                      "description": "Unique identifier of the team.",
+                                      "x-go-name": "ID",
+                                      "x-order": 1,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "id",
+                                        "json": "id,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "x-go-type": "uuid.UUID",
+                                      "x-go-type-import": {
+                                        "path": "github.com/gofrs/uuid"
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Name of the team.",
+                                      "x-order": 2,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "name",
+                                        "json": "name,omitempty"
+                                      }
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Human readable description of the team.",
+                                      "x-order": 3,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "description",
+                                        "json": "description,omitempty"
+                                      }
+                                    },
+                                    "owner": {
+                                      "description": "Identifier of the team owner.",
+                                      "x-order": 4,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "owner",
+                                        "json": "owner,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "x-go-type": "uuid.UUID",
+                                      "x-go-type-import": {
+                                        "path": "github.com/gofrs/uuid"
+                                      }
+                                    },
+                                    "metadata": {
+                                      "type": "object",
+                                      "additionalProperties": true,
+                                      "description": "Free-form metadata associated with the team.",
+                                      "x-go-type": "core.Map",
+                                      "x-go-type-skip-optional-pointer": true,
+                                      "x-order": 5,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "metadata",
+                                        "json": "metadata,omitempty"
+                                      }
+                                    },
+                                    "createdAt": {
+                                      "description": "Timestamp when the team was created.",
+                                      "x-order": 6,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "created_at",
+                                        "json": "createdAt,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "x-go-type-skip-optional-pointer": true
+                                    },
+                                    "updatedAt": {
+                                      "description": "Timestamp when the team was last updated.",
+                                      "x-order": 7,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "updated_at",
+                                        "json": "updatedAt,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "x-go-type-skip-optional-pointer": true
+                                    },
+                                    "deletedAt": {
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "nullable": true,
+                                      "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                                      "x-go-type": "core.NullTime",
+                                      "x-order": 8,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "deleted_at",
+                                        "json": "deletedAt,omitempty"
+                                      }
+                                    },
+                                    "roleNames": {
+                                      "type": "array",
+                                      "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-go-type-skip-optional-pointer": true,
+                                      "x-order": 9,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "role_names",
+                                        "json": "roleNames"
+                                      }
+                                    }
+                                  }
                                 },
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "teams_with_roles",
@@ -1243,7 +1594,128 @@ const UserSchema: Record<string, unknown> = {
                                 "type": "array",
                                 "description": "Organization memberships for the user with their assigned roles.",
                                 "items": {
-                                  "type": "object"
+                                  "type": "object",
+                                  "additionalProperties": false,
+                                  "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                  "required": [
+                                    "id",
+                                    "name",
+                                    "roleNames"
+                                  ],
+                                  "properties": {
+                                    "id": {
+                                      "description": "Unique identifier of the organization.",
+                                      "x-go-name": "ID",
+                                      "x-order": 1,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "id",
+                                        "json": "id,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "x-go-type": "uuid.UUID",
+                                      "x-go-type-import": {
+                                        "path": "github.com/gofrs/uuid"
+                                      }
+                                    },
+                                    "name": {
+                                      "type": "string",
+                                      "description": "Name of the organization.",
+                                      "x-order": 2,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "name",
+                                        "json": "name,omitempty"
+                                      }
+                                    },
+                                    "description": {
+                                      "type": "string",
+                                      "description": "Human readable description of the organization.",
+                                      "x-order": 3,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "description",
+                                        "json": "description,omitempty"
+                                      }
+                                    },
+                                    "country": {
+                                      "type": "string",
+                                      "description": "Country associated with the organization.",
+                                      "x-order": 4,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "country",
+                                        "json": "country,omitempty"
+                                      }
+                                    },
+                                    "region": {
+                                      "type": "string",
+                                      "description": "Region associated with the organization.",
+                                      "x-order": 5,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "region",
+                                        "json": "region,omitempty"
+                                      }
+                                    },
+                                    "owner": {
+                                      "description": "Identifier of the organization owner.",
+                                      "x-order": 6,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "owner",
+                                        "json": "owner,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "uuid",
+                                      "x-go-type": "uuid.UUID",
+                                      "x-go-type-import": {
+                                        "path": "github.com/gofrs/uuid"
+                                      }
+                                    },
+                                    "createdAt": {
+                                      "description": "Timestamp when the organization was created.",
+                                      "x-order": 7,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "created_at",
+                                        "json": "createdAt,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "x-go-type-skip-optional-pointer": true
+                                    },
+                                    "updatedAt": {
+                                      "description": "Timestamp when the organization was last updated.",
+                                      "x-order": 8,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "updated_at",
+                                        "json": "updatedAt,omitempty"
+                                      },
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "x-go-type-skip-optional-pointer": true
+                                    },
+                                    "deletedAt": {
+                                      "type": "string",
+                                      "format": "date-time",
+                                      "nullable": true,
+                                      "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                                      "x-go-type": "core.NullTime",
+                                      "x-order": 9,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "deleted_at",
+                                        "json": "deletedAt,omitempty"
+                                      }
+                                    },
+                                    "roleNames": {
+                                      "type": "array",
+                                      "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                                      "items": {
+                                        "type": "string"
+                                      },
+                                      "x-go-type-skip-optional-pointer": true,
+                                      "x-order": 10,
+                                      "x-oapi-codegen-extra-tags": {
+                                        "db": "role_names",
+                                        "json": "roleNames"
+                                      }
+                                    }
+                                  }
                                 },
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "organizations_with_roles",
@@ -1787,7 +2259,122 @@ const UserSchema: Record<string, unknown> = {
                           "type": "array",
                           "description": "Team memberships for the user with their assigned roles.",
                           "items": {
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                            "required": [
+                              "id",
+                              "name",
+                              "roleNames"
+                            ],
+                            "properties": {
+                              "id": {
+                                "description": "Unique identifier of the team.",
+                                "x-go-name": "ID",
+                                "x-order": 1,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "id",
+                                  "json": "id,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Name of the team.",
+                                "x-order": 2,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "name",
+                                  "json": "name,omitempty"
+                                }
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "Human readable description of the team.",
+                                "x-order": 3,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "description",
+                                  "json": "description,omitempty"
+                                }
+                              },
+                              "owner": {
+                                "description": "Identifier of the team owner.",
+                                "x-order": 4,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "owner",
+                                  "json": "owner,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "additionalProperties": true,
+                                "description": "Free-form metadata associated with the team.",
+                                "x-go-type": "core.Map",
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-order": 5,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "metadata",
+                                  "json": "metadata,omitempty"
+                                }
+                              },
+                              "createdAt": {
+                                "description": "Timestamp when the team was created.",
+                                "x-order": 6,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "created_at",
+                                  "json": "createdAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "updatedAt": {
+                                "description": "Timestamp when the team was last updated.",
+                                "x-order": 7,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "updated_at",
+                                  "json": "updatedAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "deletedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true,
+                                "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                                "x-go-type": "core.NullTime",
+                                "x-order": 8,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "deleted_at",
+                                  "json": "deletedAt,omitempty"
+                                }
+                              },
+                              "roleNames": {
+                                "type": "array",
+                                "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-order": 9,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "role_names",
+                                  "json": "roleNames"
+                                }
+                              }
+                            }
                           },
                           "x-oapi-codegen-extra-tags": {
                             "db": "teams_with_roles",
@@ -1817,7 +2404,128 @@ const UserSchema: Record<string, unknown> = {
                           "type": "array",
                           "description": "Organization memberships for the user with their assigned roles.",
                           "items": {
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                            "required": [
+                              "id",
+                              "name",
+                              "roleNames"
+                            ],
+                            "properties": {
+                              "id": {
+                                "description": "Unique identifier of the organization.",
+                                "x-go-name": "ID",
+                                "x-order": 1,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "id",
+                                  "json": "id,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Name of the organization.",
+                                "x-order": 2,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "name",
+                                  "json": "name,omitempty"
+                                }
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "Human readable description of the organization.",
+                                "x-order": 3,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "description",
+                                  "json": "description,omitempty"
+                                }
+                              },
+                              "country": {
+                                "type": "string",
+                                "description": "Country associated with the organization.",
+                                "x-order": 4,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "country",
+                                  "json": "country,omitempty"
+                                }
+                              },
+                              "region": {
+                                "type": "string",
+                                "description": "Region associated with the organization.",
+                                "x-order": 5,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "region",
+                                  "json": "region,omitempty"
+                                }
+                              },
+                              "owner": {
+                                "description": "Identifier of the organization owner.",
+                                "x-order": 6,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "owner",
+                                  "json": "owner,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "createdAt": {
+                                "description": "Timestamp when the organization was created.",
+                                "x-order": 7,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "created_at",
+                                  "json": "createdAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "updatedAt": {
+                                "description": "Timestamp when the organization was last updated.",
+                                "x-order": 8,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "updated_at",
+                                  "json": "updatedAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "deletedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true,
+                                "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                                "x-go-type": "core.NullTime",
+                                "x-order": 9,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "deleted_at",
+                                  "json": "deletedAt,omitempty"
+                                }
+                              },
+                              "roleNames": {
+                                "type": "array",
+                                "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-order": 10,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "role_names",
+                                  "json": "roleNames"
+                                }
+                              }
+                            }
                           },
                           "x-oapi-codegen-extra-tags": {
                             "db": "organizations_with_roles",
@@ -2350,7 +3058,122 @@ const UserSchema: Record<string, unknown> = {
                           "type": "array",
                           "description": "Team memberships for the user with their assigned roles.",
                           "items": {
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                            "required": [
+                              "id",
+                              "name",
+                              "roleNames"
+                            ],
+                            "properties": {
+                              "id": {
+                                "description": "Unique identifier of the team.",
+                                "x-go-name": "ID",
+                                "x-order": 1,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "id",
+                                  "json": "id,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Name of the team.",
+                                "x-order": 2,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "name",
+                                  "json": "name,omitempty"
+                                }
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "Human readable description of the team.",
+                                "x-order": 3,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "description",
+                                  "json": "description,omitempty"
+                                }
+                              },
+                              "owner": {
+                                "description": "Identifier of the team owner.",
+                                "x-order": 4,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "owner",
+                                  "json": "owner,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "additionalProperties": true,
+                                "description": "Free-form metadata associated with the team.",
+                                "x-go-type": "core.Map",
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-order": 5,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "metadata",
+                                  "json": "metadata,omitempty"
+                                }
+                              },
+                              "createdAt": {
+                                "description": "Timestamp when the team was created.",
+                                "x-order": 6,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "created_at",
+                                  "json": "createdAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "updatedAt": {
+                                "description": "Timestamp when the team was last updated.",
+                                "x-order": 7,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "updated_at",
+                                  "json": "updatedAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "deletedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true,
+                                "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                                "x-go-type": "core.NullTime",
+                                "x-order": 8,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "deleted_at",
+                                  "json": "deletedAt,omitempty"
+                                }
+                              },
+                              "roleNames": {
+                                "type": "array",
+                                "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-order": 9,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "role_names",
+                                  "json": "roleNames"
+                                }
+                              }
+                            }
                           },
                           "x-oapi-codegen-extra-tags": {
                             "db": "teams_with_roles",
@@ -2380,7 +3203,128 @@ const UserSchema: Record<string, unknown> = {
                           "type": "array",
                           "description": "Organization memberships for the user with their assigned roles.",
                           "items": {
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                            "required": [
+                              "id",
+                              "name",
+                              "roleNames"
+                            ],
+                            "properties": {
+                              "id": {
+                                "description": "Unique identifier of the organization.",
+                                "x-go-name": "ID",
+                                "x-order": 1,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "id",
+                                  "json": "id,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Name of the organization.",
+                                "x-order": 2,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "name",
+                                  "json": "name,omitempty"
+                                }
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "Human readable description of the organization.",
+                                "x-order": 3,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "description",
+                                  "json": "description,omitempty"
+                                }
+                              },
+                              "country": {
+                                "type": "string",
+                                "description": "Country associated with the organization.",
+                                "x-order": 4,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "country",
+                                  "json": "country,omitempty"
+                                }
+                              },
+                              "region": {
+                                "type": "string",
+                                "description": "Region associated with the organization.",
+                                "x-order": 5,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "region",
+                                  "json": "region,omitempty"
+                                }
+                              },
+                              "owner": {
+                                "description": "Identifier of the organization owner.",
+                                "x-order": 6,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "owner",
+                                  "json": "owner,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "createdAt": {
+                                "description": "Timestamp when the organization was created.",
+                                "x-order": 7,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "created_at",
+                                  "json": "createdAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "updatedAt": {
+                                "description": "Timestamp when the organization was last updated.",
+                                "x-order": 8,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "updated_at",
+                                  "json": "updatedAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "deletedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true,
+                                "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                                "x-go-type": "core.NullTime",
+                                "x-order": 9,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "deleted_at",
+                                  "json": "deletedAt,omitempty"
+                                }
+                              },
+                              "roleNames": {
+                                "type": "array",
+                                "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-order": 10,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "role_names",
+                                  "json": "roleNames"
+                                }
+                              }
+                            }
                           },
                           "x-oapi-codegen-extra-tags": {
                             "db": "organizations_with_roles",
@@ -3006,7 +3950,122 @@ const UserSchema: Record<string, unknown> = {
                 "type": "array",
                 "description": "Team memberships for the user with their assigned roles.",
                 "items": {
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                  "required": [
+                    "id",
+                    "name",
+                    "roleNames"
+                  ],
+                  "properties": {
+                    "id": {
+                      "description": "Unique identifier of the team.",
+                      "x-go-name": "ID",
+                      "x-order": 1,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "id",
+                        "json": "id,omitempty"
+                      },
+                      "type": "string",
+                      "format": "uuid",
+                      "x-go-type": "uuid.UUID",
+                      "x-go-type-import": {
+                        "path": "github.com/gofrs/uuid"
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the team.",
+                      "x-order": 2,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "name",
+                        "json": "name,omitempty"
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Human readable description of the team.",
+                      "x-order": 3,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "description",
+                        "json": "description,omitempty"
+                      }
+                    },
+                    "owner": {
+                      "description": "Identifier of the team owner.",
+                      "x-order": 4,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "owner",
+                        "json": "owner,omitempty"
+                      },
+                      "type": "string",
+                      "format": "uuid",
+                      "x-go-type": "uuid.UUID",
+                      "x-go-type-import": {
+                        "path": "github.com/gofrs/uuid"
+                      }
+                    },
+                    "metadata": {
+                      "type": "object",
+                      "additionalProperties": true,
+                      "description": "Free-form metadata associated with the team.",
+                      "x-go-type": "core.Map",
+                      "x-go-type-skip-optional-pointer": true,
+                      "x-order": 5,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "metadata",
+                        "json": "metadata,omitempty"
+                      }
+                    },
+                    "createdAt": {
+                      "description": "Timestamp when the team was created.",
+                      "x-order": 6,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "created_at",
+                        "json": "createdAt,omitempty"
+                      },
+                      "type": "string",
+                      "format": "date-time",
+                      "x-go-type-skip-optional-pointer": true
+                    },
+                    "updatedAt": {
+                      "description": "Timestamp when the team was last updated.",
+                      "x-order": 7,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "updated_at",
+                        "json": "updatedAt,omitempty"
+                      },
+                      "type": "string",
+                      "format": "date-time",
+                      "x-go-type-skip-optional-pointer": true
+                    },
+                    "deletedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true,
+                      "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                      "x-go-type": "core.NullTime",
+                      "x-order": 8,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "deleted_at",
+                        "json": "deletedAt,omitempty"
+                      }
+                    },
+                    "roleNames": {
+                      "type": "array",
+                      "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "x-go-type-skip-optional-pointer": true,
+                      "x-order": 9,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "role_names",
+                        "json": "roleNames"
+                      }
+                    }
+                  }
                 },
                 "x-oapi-codegen-extra-tags": {
                   "db": "teams_with_roles",
@@ -3036,7 +4095,128 @@ const UserSchema: Record<string, unknown> = {
                 "type": "array",
                 "description": "Organization memberships for the user with their assigned roles.",
                 "items": {
-                  "type": "object"
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                  "required": [
+                    "id",
+                    "name",
+                    "roleNames"
+                  ],
+                  "properties": {
+                    "id": {
+                      "description": "Unique identifier of the organization.",
+                      "x-go-name": "ID",
+                      "x-order": 1,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "id",
+                        "json": "id,omitempty"
+                      },
+                      "type": "string",
+                      "format": "uuid",
+                      "x-go-type": "uuid.UUID",
+                      "x-go-type-import": {
+                        "path": "github.com/gofrs/uuid"
+                      }
+                    },
+                    "name": {
+                      "type": "string",
+                      "description": "Name of the organization.",
+                      "x-order": 2,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "name",
+                        "json": "name,omitempty"
+                      }
+                    },
+                    "description": {
+                      "type": "string",
+                      "description": "Human readable description of the organization.",
+                      "x-order": 3,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "description",
+                        "json": "description,omitempty"
+                      }
+                    },
+                    "country": {
+                      "type": "string",
+                      "description": "Country associated with the organization.",
+                      "x-order": 4,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "country",
+                        "json": "country,omitempty"
+                      }
+                    },
+                    "region": {
+                      "type": "string",
+                      "description": "Region associated with the organization.",
+                      "x-order": 5,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "region",
+                        "json": "region,omitempty"
+                      }
+                    },
+                    "owner": {
+                      "description": "Identifier of the organization owner.",
+                      "x-order": 6,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "owner",
+                        "json": "owner,omitempty"
+                      },
+                      "type": "string",
+                      "format": "uuid",
+                      "x-go-type": "uuid.UUID",
+                      "x-go-type-import": {
+                        "path": "github.com/gofrs/uuid"
+                      }
+                    },
+                    "createdAt": {
+                      "description": "Timestamp when the organization was created.",
+                      "x-order": 7,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "created_at",
+                        "json": "createdAt,omitempty"
+                      },
+                      "type": "string",
+                      "format": "date-time",
+                      "x-go-type-skip-optional-pointer": true
+                    },
+                    "updatedAt": {
+                      "description": "Timestamp when the organization was last updated.",
+                      "x-order": 8,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "updated_at",
+                        "json": "updatedAt,omitempty"
+                      },
+                      "type": "string",
+                      "format": "date-time",
+                      "x-go-type-skip-optional-pointer": true
+                    },
+                    "deletedAt": {
+                      "type": "string",
+                      "format": "date-time",
+                      "nullable": true,
+                      "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                      "x-go-type": "core.NullTime",
+                      "x-order": 9,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "deleted_at",
+                        "json": "deletedAt,omitempty"
+                      }
+                    },
+                    "roleNames": {
+                      "type": "array",
+                      "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "x-go-type-skip-optional-pointer": true,
+                      "x-order": 10,
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "role_names",
+                        "json": "roleNames"
+                      }
+                    }
+                  }
                 },
                 "x-oapi-codegen-extra-tags": {
                   "db": "organizations_with_roles",
@@ -3056,6 +4236,248 @@ const UserSchema: Record<string, unknown> = {
           }
         },
         "additionalProperties": false
+      },
+      "OrganizationWithRoles": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+        "required": [
+          "id",
+          "name",
+          "roleNames"
+        ],
+        "properties": {
+          "id": {
+            "description": "Unique identifier of the organization.",
+            "x-go-name": "ID",
+            "x-order": 1,
+            "x-oapi-codegen-extra-tags": {
+              "db": "id",
+              "json": "id,omitempty"
+            },
+            "type": "string",
+            "format": "uuid",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/gofrs/uuid"
+            }
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the organization.",
+            "x-order": 2,
+            "x-oapi-codegen-extra-tags": {
+              "db": "name",
+              "json": "name,omitempty"
+            }
+          },
+          "description": {
+            "type": "string",
+            "description": "Human readable description of the organization.",
+            "x-order": 3,
+            "x-oapi-codegen-extra-tags": {
+              "db": "description",
+              "json": "description,omitempty"
+            }
+          },
+          "country": {
+            "type": "string",
+            "description": "Country associated with the organization.",
+            "x-order": 4,
+            "x-oapi-codegen-extra-tags": {
+              "db": "country",
+              "json": "country,omitempty"
+            }
+          },
+          "region": {
+            "type": "string",
+            "description": "Region associated with the organization.",
+            "x-order": 5,
+            "x-oapi-codegen-extra-tags": {
+              "db": "region",
+              "json": "region,omitempty"
+            }
+          },
+          "owner": {
+            "description": "Identifier of the organization owner.",
+            "x-order": 6,
+            "x-oapi-codegen-extra-tags": {
+              "db": "owner",
+              "json": "owner,omitempty"
+            },
+            "type": "string",
+            "format": "uuid",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/gofrs/uuid"
+            }
+          },
+          "createdAt": {
+            "description": "Timestamp when the organization was created.",
+            "x-order": 7,
+            "x-oapi-codegen-extra-tags": {
+              "db": "created_at",
+              "json": "createdAt,omitempty"
+            },
+            "type": "string",
+            "format": "date-time",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "updatedAt": {
+            "description": "Timestamp when the organization was last updated.",
+            "x-order": 8,
+            "x-oapi-codegen-extra-tags": {
+              "db": "updated_at",
+              "json": "updatedAt,omitempty"
+            },
+            "type": "string",
+            "format": "date-time",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "deletedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+            "x-go-type": "core.NullTime",
+            "x-order": 9,
+            "x-oapi-codegen-extra-tags": {
+              "db": "deleted_at",
+              "json": "deletedAt,omitempty"
+            }
+          },
+          "roleNames": {
+            "type": "array",
+            "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+            "items": {
+              "type": "string"
+            },
+            "x-go-type-skip-optional-pointer": true,
+            "x-order": 10,
+            "x-oapi-codegen-extra-tags": {
+              "db": "role_names",
+              "json": "roleNames"
+            }
+          }
+        }
+      },
+      "TeamWithRoles": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+        "required": [
+          "id",
+          "name",
+          "roleNames"
+        ],
+        "properties": {
+          "id": {
+            "description": "Unique identifier of the team.",
+            "x-go-name": "ID",
+            "x-order": 1,
+            "x-oapi-codegen-extra-tags": {
+              "db": "id",
+              "json": "id,omitempty"
+            },
+            "type": "string",
+            "format": "uuid",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/gofrs/uuid"
+            }
+          },
+          "name": {
+            "type": "string",
+            "description": "Name of the team.",
+            "x-order": 2,
+            "x-oapi-codegen-extra-tags": {
+              "db": "name",
+              "json": "name,omitempty"
+            }
+          },
+          "description": {
+            "type": "string",
+            "description": "Human readable description of the team.",
+            "x-order": 3,
+            "x-oapi-codegen-extra-tags": {
+              "db": "description",
+              "json": "description,omitempty"
+            }
+          },
+          "owner": {
+            "description": "Identifier of the team owner.",
+            "x-order": 4,
+            "x-oapi-codegen-extra-tags": {
+              "db": "owner",
+              "json": "owner,omitempty"
+            },
+            "type": "string",
+            "format": "uuid",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/gofrs/uuid"
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true,
+            "description": "Free-form metadata associated with the team.",
+            "x-go-type": "core.Map",
+            "x-go-type-skip-optional-pointer": true,
+            "x-order": 5,
+            "x-oapi-codegen-extra-tags": {
+              "db": "metadata",
+              "json": "metadata,omitempty"
+            }
+          },
+          "createdAt": {
+            "description": "Timestamp when the team was created.",
+            "x-order": 6,
+            "x-oapi-codegen-extra-tags": {
+              "db": "created_at",
+              "json": "createdAt,omitempty"
+            },
+            "type": "string",
+            "format": "date-time",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "updatedAt": {
+            "description": "Timestamp when the team was last updated.",
+            "x-order": 7,
+            "x-oapi-codegen-extra-tags": {
+              "db": "updated_at",
+              "json": "updatedAt,omitempty"
+            },
+            "type": "string",
+            "format": "date-time",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "deletedAt": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true,
+            "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+            "x-go-type": "core.NullTime",
+            "x-order": 8,
+            "x-oapi-codegen-extra-tags": {
+              "db": "deleted_at",
+              "json": "deletedAt,omitempty"
+            }
+          },
+          "roleNames": {
+            "type": "array",
+            "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+            "items": {
+              "type": "string"
+            },
+            "x-go-type-skip-optional-pointer": true,
+            "x-order": 9,
+            "x-oapi-codegen-extra-tags": {
+              "db": "role_names",
+              "json": "roleNames"
+            }
+          }
+        }
       },
       "UsersPageForAdmin": {
         "type": "object",
@@ -3528,7 +4950,122 @@ const UserSchema: Record<string, unknown> = {
                       "type": "array",
                       "description": "Team memberships for the user with their assigned roles.",
                       "items": {
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                        "required": [
+                          "id",
+                          "name",
+                          "roleNames"
+                        ],
+                        "properties": {
+                          "id": {
+                            "description": "Unique identifier of the team.",
+                            "x-go-name": "ID",
+                            "x-order": 1,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "id",
+                              "json": "id,omitempty"
+                            },
+                            "type": "string",
+                            "format": "uuid",
+                            "x-go-type": "uuid.UUID",
+                            "x-go-type-import": {
+                              "path": "github.com/gofrs/uuid"
+                            }
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Name of the team.",
+                            "x-order": 2,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "name",
+                              "json": "name,omitempty"
+                            }
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "Human readable description of the team.",
+                            "x-order": 3,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "description",
+                              "json": "description,omitempty"
+                            }
+                          },
+                          "owner": {
+                            "description": "Identifier of the team owner.",
+                            "x-order": 4,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "owner",
+                              "json": "owner,omitempty"
+                            },
+                            "type": "string",
+                            "format": "uuid",
+                            "x-go-type": "uuid.UUID",
+                            "x-go-type-import": {
+                              "path": "github.com/gofrs/uuid"
+                            }
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Free-form metadata associated with the team.",
+                            "x-go-type": "core.Map",
+                            "x-go-type-skip-optional-pointer": true,
+                            "x-order": 5,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "metadata",
+                              "json": "metadata,omitempty"
+                            }
+                          },
+                          "createdAt": {
+                            "description": "Timestamp when the team was created.",
+                            "x-order": 6,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "created_at",
+                              "json": "createdAt,omitempty"
+                            },
+                            "type": "string",
+                            "format": "date-time",
+                            "x-go-type-skip-optional-pointer": true
+                          },
+                          "updatedAt": {
+                            "description": "Timestamp when the team was last updated.",
+                            "x-order": 7,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "updated_at",
+                              "json": "updatedAt,omitempty"
+                            },
+                            "type": "string",
+                            "format": "date-time",
+                            "x-go-type-skip-optional-pointer": true
+                          },
+                          "deletedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true,
+                            "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                            "x-go-type": "core.NullTime",
+                            "x-order": 8,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "deleted_at",
+                              "json": "deletedAt,omitempty"
+                            }
+                          },
+                          "roleNames": {
+                            "type": "array",
+                            "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-go-type-skip-optional-pointer": true,
+                            "x-order": 9,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "role_names",
+                              "json": "roleNames"
+                            }
+                          }
+                        }
                       },
                       "x-oapi-codegen-extra-tags": {
                         "db": "teams_with_roles",
@@ -3558,7 +5095,128 @@ const UserSchema: Record<string, unknown> = {
                       "type": "array",
                       "description": "Organization memberships for the user with their assigned roles.",
                       "items": {
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                        "required": [
+                          "id",
+                          "name",
+                          "roleNames"
+                        ],
+                        "properties": {
+                          "id": {
+                            "description": "Unique identifier of the organization.",
+                            "x-go-name": "ID",
+                            "x-order": 1,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "id",
+                              "json": "id,omitempty"
+                            },
+                            "type": "string",
+                            "format": "uuid",
+                            "x-go-type": "uuid.UUID",
+                            "x-go-type-import": {
+                              "path": "github.com/gofrs/uuid"
+                            }
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Name of the organization.",
+                            "x-order": 2,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "name",
+                              "json": "name,omitempty"
+                            }
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "Human readable description of the organization.",
+                            "x-order": 3,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "description",
+                              "json": "description,omitempty"
+                            }
+                          },
+                          "country": {
+                            "type": "string",
+                            "description": "Country associated with the organization.",
+                            "x-order": 4,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "country",
+                              "json": "country,omitempty"
+                            }
+                          },
+                          "region": {
+                            "type": "string",
+                            "description": "Region associated with the organization.",
+                            "x-order": 5,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "region",
+                              "json": "region,omitempty"
+                            }
+                          },
+                          "owner": {
+                            "description": "Identifier of the organization owner.",
+                            "x-order": 6,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "owner",
+                              "json": "owner,omitempty"
+                            },
+                            "type": "string",
+                            "format": "uuid",
+                            "x-go-type": "uuid.UUID",
+                            "x-go-type-import": {
+                              "path": "github.com/gofrs/uuid"
+                            }
+                          },
+                          "createdAt": {
+                            "description": "Timestamp when the organization was created.",
+                            "x-order": 7,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "created_at",
+                              "json": "createdAt,omitempty"
+                            },
+                            "type": "string",
+                            "format": "date-time",
+                            "x-go-type-skip-optional-pointer": true
+                          },
+                          "updatedAt": {
+                            "description": "Timestamp when the organization was last updated.",
+                            "x-order": 8,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "updated_at",
+                              "json": "updatedAt,omitempty"
+                            },
+                            "type": "string",
+                            "format": "date-time",
+                            "x-go-type-skip-optional-pointer": true
+                          },
+                          "deletedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true,
+                            "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                            "x-go-type": "core.NullTime",
+                            "x-order": 9,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "deleted_at",
+                              "json": "deletedAt,omitempty"
+                            }
+                          },
+                          "roleNames": {
+                            "type": "array",
+                            "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-go-type-skip-optional-pointer": true,
+                            "x-order": 10,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "role_names",
+                              "json": "roleNames"
+                            }
+                          }
+                        }
                       },
                       "x-oapi-codegen-extra-tags": {
                         "db": "organizations_with_roles",
@@ -4054,7 +5712,122 @@ const UserSchema: Record<string, unknown> = {
                       "type": "array",
                       "description": "Team memberships for the user with their assigned roles.",
                       "items": {
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                        "required": [
+                          "id",
+                          "name",
+                          "roleNames"
+                        ],
+                        "properties": {
+                          "id": {
+                            "description": "Unique identifier of the team.",
+                            "x-go-name": "ID",
+                            "x-order": 1,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "id",
+                              "json": "id,omitempty"
+                            },
+                            "type": "string",
+                            "format": "uuid",
+                            "x-go-type": "uuid.UUID",
+                            "x-go-type-import": {
+                              "path": "github.com/gofrs/uuid"
+                            }
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Name of the team.",
+                            "x-order": 2,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "name",
+                              "json": "name,omitempty"
+                            }
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "Human readable description of the team.",
+                            "x-order": 3,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "description",
+                              "json": "description,omitempty"
+                            }
+                          },
+                          "owner": {
+                            "description": "Identifier of the team owner.",
+                            "x-order": 4,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "owner",
+                              "json": "owner,omitempty"
+                            },
+                            "type": "string",
+                            "format": "uuid",
+                            "x-go-type": "uuid.UUID",
+                            "x-go-type-import": {
+                              "path": "github.com/gofrs/uuid"
+                            }
+                          },
+                          "metadata": {
+                            "type": "object",
+                            "additionalProperties": true,
+                            "description": "Free-form metadata associated with the team.",
+                            "x-go-type": "core.Map",
+                            "x-go-type-skip-optional-pointer": true,
+                            "x-order": 5,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "metadata",
+                              "json": "metadata,omitempty"
+                            }
+                          },
+                          "createdAt": {
+                            "description": "Timestamp when the team was created.",
+                            "x-order": 6,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "created_at",
+                              "json": "createdAt,omitempty"
+                            },
+                            "type": "string",
+                            "format": "date-time",
+                            "x-go-type-skip-optional-pointer": true
+                          },
+                          "updatedAt": {
+                            "description": "Timestamp when the team was last updated.",
+                            "x-order": 7,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "updated_at",
+                              "json": "updatedAt,omitempty"
+                            },
+                            "type": "string",
+                            "format": "date-time",
+                            "x-go-type-skip-optional-pointer": true
+                          },
+                          "deletedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true,
+                            "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                            "x-go-type": "core.NullTime",
+                            "x-order": 8,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "deleted_at",
+                              "json": "deletedAt,omitempty"
+                            }
+                          },
+                          "roleNames": {
+                            "type": "array",
+                            "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-go-type-skip-optional-pointer": true,
+                            "x-order": 9,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "role_names",
+                              "json": "roleNames"
+                            }
+                          }
+                        }
                       },
                       "x-oapi-codegen-extra-tags": {
                         "db": "teams_with_roles",
@@ -4084,7 +5857,128 @@ const UserSchema: Record<string, unknown> = {
                       "type": "array",
                       "description": "Organization memberships for the user with their assigned roles.",
                       "items": {
-                        "type": "object"
+                        "type": "object",
+                        "additionalProperties": false,
+                        "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                        "required": [
+                          "id",
+                          "name",
+                          "roleNames"
+                        ],
+                        "properties": {
+                          "id": {
+                            "description": "Unique identifier of the organization.",
+                            "x-go-name": "ID",
+                            "x-order": 1,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "id",
+                              "json": "id,omitempty"
+                            },
+                            "type": "string",
+                            "format": "uuid",
+                            "x-go-type": "uuid.UUID",
+                            "x-go-type-import": {
+                              "path": "github.com/gofrs/uuid"
+                            }
+                          },
+                          "name": {
+                            "type": "string",
+                            "description": "Name of the organization.",
+                            "x-order": 2,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "name",
+                              "json": "name,omitempty"
+                            }
+                          },
+                          "description": {
+                            "type": "string",
+                            "description": "Human readable description of the organization.",
+                            "x-order": 3,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "description",
+                              "json": "description,omitempty"
+                            }
+                          },
+                          "country": {
+                            "type": "string",
+                            "description": "Country associated with the organization.",
+                            "x-order": 4,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "country",
+                              "json": "country,omitempty"
+                            }
+                          },
+                          "region": {
+                            "type": "string",
+                            "description": "Region associated with the organization.",
+                            "x-order": 5,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "region",
+                              "json": "region,omitempty"
+                            }
+                          },
+                          "owner": {
+                            "description": "Identifier of the organization owner.",
+                            "x-order": 6,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "owner",
+                              "json": "owner,omitempty"
+                            },
+                            "type": "string",
+                            "format": "uuid",
+                            "x-go-type": "uuid.UUID",
+                            "x-go-type-import": {
+                              "path": "github.com/gofrs/uuid"
+                            }
+                          },
+                          "createdAt": {
+                            "description": "Timestamp when the organization was created.",
+                            "x-order": 7,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "created_at",
+                              "json": "createdAt,omitempty"
+                            },
+                            "type": "string",
+                            "format": "date-time",
+                            "x-go-type-skip-optional-pointer": true
+                          },
+                          "updatedAt": {
+                            "description": "Timestamp when the organization was last updated.",
+                            "x-order": 8,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "updated_at",
+                              "json": "updatedAt,omitempty"
+                            },
+                            "type": "string",
+                            "format": "date-time",
+                            "x-go-type-skip-optional-pointer": true
+                          },
+                          "deletedAt": {
+                            "type": "string",
+                            "format": "date-time",
+                            "nullable": true,
+                            "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                            "x-go-type": "core.NullTime",
+                            "x-order": 9,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "deleted_at",
+                              "json": "deletedAt,omitempty"
+                            }
+                          },
+                          "roleNames": {
+                            "type": "array",
+                            "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                            "items": {
+                              "type": "string"
+                            },
+                            "x-go-type-skip-optional-pointer": true,
+                            "x-order": 10,
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "role_names",
+                              "json": "roleNames"
+                            }
+                          }
+                        }
                       },
                       "x-oapi-codegen-extra-tags": {
                         "db": "organizations_with_roles",

--- a/typescript/generated/v1beta2/user/UserSchema.ts
+++ b/typescript/generated/v1beta2/user/UserSchema.ts
@@ -556,8 +556,8 @@ const UserSchema: Record<string, unknown> = {
                             },
                             "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                             "example": [
-                              "admin",
-                              "organization admin"
+                              "organization admin",
+                              "user"
                             ],
                             "x-oapi-codegen-extra-tags": {
                               "db": "role_names",
@@ -1425,8 +1425,8 @@ const UserSchema: Record<string, unknown> = {
                             },
                             "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                             "example": [
-                              "admin",
-                              "organization admin"
+                              "organization admin",
+                              "user"
                             ],
                             "x-oapi-codegen-extra-tags": {
                               "db": "role_names",
@@ -2236,8 +2236,8 @@ const UserSchema: Record<string, unknown> = {
                       },
                       "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                       "example": [
-                        "admin",
-                        "organization admin"
+                        "organization admin",
+                        "user"
                       ],
                       "x-oapi-codegen-extra-tags": {
                         "db": "role_names",
@@ -3036,8 +3036,8 @@ const UserSchema: Record<string, unknown> = {
                       },
                       "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                       "example": [
-                        "admin",
-                        "organization admin"
+                        "organization admin",
+                        "user"
                       ],
                       "x-oapi-codegen-extra-tags": {
                         "db": "role_names",
@@ -3929,8 +3929,8 @@ const UserSchema: Record<string, unknown> = {
             },
             "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
             "example": [
-              "admin",
-              "organization admin"
+              "organization admin",
+              "user"
             ],
             "x-oapi-codegen-extra-tags": {
               "db": "role_names",
@@ -4936,8 +4936,8 @@ const UserSchema: Record<string, unknown> = {
                   },
                   "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                   "example": [
-                    "admin",
-                    "organization admin"
+                    "organization admin",
+                    "user"
                   ],
                   "x-oapi-codegen-extra-tags": {
                     "db": "role_names",
@@ -5699,8 +5699,8 @@ const UserSchema: Record<string, unknown> = {
                   },
                   "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                   "example": [
-                    "admin",
-                    "organization admin"
+                    "organization admin",
+                    "user"
                   ],
                   "x-oapi-codegen-extra-tags": {
                     "db": "role_names",

--- a/typescript/generated/v1beta3/design/Design.ts
+++ b/typescript/generated/v1beta3/design/Design.ts
@@ -2009,14 +2009,86 @@ export interface components {
                 /** @description Teams the user belongs to with role information */
                 teams?: {
                     /** @description Team memberships for the user with their assigned roles. */
-                    teamsWithRoles?: Record<string, never>[];
+                    teamsWithRoles?: {
+                        /**
+                         * Format: uuid
+                         * @description Unique identifier of the team.
+                         */
+                        id: string;
+                        /** @description Name of the team. */
+                        name: string;
+                        /** @description Human readable description of the team. */
+                        description?: string;
+                        /**
+                         * Format: uuid
+                         * @description Identifier of the team owner.
+                         */
+                        owner?: string;
+                        /** @description Free-form metadata associated with the team. */
+                        metadata?: {
+                            [key: string]: unknown;
+                        };
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the team was created.
+                         */
+                        createdAt?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the team was last updated.
+                         */
+                        updatedAt?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the team was soft-deleted (null if not deleted).
+                         */
+                        deletedAt?: string | null;
+                        /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                        roleNames: string[];
+                    }[];
                     /** @description Total number of team memberships returned for the user. */
                     totalCount?: number;
                 };
                 /** @description Organizations the user belongs to with role information */
                 organizations?: {
                     /** @description Organization memberships for the user with their assigned roles. */
-                    organizationsWithRoles?: Record<string, never>[];
+                    organizationsWithRoles?: {
+                        /**
+                         * Format: uuid
+                         * @description Unique identifier of the organization.
+                         */
+                        id: string;
+                        /** @description Name of the organization. */
+                        name: string;
+                        /** @description Human readable description of the organization. */
+                        description?: string;
+                        /** @description Country associated with the organization. */
+                        country?: string;
+                        /** @description Region associated with the organization. */
+                        region?: string;
+                        /**
+                         * Format: uuid
+                         * @description Identifier of the organization owner.
+                         */
+                        owner?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the organization was created.
+                         */
+                        createdAt?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the organization was last updated.
+                         */
+                        updatedAt?: string;
+                        /**
+                         * Format: date-time
+                         * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                         */
+                        deletedAt?: string | null;
+                        /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                        roleNames: string[];
+                    }[];
                     /** @description Total number of organization memberships returned for the user. */
                     totalCount?: number;
                 };
@@ -2306,14 +2378,86 @@ export interface components {
                     /** @description Teams the user belongs to with role information */
                     teams?: {
                         /** @description Team memberships for the user with their assigned roles. */
-                        teamsWithRoles?: Record<string, never>[];
+                        teamsWithRoles?: {
+                            /**
+                             * Format: uuid
+                             * @description Unique identifier of the team.
+                             */
+                            id: string;
+                            /** @description Name of the team. */
+                            name: string;
+                            /** @description Human readable description of the team. */
+                            description?: string;
+                            /**
+                             * Format: uuid
+                             * @description Identifier of the team owner.
+                             */
+                            owner?: string;
+                            /** @description Free-form metadata associated with the team. */
+                            metadata?: {
+                                [key: string]: unknown;
+                            };
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the team was created.
+                             */
+                            createdAt?: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the team was last updated.
+                             */
+                            updatedAt?: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the team was soft-deleted (null if not deleted).
+                             */
+                            deletedAt?: string | null;
+                            /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                            roleNames: string[];
+                        }[];
                         /** @description Total number of team memberships returned for the user. */
                         totalCount?: number;
                     };
                     /** @description Organizations the user belongs to with role information */
                     organizations?: {
                         /** @description Organization memberships for the user with their assigned roles. */
-                        organizationsWithRoles?: Record<string, never>[];
+                        organizationsWithRoles?: {
+                            /**
+                             * Format: uuid
+                             * @description Unique identifier of the organization.
+                             */
+                            id: string;
+                            /** @description Name of the organization. */
+                            name: string;
+                            /** @description Human readable description of the organization. */
+                            description?: string;
+                            /** @description Country associated with the organization. */
+                            country?: string;
+                            /** @description Region associated with the organization. */
+                            region?: string;
+                            /**
+                             * Format: uuid
+                             * @description Identifier of the organization owner.
+                             */
+                            owner?: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the organization was created.
+                             */
+                            createdAt?: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the organization was last updated.
+                             */
+                            updatedAt?: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                             */
+                            deletedAt?: string | null;
+                            /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                            roleNames: string[];
+                        }[];
                         /** @description Total number of organization memberships returned for the user. */
                         totalCount?: number;
                     };
@@ -2849,14 +2993,86 @@ export interface components {
                     /** @description Teams the user belongs to with role information */
                     teams?: {
                         /** @description Team memberships for the user with their assigned roles. */
-                        teamsWithRoles?: Record<string, never>[];
+                        teamsWithRoles?: {
+                            /**
+                             * Format: uuid
+                             * @description Unique identifier of the team.
+                             */
+                            id: string;
+                            /** @description Name of the team. */
+                            name: string;
+                            /** @description Human readable description of the team. */
+                            description?: string;
+                            /**
+                             * Format: uuid
+                             * @description Identifier of the team owner.
+                             */
+                            owner?: string;
+                            /** @description Free-form metadata associated with the team. */
+                            metadata?: {
+                                [key: string]: unknown;
+                            };
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the team was created.
+                             */
+                            createdAt?: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the team was last updated.
+                             */
+                            updatedAt?: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the team was soft-deleted (null if not deleted).
+                             */
+                            deletedAt?: string | null;
+                            /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                            roleNames: string[];
+                        }[];
                         /** @description Total number of team memberships returned for the user. */
                         totalCount?: number;
                     };
                     /** @description Organizations the user belongs to with role information */
                     organizations?: {
                         /** @description Organization memberships for the user with their assigned roles. */
-                        organizationsWithRoles?: Record<string, never>[];
+                        organizationsWithRoles?: {
+                            /**
+                             * Format: uuid
+                             * @description Unique identifier of the organization.
+                             */
+                            id: string;
+                            /** @description Name of the organization. */
+                            name: string;
+                            /** @description Human readable description of the organization. */
+                            description?: string;
+                            /** @description Country associated with the organization. */
+                            country?: string;
+                            /** @description Region associated with the organization. */
+                            region?: string;
+                            /**
+                             * Format: uuid
+                             * @description Identifier of the organization owner.
+                             */
+                            owner?: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the organization was created.
+                             */
+                            createdAt?: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the organization was last updated.
+                             */
+                            updatedAt?: string;
+                            /**
+                             * Format: date-time
+                             * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                             */
+                            deletedAt?: string | null;
+                            /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                            roleNames: string[];
+                        }[];
                         /** @description Total number of organization memberships returned for the user. */
                         totalCount?: number;
                     };
@@ -3429,14 +3645,86 @@ export interface operations {
                                 /** @description Teams the user belongs to with role information */
                                 teams?: {
                                     /** @description Team memberships for the user with their assigned roles. */
-                                    teamsWithRoles?: Record<string, never>[];
+                                    teamsWithRoles?: {
+                                        /**
+                                         * Format: uuid
+                                         * @description Unique identifier of the team.
+                                         */
+                                        id: string;
+                                        /** @description Name of the team. */
+                                        name: string;
+                                        /** @description Human readable description of the team. */
+                                        description?: string;
+                                        /**
+                                         * Format: uuid
+                                         * @description Identifier of the team owner.
+                                         */
+                                        owner?: string;
+                                        /** @description Free-form metadata associated with the team. */
+                                        metadata?: {
+                                            [key: string]: unknown;
+                                        };
+                                        /**
+                                         * Format: date-time
+                                         * @description Timestamp when the team was created.
+                                         */
+                                        createdAt?: string;
+                                        /**
+                                         * Format: date-time
+                                         * @description Timestamp when the team was last updated.
+                                         */
+                                        updatedAt?: string;
+                                        /**
+                                         * Format: date-time
+                                         * @description Timestamp when the team was soft-deleted (null if not deleted).
+                                         */
+                                        deletedAt?: string | null;
+                                        /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                                        roleNames: string[];
+                                    }[];
                                     /** @description Total number of team memberships returned for the user. */
                                     totalCount?: number;
                                 };
                                 /** @description Organizations the user belongs to with role information */
                                 organizations?: {
                                     /** @description Organization memberships for the user with their assigned roles. */
-                                    organizationsWithRoles?: Record<string, never>[];
+                                    organizationsWithRoles?: {
+                                        /**
+                                         * Format: uuid
+                                         * @description Unique identifier of the organization.
+                                         */
+                                        id: string;
+                                        /** @description Name of the organization. */
+                                        name: string;
+                                        /** @description Human readable description of the organization. */
+                                        description?: string;
+                                        /** @description Country associated with the organization. */
+                                        country?: string;
+                                        /** @description Region associated with the organization. */
+                                        region?: string;
+                                        /**
+                                         * Format: uuid
+                                         * @description Identifier of the organization owner.
+                                         */
+                                        owner?: string;
+                                        /**
+                                         * Format: date-time
+                                         * @description Timestamp when the organization was created.
+                                         */
+                                        createdAt?: string;
+                                        /**
+                                         * Format: date-time
+                                         * @description Timestamp when the organization was last updated.
+                                         */
+                                        updatedAt?: string;
+                                        /**
+                                         * Format: date-time
+                                         * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                                         */
+                                        deletedAt?: string | null;
+                                        /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                                        roleNames: string[];
+                                    }[];
                                     /** @description Total number of organization memberships returned for the user. */
                                     totalCount?: number;
                                 };
@@ -3835,14 +4123,86 @@ export interface operations {
                             /** @description Teams the user belongs to with role information */
                             teams?: {
                                 /** @description Team memberships for the user with their assigned roles. */
-                                teamsWithRoles?: Record<string, never>[];
+                                teamsWithRoles?: {
+                                    /**
+                                     * Format: uuid
+                                     * @description Unique identifier of the team.
+                                     */
+                                    id: string;
+                                    /** @description Name of the team. */
+                                    name: string;
+                                    /** @description Human readable description of the team. */
+                                    description?: string;
+                                    /**
+                                     * Format: uuid
+                                     * @description Identifier of the team owner.
+                                     */
+                                    owner?: string;
+                                    /** @description Free-form metadata associated with the team. */
+                                    metadata?: {
+                                        [key: string]: unknown;
+                                    };
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was created.
+                                     */
+                                    createdAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was last updated.
+                                     */
+                                    updatedAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was soft-deleted (null if not deleted).
+                                     */
+                                    deletedAt?: string | null;
+                                    /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                                    roleNames: string[];
+                                }[];
                                 /** @description Total number of team memberships returned for the user. */
                                 totalCount?: number;
                             };
                             /** @description Organizations the user belongs to with role information */
                             organizations?: {
                                 /** @description Organization memberships for the user with their assigned roles. */
-                                organizationsWithRoles?: Record<string, never>[];
+                                organizationsWithRoles?: {
+                                    /**
+                                     * Format: uuid
+                                     * @description Unique identifier of the organization.
+                                     */
+                                    id: string;
+                                    /** @description Name of the organization. */
+                                    name: string;
+                                    /** @description Human readable description of the organization. */
+                                    description?: string;
+                                    /** @description Country associated with the organization. */
+                                    country?: string;
+                                    /** @description Region associated with the organization. */
+                                    region?: string;
+                                    /**
+                                     * Format: uuid
+                                     * @description Identifier of the organization owner.
+                                     */
+                                    owner?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was created.
+                                     */
+                                    createdAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was last updated.
+                                     */
+                                    updatedAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                                     */
+                                    deletedAt?: string | null;
+                                    /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                                    roleNames: string[];
+                                }[];
                                 /** @description Total number of organization memberships returned for the user. */
                                 totalCount?: number;
                             };
@@ -4418,14 +4778,86 @@ export interface operations {
                             /** @description Teams the user belongs to with role information */
                             teams?: {
                                 /** @description Team memberships for the user with their assigned roles. */
-                                teamsWithRoles?: Record<string, never>[];
+                                teamsWithRoles?: {
+                                    /**
+                                     * Format: uuid
+                                     * @description Unique identifier of the team.
+                                     */
+                                    id: string;
+                                    /** @description Name of the team. */
+                                    name: string;
+                                    /** @description Human readable description of the team. */
+                                    description?: string;
+                                    /**
+                                     * Format: uuid
+                                     * @description Identifier of the team owner.
+                                     */
+                                    owner?: string;
+                                    /** @description Free-form metadata associated with the team. */
+                                    metadata?: {
+                                        [key: string]: unknown;
+                                    };
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was created.
+                                     */
+                                    createdAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was last updated.
+                                     */
+                                    updatedAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was soft-deleted (null if not deleted).
+                                     */
+                                    deletedAt?: string | null;
+                                    /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                                    roleNames: string[];
+                                }[];
                                 /** @description Total number of team memberships returned for the user. */
                                 totalCount?: number;
                             };
                             /** @description Organizations the user belongs to with role information */
                             organizations?: {
                                 /** @description Organization memberships for the user with their assigned roles. */
-                                organizationsWithRoles?: Record<string, never>[];
+                                organizationsWithRoles?: {
+                                    /**
+                                     * Format: uuid
+                                     * @description Unique identifier of the organization.
+                                     */
+                                    id: string;
+                                    /** @description Name of the organization. */
+                                    name: string;
+                                    /** @description Human readable description of the organization. */
+                                    description?: string;
+                                    /** @description Country associated with the organization. */
+                                    country?: string;
+                                    /** @description Region associated with the organization. */
+                                    region?: string;
+                                    /**
+                                     * Format: uuid
+                                     * @description Identifier of the organization owner.
+                                     */
+                                    owner?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was created.
+                                     */
+                                    createdAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was last updated.
+                                     */
+                                    updatedAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                                     */
+                                    deletedAt?: string | null;
+                                    /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                                    roleNames: string[];
+                                }[];
                                 /** @description Total number of organization memberships returned for the user. */
                                 totalCount?: number;
                             };
@@ -4803,14 +5235,86 @@ export interface operations {
                             /** @description Teams the user belongs to with role information */
                             teams?: {
                                 /** @description Team memberships for the user with their assigned roles. */
-                                teamsWithRoles?: Record<string, never>[];
+                                teamsWithRoles?: {
+                                    /**
+                                     * Format: uuid
+                                     * @description Unique identifier of the team.
+                                     */
+                                    id: string;
+                                    /** @description Name of the team. */
+                                    name: string;
+                                    /** @description Human readable description of the team. */
+                                    description?: string;
+                                    /**
+                                     * Format: uuid
+                                     * @description Identifier of the team owner.
+                                     */
+                                    owner?: string;
+                                    /** @description Free-form metadata associated with the team. */
+                                    metadata?: {
+                                        [key: string]: unknown;
+                                    };
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was created.
+                                     */
+                                    createdAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was last updated.
+                                     */
+                                    updatedAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the team was soft-deleted (null if not deleted).
+                                     */
+                                    deletedAt?: string | null;
+                                    /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                                    roleNames: string[];
+                                }[];
                                 /** @description Total number of team memberships returned for the user. */
                                 totalCount?: number;
                             };
                             /** @description Organizations the user belongs to with role information */
                             organizations?: {
                                 /** @description Organization memberships for the user with their assigned roles. */
-                                organizationsWithRoles?: Record<string, never>[];
+                                organizationsWithRoles?: {
+                                    /**
+                                     * Format: uuid
+                                     * @description Unique identifier of the organization.
+                                     */
+                                    id: string;
+                                    /** @description Name of the organization. */
+                                    name: string;
+                                    /** @description Human readable description of the organization. */
+                                    description?: string;
+                                    /** @description Country associated with the organization. */
+                                    country?: string;
+                                    /** @description Region associated with the organization. */
+                                    region?: string;
+                                    /**
+                                     * Format: uuid
+                                     * @description Identifier of the organization owner.
+                                     */
+                                    owner?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was created.
+                                     */
+                                    createdAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was last updated.
+                                     */
+                                    updatedAt?: string;
+                                    /**
+                                     * Format: date-time
+                                     * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                                     */
+                                    deletedAt?: string | null;
+                                    /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                                    roleNames: string[];
+                                }[];
                                 /** @description Total number of organization memberships returned for the user. */
                                 totalCount?: number;
                             };
@@ -5358,14 +5862,86 @@ export interface operations {
                                 /** @description Teams the user belongs to with role information */
                                 teams?: {
                                     /** @description Team memberships for the user with their assigned roles. */
-                                    teamsWithRoles?: Record<string, never>[];
+                                    teamsWithRoles?: {
+                                        /**
+                                         * Format: uuid
+                                         * @description Unique identifier of the team.
+                                         */
+                                        id: string;
+                                        /** @description Name of the team. */
+                                        name: string;
+                                        /** @description Human readable description of the team. */
+                                        description?: string;
+                                        /**
+                                         * Format: uuid
+                                         * @description Identifier of the team owner.
+                                         */
+                                        owner?: string;
+                                        /** @description Free-form metadata associated with the team. */
+                                        metadata?: {
+                                            [key: string]: unknown;
+                                        };
+                                        /**
+                                         * Format: date-time
+                                         * @description Timestamp when the team was created.
+                                         */
+                                        createdAt?: string;
+                                        /**
+                                         * Format: date-time
+                                         * @description Timestamp when the team was last updated.
+                                         */
+                                        updatedAt?: string;
+                                        /**
+                                         * Format: date-time
+                                         * @description Timestamp when the team was soft-deleted (null if not deleted).
+                                         */
+                                        deletedAt?: string | null;
+                                        /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+                                        roleNames: string[];
+                                    }[];
                                     /** @description Total number of team memberships returned for the user. */
                                     totalCount?: number;
                                 };
                                 /** @description Organizations the user belongs to with role information */
                                 organizations?: {
                                     /** @description Organization memberships for the user with their assigned roles. */
-                                    organizationsWithRoles?: Record<string, never>[];
+                                    organizationsWithRoles?: {
+                                        /**
+                                         * Format: uuid
+                                         * @description Unique identifier of the organization.
+                                         */
+                                        id: string;
+                                        /** @description Name of the organization. */
+                                        name: string;
+                                        /** @description Human readable description of the organization. */
+                                        description?: string;
+                                        /** @description Country associated with the organization. */
+                                        country?: string;
+                                        /** @description Region associated with the organization. */
+                                        region?: string;
+                                        /**
+                                         * Format: uuid
+                                         * @description Identifier of the organization owner.
+                                         */
+                                        owner?: string;
+                                        /**
+                                         * Format: date-time
+                                         * @description Timestamp when the organization was created.
+                                         */
+                                        createdAt?: string;
+                                        /**
+                                         * Format: date-time
+                                         * @description Timestamp when the organization was last updated.
+                                         */
+                                        updatedAt?: string;
+                                        /**
+                                         * Format: date-time
+                                         * @description Timestamp when the organization was soft-deleted (null if not deleted).
+                                         */
+                                        deletedAt?: string | null;
+                                        /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+                                        roleNames: string[];
+                                    }[];
                                     /** @description Total number of organization memberships returned for the user. */
                                     totalCount?: number;
                                 };

--- a/typescript/generated/v1beta3/design/Design.ts
+++ b/typescript/generated/v1beta3/design/Design.ts
@@ -2001,8 +2001,8 @@ export interface components {
                 /**
                  * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                  * @example [
-                 *       "admin",
-                 *       "organization admin"
+                 *       "organization admin",
+                 *       "user"
                  *     ]
                  */
                 roleNames?: string[];
@@ -2370,8 +2370,8 @@ export interface components {
                     /**
                      * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                      * @example [
-                     *       "admin",
-                     *       "organization admin"
+                     *       "organization admin",
+                     *       "user"
                      *     ]
                      */
                     roleNames?: string[];
@@ -2985,8 +2985,8 @@ export interface components {
                     /**
                      * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                      * @example [
-                     *       "admin",
-                     *       "organization admin"
+                     *       "organization admin",
+                     *       "user"
                      *     ]
                      */
                     roleNames?: string[];
@@ -3637,8 +3637,8 @@ export interface operations {
                                 /**
                                  * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                                  * @example [
-                                 *       "admin",
-                                 *       "organization admin"
+                                 *       "organization admin",
+                                 *       "user"
                                  *     ]
                                  */
                                 roleNames?: string[];
@@ -4115,8 +4115,8 @@ export interface operations {
                             /**
                              * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                              * @example [
-                             *       "admin",
-                             *       "organization admin"
+                             *       "organization admin",
+                             *       "user"
                              *     ]
                              */
                             roleNames?: string[];
@@ -4770,8 +4770,8 @@ export interface operations {
                             /**
                              * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                              * @example [
-                             *       "admin",
-                             *       "organization admin"
+                             *       "organization admin",
+                             *       "user"
                              *     ]
                              */
                             roleNames?: string[];
@@ -5227,8 +5227,8 @@ export interface operations {
                             /**
                              * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                              * @example [
-                             *       "admin",
-                             *       "organization admin"
+                             *       "organization admin",
+                             *       "user"
                              *     ]
                              */
                             roleNames?: string[];
@@ -5854,8 +5854,8 @@ export interface operations {
                                 /**
                                  * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                                  * @example [
-                                 *       "admin",
-                                 *       "organization admin"
+                                 *       "organization admin",
+                                 *       "user"
                                  *     ]
                                  */
                                 roleNames?: string[];

--- a/typescript/generated/v1beta3/design/Design.ts
+++ b/typescript/generated/v1beta3/design/Design.ts
@@ -1999,13 +1999,13 @@ export interface components {
                  */
                 deletedAt: string | null;
                 /**
-                 * @description List of global roles assigned to the user
+                 * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                  * @example [
                  *       "admin",
-                 *       "meshmap"
+                 *       "organization admin"
                  *     ]
                  */
-                roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                roleNames?: string[];
                 /** @description Teams the user belongs to with role information */
                 teams?: {
                     /** @description Team memberships for the user with their assigned roles. */
@@ -2368,13 +2368,13 @@ export interface components {
                      */
                     deletedAt: string | null;
                     /**
-                     * @description List of global roles assigned to the user
+                     * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                      * @example [
                      *       "admin",
-                     *       "meshmap"
+                     *       "organization admin"
                      *     ]
                      */
-                    roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                    roleNames?: string[];
                     /** @description Teams the user belongs to with role information */
                     teams?: {
                         /** @description Team memberships for the user with their assigned roles. */
@@ -2983,13 +2983,13 @@ export interface components {
                      */
                     deletedAt: string | null;
                     /**
-                     * @description List of global roles assigned to the user
+                     * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                      * @example [
                      *       "admin",
-                     *       "meshmap"
+                     *       "organization admin"
                      *     ]
                      */
-                    roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                    roleNames?: string[];
                     /** @description Teams the user belongs to with role information */
                     teams?: {
                         /** @description Team memberships for the user with their assigned roles. */
@@ -3635,13 +3635,13 @@ export interface operations {
                                  */
                                 deletedAt: string | null;
                                 /**
-                                 * @description List of global roles assigned to the user
+                                 * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                                  * @example [
                                  *       "admin",
-                                 *       "meshmap"
+                                 *       "organization admin"
                                  *     ]
                                  */
-                                roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                                roleNames?: string[];
                                 /** @description Teams the user belongs to with role information */
                                 teams?: {
                                     /** @description Team memberships for the user with their assigned roles. */
@@ -4113,13 +4113,13 @@ export interface operations {
                              */
                             deletedAt: string | null;
                             /**
-                             * @description List of global roles assigned to the user
+                             * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                              * @example [
                              *       "admin",
-                             *       "meshmap"
+                             *       "organization admin"
                              *     ]
                              */
-                            roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                            roleNames?: string[];
                             /** @description Teams the user belongs to with role information */
                             teams?: {
                                 /** @description Team memberships for the user with their assigned roles. */
@@ -4768,13 +4768,13 @@ export interface operations {
                              */
                             deletedAt: string | null;
                             /**
-                             * @description List of global roles assigned to the user
+                             * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                              * @example [
                              *       "admin",
-                             *       "meshmap"
+                             *       "organization admin"
                              *     ]
                              */
-                            roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                            roleNames?: string[];
                             /** @description Teams the user belongs to with role information */
                             teams?: {
                                 /** @description Team memberships for the user with their assigned roles. */
@@ -5225,13 +5225,13 @@ export interface operations {
                              */
                             deletedAt: string | null;
                             /**
-                             * @description List of global roles assigned to the user
+                             * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                              * @example [
                              *       "admin",
-                             *       "meshmap"
+                             *       "organization admin"
                              *     ]
                              */
-                            roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                            roleNames?: string[];
                             /** @description Teams the user belongs to with role information */
                             teams?: {
                                 /** @description Team memberships for the user with their assigned roles. */
@@ -5852,13 +5852,13 @@ export interface operations {
                                  */
                                 deletedAt: string | null;
                                 /**
-                                 * @description List of global roles assigned to the user
+                                 * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
                                  * @example [
                                  *       "admin",
-                                 *       "meshmap"
+                                 *       "organization admin"
                                  *     ]
                                  */
-                                roleNames?: ("admin" | "meshmap" | "curator" | "team admin" | "workspace admin" | "workspace manager" | "organization admin" | "user")[];
+                                roleNames?: string[];
                                 /** @description Teams the user belongs to with role information */
                                 teams?: {
                                     /** @description Team memberships for the user with their assigned roles. */

--- a/typescript/generated/v1beta3/design/DesignSchema.ts
+++ b/typescript/generated/v1beta3/design/DesignSchema.ts
@@ -727,8 +727,8 @@ const DesignSchema: Record<string, unknown> = {
                                 },
                                 "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                                 "example": [
-                                  "admin",
-                                  "organization admin"
+                                  "organization admin",
+                                  "user"
                                 ],
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "role_names",
@@ -1978,8 +1978,8 @@ const DesignSchema: Record<string, unknown> = {
                           },
                           "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                           "example": [
-                            "admin",
-                            "organization admin"
+                            "organization admin",
+                            "user"
                           ],
                           "x-oapi-codegen-extra-tags": {
                             "db": "role_names",
@@ -3376,8 +3376,8 @@ const DesignSchema: Record<string, unknown> = {
                           },
                           "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                           "example": [
-                            "admin",
-                            "organization admin"
+                            "organization admin",
+                            "user"
                           ],
                           "x-oapi-codegen-extra-tags": {
                             "db": "role_names",
@@ -4505,8 +4505,8 @@ const DesignSchema: Record<string, unknown> = {
                           },
                           "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                           "example": [
-                            "admin",
-                            "organization admin"
+                            "organization admin",
+                            "user"
                           ],
                           "x-oapi-codegen-extra-tags": {
                             "db": "role_names",
@@ -5968,8 +5968,8 @@ const DesignSchema: Record<string, unknown> = {
                                 },
                                 "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                                 "example": [
-                                  "admin",
-                                  "organization admin"
+                                  "organization admin",
+                                  "user"
                                 ],
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "role_names",
@@ -12809,8 +12809,8 @@ const DesignSchema: Record<string, unknown> = {
                 },
                 "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                 "example": [
-                  "admin",
-                  "organization admin"
+                  "organization admin",
+                  "user"
                 ],
                 "x-oapi-codegen-extra-tags": {
                   "db": "role_names",
@@ -13829,8 +13829,8 @@ const DesignSchema: Record<string, unknown> = {
                       },
                       "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                       "example": [
-                        "admin",
-                        "organization admin"
+                        "organization admin",
+                        "user"
                       ],
                       "x-oapi-codegen-extra-tags": {
                         "db": "role_names",
@@ -15410,8 +15410,8 @@ const DesignSchema: Record<string, unknown> = {
                       },
                       "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                       "example": [
-                        "admin",
-                        "organization admin"
+                        "organization admin",
+                        "user"
                       ],
                       "x-oapi-codegen-extra-tags": {
                         "db": "role_names",

--- a/typescript/generated/v1beta3/design/DesignSchema.ts
+++ b/typescript/generated/v1beta3/design/DesignSchema.ts
@@ -752,7 +752,122 @@ const DesignSchema: Record<string, unknown> = {
                                     "type": "array",
                                     "description": "Team memberships for the user with their assigned roles.",
                                     "items": {
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false,
+                                      "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                      "required": [
+                                        "id",
+                                        "name",
+                                        "roleNames"
+                                      ],
+                                      "properties": {
+                                        "id": {
+                                          "description": "Unique identifier of the team.",
+                                          "x-go-name": "ID",
+                                          "x-order": 1,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "id",
+                                            "json": "id,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          }
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                          "description": "Name of the team.",
+                                          "x-order": 2,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "name",
+                                            "json": "name,omitempty"
+                                          }
+                                        },
+                                        "description": {
+                                          "type": "string",
+                                          "description": "Human readable description of the team.",
+                                          "x-order": 3,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "description",
+                                            "json": "description,omitempty"
+                                          }
+                                        },
+                                        "owner": {
+                                          "description": "Identifier of the team owner.",
+                                          "x-order": 4,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "owner",
+                                            "json": "owner,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          }
+                                        },
+                                        "metadata": {
+                                          "type": "object",
+                                          "additionalProperties": true,
+                                          "description": "Free-form metadata associated with the team.",
+                                          "x-go-type": "core.Map",
+                                          "x-go-type-skip-optional-pointer": true,
+                                          "x-order": 5,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "metadata",
+                                            "json": "metadata,omitempty"
+                                          }
+                                        },
+                                        "createdAt": {
+                                          "description": "Timestamp when the team was created.",
+                                          "x-order": 6,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "created_at",
+                                            "json": "createdAt,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "x-go-type-skip-optional-pointer": true
+                                        },
+                                        "updatedAt": {
+                                          "description": "Timestamp when the team was last updated.",
+                                          "x-order": 7,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "updated_at",
+                                            "json": "updatedAt,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "x-go-type-skip-optional-pointer": true
+                                        },
+                                        "deletedAt": {
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "nullable": true,
+                                          "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                                          "x-go-type": "core.NullTime",
+                                          "x-order": 8,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "deleted_at",
+                                            "json": "deletedAt,omitempty"
+                                          }
+                                        },
+                                        "roleNames": {
+                                          "type": "array",
+                                          "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-go-type-skip-optional-pointer": true,
+                                          "x-order": 9,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "role_names",
+                                            "json": "roleNames"
+                                          }
+                                        }
+                                      }
                                     },
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "teams_with_roles",
@@ -782,7 +897,128 @@ const DesignSchema: Record<string, unknown> = {
                                     "type": "array",
                                     "description": "Organization memberships for the user with their assigned roles.",
                                     "items": {
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false,
+                                      "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                      "required": [
+                                        "id",
+                                        "name",
+                                        "roleNames"
+                                      ],
+                                      "properties": {
+                                        "id": {
+                                          "description": "Unique identifier of the organization.",
+                                          "x-go-name": "ID",
+                                          "x-order": 1,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "id",
+                                            "json": "id,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          }
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                          "description": "Name of the organization.",
+                                          "x-order": 2,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "name",
+                                            "json": "name,omitempty"
+                                          }
+                                        },
+                                        "description": {
+                                          "type": "string",
+                                          "description": "Human readable description of the organization.",
+                                          "x-order": 3,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "description",
+                                            "json": "description,omitempty"
+                                          }
+                                        },
+                                        "country": {
+                                          "type": "string",
+                                          "description": "Country associated with the organization.",
+                                          "x-order": 4,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "country",
+                                            "json": "country,omitempty"
+                                          }
+                                        },
+                                        "region": {
+                                          "type": "string",
+                                          "description": "Region associated with the organization.",
+                                          "x-order": 5,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "region",
+                                            "json": "region,omitempty"
+                                          }
+                                        },
+                                        "owner": {
+                                          "description": "Identifier of the organization owner.",
+                                          "x-order": 6,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "owner",
+                                            "json": "owner,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          }
+                                        },
+                                        "createdAt": {
+                                          "description": "Timestamp when the organization was created.",
+                                          "x-order": 7,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "created_at",
+                                            "json": "createdAt,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "x-go-type-skip-optional-pointer": true
+                                        },
+                                        "updatedAt": {
+                                          "description": "Timestamp when the organization was last updated.",
+                                          "x-order": 8,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "updated_at",
+                                            "json": "updatedAt,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "x-go-type-skip-optional-pointer": true
+                                        },
+                                        "deletedAt": {
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "nullable": true,
+                                          "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                                          "x-go-type": "core.NullTime",
+                                          "x-order": 9,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "deleted_at",
+                                            "json": "deletedAt,omitempty"
+                                          }
+                                        },
+                                        "roleNames": {
+                                          "type": "array",
+                                          "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-go-type-skip-optional-pointer": true,
+                                          "x-order": 10,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "role_names",
+                                            "json": "roleNames"
+                                          }
+                                        }
+                                      }
                                     },
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "organizations_with_roles",
@@ -1766,7 +2002,122 @@ const DesignSchema: Record<string, unknown> = {
                               "type": "array",
                               "description": "Team memberships for the user with their assigned roles.",
                               "items": {
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false,
+                                "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                "required": [
+                                  "id",
+                                  "name",
+                                  "roleNames"
+                                ],
+                                "properties": {
+                                  "id": {
+                                    "description": "Unique identifier of the team.",
+                                    "x-go-name": "ID",
+                                    "x-order": 1,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "id",
+                                      "json": "id,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Name of the team.",
+                                    "x-order": 2,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "name",
+                                      "json": "name,omitempty"
+                                    }
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Human readable description of the team.",
+                                    "x-order": 3,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "description",
+                                      "json": "description,omitempty"
+                                    }
+                                  },
+                                  "owner": {
+                                    "description": "Identifier of the team owner.",
+                                    "x-order": 4,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "owner",
+                                      "json": "owner,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    }
+                                  },
+                                  "metadata": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Free-form metadata associated with the team.",
+                                    "x-go-type": "core.Map",
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "x-order": 5,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "metadata",
+                                      "json": "metadata,omitempty"
+                                    }
+                                  },
+                                  "createdAt": {
+                                    "description": "Timestamp when the team was created.",
+                                    "x-order": 6,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "created_at",
+                                      "json": "createdAt,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "updatedAt": {
+                                    "description": "Timestamp when the team was last updated.",
+                                    "x-order": 7,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "updated_at",
+                                      "json": "updatedAt,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "deletedAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "nullable": true,
+                                    "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                                    "x-go-type": "core.NullTime",
+                                    "x-order": 8,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "deleted_at",
+                                      "json": "deletedAt,omitempty"
+                                    }
+                                  },
+                                  "roleNames": {
+                                    "type": "array",
+                                    "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "x-order": 9,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "role_names",
+                                      "json": "roleNames"
+                                    }
+                                  }
+                                }
                               },
                               "x-oapi-codegen-extra-tags": {
                                 "db": "teams_with_roles",
@@ -1796,7 +2147,128 @@ const DesignSchema: Record<string, unknown> = {
                               "type": "array",
                               "description": "Organization memberships for the user with their assigned roles.",
                               "items": {
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false,
+                                "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                "required": [
+                                  "id",
+                                  "name",
+                                  "roleNames"
+                                ],
+                                "properties": {
+                                  "id": {
+                                    "description": "Unique identifier of the organization.",
+                                    "x-go-name": "ID",
+                                    "x-order": 1,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "id",
+                                      "json": "id,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Name of the organization.",
+                                    "x-order": 2,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "name",
+                                      "json": "name,omitempty"
+                                    }
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Human readable description of the organization.",
+                                    "x-order": 3,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "description",
+                                      "json": "description,omitempty"
+                                    }
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "description": "Country associated with the organization.",
+                                    "x-order": 4,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "country",
+                                      "json": "country,omitempty"
+                                    }
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "description": "Region associated with the organization.",
+                                    "x-order": 5,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "region",
+                                      "json": "region,omitempty"
+                                    }
+                                  },
+                                  "owner": {
+                                    "description": "Identifier of the organization owner.",
+                                    "x-order": 6,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "owner",
+                                      "json": "owner,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    }
+                                  },
+                                  "createdAt": {
+                                    "description": "Timestamp when the organization was created.",
+                                    "x-order": 7,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "created_at",
+                                      "json": "createdAt,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "updatedAt": {
+                                    "description": "Timestamp when the organization was last updated.",
+                                    "x-order": 8,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "updated_at",
+                                      "json": "updatedAt,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "deletedAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "nullable": true,
+                                    "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                                    "x-go-type": "core.NullTime",
+                                    "x-order": 9,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "deleted_at",
+                                      "json": "deletedAt,omitempty"
+                                    }
+                                  },
+                                  "roleNames": {
+                                    "type": "array",
+                                    "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "x-order": 10,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "role_names",
+                                      "json": "roleNames"
+                                    }
+                                  }
+                                }
                               },
                               "x-oapi-codegen-extra-tags": {
                                 "db": "organizations_with_roles",
@@ -2927,7 +3399,122 @@ const DesignSchema: Record<string, unknown> = {
                               "type": "array",
                               "description": "Team memberships for the user with their assigned roles.",
                               "items": {
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false,
+                                "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                "required": [
+                                  "id",
+                                  "name",
+                                  "roleNames"
+                                ],
+                                "properties": {
+                                  "id": {
+                                    "description": "Unique identifier of the team.",
+                                    "x-go-name": "ID",
+                                    "x-order": 1,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "id",
+                                      "json": "id,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Name of the team.",
+                                    "x-order": 2,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "name",
+                                      "json": "name,omitempty"
+                                    }
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Human readable description of the team.",
+                                    "x-order": 3,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "description",
+                                      "json": "description,omitempty"
+                                    }
+                                  },
+                                  "owner": {
+                                    "description": "Identifier of the team owner.",
+                                    "x-order": 4,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "owner",
+                                      "json": "owner,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    }
+                                  },
+                                  "metadata": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Free-form metadata associated with the team.",
+                                    "x-go-type": "core.Map",
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "x-order": 5,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "metadata",
+                                      "json": "metadata,omitempty"
+                                    }
+                                  },
+                                  "createdAt": {
+                                    "description": "Timestamp when the team was created.",
+                                    "x-order": 6,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "created_at",
+                                      "json": "createdAt,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "updatedAt": {
+                                    "description": "Timestamp when the team was last updated.",
+                                    "x-order": 7,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "updated_at",
+                                      "json": "updatedAt,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "deletedAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "nullable": true,
+                                    "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                                    "x-go-type": "core.NullTime",
+                                    "x-order": 8,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "deleted_at",
+                                      "json": "deletedAt,omitempty"
+                                    }
+                                  },
+                                  "roleNames": {
+                                    "type": "array",
+                                    "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "x-order": 9,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "role_names",
+                                      "json": "roleNames"
+                                    }
+                                  }
+                                }
                               },
                               "x-oapi-codegen-extra-tags": {
                                 "db": "teams_with_roles",
@@ -2957,7 +3544,128 @@ const DesignSchema: Record<string, unknown> = {
                               "type": "array",
                               "description": "Organization memberships for the user with their assigned roles.",
                               "items": {
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false,
+                                "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                "required": [
+                                  "id",
+                                  "name",
+                                  "roleNames"
+                                ],
+                                "properties": {
+                                  "id": {
+                                    "description": "Unique identifier of the organization.",
+                                    "x-go-name": "ID",
+                                    "x-order": 1,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "id",
+                                      "json": "id,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Name of the organization.",
+                                    "x-order": 2,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "name",
+                                      "json": "name,omitempty"
+                                    }
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Human readable description of the organization.",
+                                    "x-order": 3,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "description",
+                                      "json": "description,omitempty"
+                                    }
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "description": "Country associated with the organization.",
+                                    "x-order": 4,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "country",
+                                      "json": "country,omitempty"
+                                    }
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "description": "Region associated with the organization.",
+                                    "x-order": 5,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "region",
+                                      "json": "region,omitempty"
+                                    }
+                                  },
+                                  "owner": {
+                                    "description": "Identifier of the organization owner.",
+                                    "x-order": 6,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "owner",
+                                      "json": "owner,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    }
+                                  },
+                                  "createdAt": {
+                                    "description": "Timestamp when the organization was created.",
+                                    "x-order": 7,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "created_at",
+                                      "json": "createdAt,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "updatedAt": {
+                                    "description": "Timestamp when the organization was last updated.",
+                                    "x-order": 8,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "updated_at",
+                                      "json": "updatedAt,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "deletedAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "nullable": true,
+                                    "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                                    "x-go-type": "core.NullTime",
+                                    "x-order": 9,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "deleted_at",
+                                      "json": "deletedAt,omitempty"
+                                    }
+                                  },
+                                  "roleNames": {
+                                    "type": "array",
+                                    "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "x-order": 10,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "role_names",
+                                      "json": "roleNames"
+                                    }
+                                  }
+                                }
                               },
                               "x-oapi-codegen-extra-tags": {
                                 "db": "organizations_with_roles",
@@ -3819,7 +4527,122 @@ const DesignSchema: Record<string, unknown> = {
                               "type": "array",
                               "description": "Team memberships for the user with their assigned roles.",
                               "items": {
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false,
+                                "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                "required": [
+                                  "id",
+                                  "name",
+                                  "roleNames"
+                                ],
+                                "properties": {
+                                  "id": {
+                                    "description": "Unique identifier of the team.",
+                                    "x-go-name": "ID",
+                                    "x-order": 1,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "id",
+                                      "json": "id,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Name of the team.",
+                                    "x-order": 2,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "name",
+                                      "json": "name,omitempty"
+                                    }
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Human readable description of the team.",
+                                    "x-order": 3,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "description",
+                                      "json": "description,omitempty"
+                                    }
+                                  },
+                                  "owner": {
+                                    "description": "Identifier of the team owner.",
+                                    "x-order": 4,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "owner",
+                                      "json": "owner,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    }
+                                  },
+                                  "metadata": {
+                                    "type": "object",
+                                    "additionalProperties": true,
+                                    "description": "Free-form metadata associated with the team.",
+                                    "x-go-type": "core.Map",
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "x-order": 5,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "metadata",
+                                      "json": "metadata,omitempty"
+                                    }
+                                  },
+                                  "createdAt": {
+                                    "description": "Timestamp when the team was created.",
+                                    "x-order": 6,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "created_at",
+                                      "json": "createdAt,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "updatedAt": {
+                                    "description": "Timestamp when the team was last updated.",
+                                    "x-order": 7,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "updated_at",
+                                      "json": "updatedAt,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "deletedAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "nullable": true,
+                                    "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                                    "x-go-type": "core.NullTime",
+                                    "x-order": 8,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "deleted_at",
+                                      "json": "deletedAt,omitempty"
+                                    }
+                                  },
+                                  "roleNames": {
+                                    "type": "array",
+                                    "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "x-order": 9,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "role_names",
+                                      "json": "roleNames"
+                                    }
+                                  }
+                                }
                               },
                               "x-oapi-codegen-extra-tags": {
                                 "db": "teams_with_roles",
@@ -3849,7 +4672,128 @@ const DesignSchema: Record<string, unknown> = {
                               "type": "array",
                               "description": "Organization memberships for the user with their assigned roles.",
                               "items": {
-                                "type": "object"
+                                "type": "object",
+                                "additionalProperties": false,
+                                "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                "required": [
+                                  "id",
+                                  "name",
+                                  "roleNames"
+                                ],
+                                "properties": {
+                                  "id": {
+                                    "description": "Unique identifier of the organization.",
+                                    "x-go-name": "ID",
+                                    "x-order": 1,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "id",
+                                      "json": "id,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    }
+                                  },
+                                  "name": {
+                                    "type": "string",
+                                    "description": "Name of the organization.",
+                                    "x-order": 2,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "name",
+                                      "json": "name,omitempty"
+                                    }
+                                  },
+                                  "description": {
+                                    "type": "string",
+                                    "description": "Human readable description of the organization.",
+                                    "x-order": 3,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "description",
+                                      "json": "description,omitempty"
+                                    }
+                                  },
+                                  "country": {
+                                    "type": "string",
+                                    "description": "Country associated with the organization.",
+                                    "x-order": 4,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "country",
+                                      "json": "country,omitempty"
+                                    }
+                                  },
+                                  "region": {
+                                    "type": "string",
+                                    "description": "Region associated with the organization.",
+                                    "x-order": 5,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "region",
+                                      "json": "region,omitempty"
+                                    }
+                                  },
+                                  "owner": {
+                                    "description": "Identifier of the organization owner.",
+                                    "x-order": 6,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "owner",
+                                      "json": "owner,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    }
+                                  },
+                                  "createdAt": {
+                                    "description": "Timestamp when the organization was created.",
+                                    "x-order": 7,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "created_at",
+                                      "json": "createdAt,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "updatedAt": {
+                                    "description": "Timestamp when the organization was last updated.",
+                                    "x-order": 8,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "updated_at",
+                                      "json": "updatedAt,omitempty"
+                                    },
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "x-go-type-skip-optional-pointer": true
+                                  },
+                                  "deletedAt": {
+                                    "type": "string",
+                                    "format": "date-time",
+                                    "nullable": true,
+                                    "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                                    "x-go-type": "core.NullTime",
+                                    "x-order": 9,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "deleted_at",
+                                      "json": "deletedAt,omitempty"
+                                    }
+                                  },
+                                  "roleNames": {
+                                    "type": "array",
+                                    "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                                    "items": {
+                                      "type": "string"
+                                    },
+                                    "x-go-type-skip-optional-pointer": true,
+                                    "x-order": 10,
+                                    "x-oapi-codegen-extra-tags": {
+                                      "db": "role_names",
+                                      "json": "roleNames"
+                                    }
+                                  }
+                                }
                               },
                               "x-oapi-codegen-extra-tags": {
                                 "db": "organizations_with_roles",
@@ -5045,7 +5989,122 @@ const DesignSchema: Record<string, unknown> = {
                                     "type": "array",
                                     "description": "Team memberships for the user with their assigned roles.",
                                     "items": {
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false,
+                                      "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                      "required": [
+                                        "id",
+                                        "name",
+                                        "roleNames"
+                                      ],
+                                      "properties": {
+                                        "id": {
+                                          "description": "Unique identifier of the team.",
+                                          "x-go-name": "ID",
+                                          "x-order": 1,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "id",
+                                            "json": "id,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          }
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                          "description": "Name of the team.",
+                                          "x-order": 2,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "name",
+                                            "json": "name,omitempty"
+                                          }
+                                        },
+                                        "description": {
+                                          "type": "string",
+                                          "description": "Human readable description of the team.",
+                                          "x-order": 3,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "description",
+                                            "json": "description,omitempty"
+                                          }
+                                        },
+                                        "owner": {
+                                          "description": "Identifier of the team owner.",
+                                          "x-order": 4,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "owner",
+                                            "json": "owner,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          }
+                                        },
+                                        "metadata": {
+                                          "type": "object",
+                                          "additionalProperties": true,
+                                          "description": "Free-form metadata associated with the team.",
+                                          "x-go-type": "core.Map",
+                                          "x-go-type-skip-optional-pointer": true,
+                                          "x-order": 5,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "metadata",
+                                            "json": "metadata,omitempty"
+                                          }
+                                        },
+                                        "createdAt": {
+                                          "description": "Timestamp when the team was created.",
+                                          "x-order": 6,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "created_at",
+                                            "json": "createdAt,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "x-go-type-skip-optional-pointer": true
+                                        },
+                                        "updatedAt": {
+                                          "description": "Timestamp when the team was last updated.",
+                                          "x-order": 7,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "updated_at",
+                                            "json": "updatedAt,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "x-go-type-skip-optional-pointer": true
+                                        },
+                                        "deletedAt": {
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "nullable": true,
+                                          "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                                          "x-go-type": "core.NullTime",
+                                          "x-order": 8,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "deleted_at",
+                                            "json": "deletedAt,omitempty"
+                                          }
+                                        },
+                                        "roleNames": {
+                                          "type": "array",
+                                          "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-go-type-skip-optional-pointer": true,
+                                          "x-order": 9,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "role_names",
+                                            "json": "roleNames"
+                                          }
+                                        }
+                                      }
                                     },
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "teams_with_roles",
@@ -5075,7 +6134,128 @@ const DesignSchema: Record<string, unknown> = {
                                     "type": "array",
                                     "description": "Organization memberships for the user with their assigned roles.",
                                     "items": {
-                                      "type": "object"
+                                      "type": "object",
+                                      "additionalProperties": false,
+                                      "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                                      "required": [
+                                        "id",
+                                        "name",
+                                        "roleNames"
+                                      ],
+                                      "properties": {
+                                        "id": {
+                                          "description": "Unique identifier of the organization.",
+                                          "x-go-name": "ID",
+                                          "x-order": 1,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "id",
+                                            "json": "id,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          }
+                                        },
+                                        "name": {
+                                          "type": "string",
+                                          "description": "Name of the organization.",
+                                          "x-order": 2,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "name",
+                                            "json": "name,omitempty"
+                                          }
+                                        },
+                                        "description": {
+                                          "type": "string",
+                                          "description": "Human readable description of the organization.",
+                                          "x-order": 3,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "description",
+                                            "json": "description,omitempty"
+                                          }
+                                        },
+                                        "country": {
+                                          "type": "string",
+                                          "description": "Country associated with the organization.",
+                                          "x-order": 4,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "country",
+                                            "json": "country,omitempty"
+                                          }
+                                        },
+                                        "region": {
+                                          "type": "string",
+                                          "description": "Region associated with the organization.",
+                                          "x-order": 5,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "region",
+                                            "json": "region,omitempty"
+                                          }
+                                        },
+                                        "owner": {
+                                          "description": "Identifier of the organization owner.",
+                                          "x-order": 6,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "owner",
+                                            "json": "owner,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          }
+                                        },
+                                        "createdAt": {
+                                          "description": "Timestamp when the organization was created.",
+                                          "x-order": 7,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "created_at",
+                                            "json": "createdAt,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "x-go-type-skip-optional-pointer": true
+                                        },
+                                        "updatedAt": {
+                                          "description": "Timestamp when the organization was last updated.",
+                                          "x-order": 8,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "updated_at",
+                                            "json": "updatedAt,omitempty"
+                                          },
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "x-go-type-skip-optional-pointer": true
+                                        },
+                                        "deletedAt": {
+                                          "type": "string",
+                                          "format": "date-time",
+                                          "nullable": true,
+                                          "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                                          "x-go-type": "core.NullTime",
+                                          "x-order": 9,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "deleted_at",
+                                            "json": "deletedAt,omitempty"
+                                          }
+                                        },
+                                        "roleNames": {
+                                          "type": "array",
+                                          "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                                          "items": {
+                                            "type": "string"
+                                          },
+                                          "x-go-type-skip-optional-pointer": true,
+                                          "x-order": 10,
+                                          "x-oapi-codegen-extra-tags": {
+                                            "db": "role_names",
+                                            "json": "roleNames"
+                                          }
+                                        }
+                                      }
                                     },
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "organizations_with_roles",
@@ -11649,7 +12829,122 @@ const DesignSchema: Record<string, unknown> = {
                     "type": "array",
                     "description": "Team memberships for the user with their assigned roles.",
                     "items": {
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                      "required": [
+                        "id",
+                        "name",
+                        "roleNames"
+                      ],
+                      "properties": {
+                        "id": {
+                          "description": "Unique identifier of the team.",
+                          "x-go-name": "ID",
+                          "x-order": 1,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "id",
+                            "json": "id,omitempty"
+                          },
+                          "type": "string",
+                          "format": "uuid",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
+                          }
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Name of the team.",
+                          "x-order": 2,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "name",
+                            "json": "name,omitempty"
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Human readable description of the team.",
+                          "x-order": 3,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "description",
+                            "json": "description,omitempty"
+                          }
+                        },
+                        "owner": {
+                          "description": "Identifier of the team owner.",
+                          "x-order": 4,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "owner",
+                            "json": "owner,omitempty"
+                          },
+                          "type": "string",
+                          "format": "uuid",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
+                          }
+                        },
+                        "metadata": {
+                          "type": "object",
+                          "additionalProperties": true,
+                          "description": "Free-form metadata associated with the team.",
+                          "x-go-type": "core.Map",
+                          "x-go-type-skip-optional-pointer": true,
+                          "x-order": 5,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "metadata",
+                            "json": "metadata,omitempty"
+                          }
+                        },
+                        "createdAt": {
+                          "description": "Timestamp when the team was created.",
+                          "x-order": 6,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "created_at",
+                            "json": "createdAt,omitempty"
+                          },
+                          "type": "string",
+                          "format": "date-time",
+                          "x-go-type-skip-optional-pointer": true
+                        },
+                        "updatedAt": {
+                          "description": "Timestamp when the team was last updated.",
+                          "x-order": 7,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "updated_at",
+                            "json": "updatedAt,omitempty"
+                          },
+                          "type": "string",
+                          "format": "date-time",
+                          "x-go-type-skip-optional-pointer": true
+                        },
+                        "deletedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true,
+                          "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                          "x-go-type": "core.NullTime",
+                          "x-order": 8,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "deleted_at",
+                            "json": "deletedAt,omitempty"
+                          }
+                        },
+                        "roleNames": {
+                          "type": "array",
+                          "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "x-go-type-skip-optional-pointer": true,
+                          "x-order": 9,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "role_names",
+                            "json": "roleNames"
+                          }
+                        }
+                      }
                     },
                     "x-oapi-codegen-extra-tags": {
                       "db": "teams_with_roles",
@@ -11679,7 +12974,128 @@ const DesignSchema: Record<string, unknown> = {
                     "type": "array",
                     "description": "Organization memberships for the user with their assigned roles.",
                     "items": {
-                      "type": "object"
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                      "required": [
+                        "id",
+                        "name",
+                        "roleNames"
+                      ],
+                      "properties": {
+                        "id": {
+                          "description": "Unique identifier of the organization.",
+                          "x-go-name": "ID",
+                          "x-order": 1,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "id",
+                            "json": "id,omitempty"
+                          },
+                          "type": "string",
+                          "format": "uuid",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
+                          }
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "Name of the organization.",
+                          "x-order": 2,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "name",
+                            "json": "name,omitempty"
+                          }
+                        },
+                        "description": {
+                          "type": "string",
+                          "description": "Human readable description of the organization.",
+                          "x-order": 3,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "description",
+                            "json": "description,omitempty"
+                          }
+                        },
+                        "country": {
+                          "type": "string",
+                          "description": "Country associated with the organization.",
+                          "x-order": 4,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "country",
+                            "json": "country,omitempty"
+                          }
+                        },
+                        "region": {
+                          "type": "string",
+                          "description": "Region associated with the organization.",
+                          "x-order": 5,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "region",
+                            "json": "region,omitempty"
+                          }
+                        },
+                        "owner": {
+                          "description": "Identifier of the organization owner.",
+                          "x-order": 6,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "owner",
+                            "json": "owner,omitempty"
+                          },
+                          "type": "string",
+                          "format": "uuid",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
+                          }
+                        },
+                        "createdAt": {
+                          "description": "Timestamp when the organization was created.",
+                          "x-order": 7,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "created_at",
+                            "json": "createdAt,omitempty"
+                          },
+                          "type": "string",
+                          "format": "date-time",
+                          "x-go-type-skip-optional-pointer": true
+                        },
+                        "updatedAt": {
+                          "description": "Timestamp when the organization was last updated.",
+                          "x-order": 8,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "updated_at",
+                            "json": "updatedAt,omitempty"
+                          },
+                          "type": "string",
+                          "format": "date-time",
+                          "x-go-type-skip-optional-pointer": true
+                        },
+                        "deletedAt": {
+                          "type": "string",
+                          "format": "date-time",
+                          "nullable": true,
+                          "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                          "x-go-type": "core.NullTime",
+                          "x-order": 9,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "deleted_at",
+                            "json": "deletedAt,omitempty"
+                          }
+                        },
+                        "roleNames": {
+                          "type": "array",
+                          "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                          "items": {
+                            "type": "string"
+                          },
+                          "x-go-type-skip-optional-pointer": true,
+                          "x-order": 10,
+                          "x-oapi-codegen-extra-tags": {
+                            "db": "role_names",
+                            "json": "roleNames"
+                          }
+                        }
+                      }
                     },
                     "x-oapi-codegen-extra-tags": {
                       "db": "organizations_with_roles",
@@ -12432,7 +13848,122 @@ const DesignSchema: Record<string, unknown> = {
                           "type": "array",
                           "description": "Team memberships for the user with their assigned roles.",
                           "items": {
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                            "required": [
+                              "id",
+                              "name",
+                              "roleNames"
+                            ],
+                            "properties": {
+                              "id": {
+                                "description": "Unique identifier of the team.",
+                                "x-go-name": "ID",
+                                "x-order": 1,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "id",
+                                  "json": "id,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Name of the team.",
+                                "x-order": 2,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "name",
+                                  "json": "name,omitempty"
+                                }
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "Human readable description of the team.",
+                                "x-order": 3,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "description",
+                                  "json": "description,omitempty"
+                                }
+                              },
+                              "owner": {
+                                "description": "Identifier of the team owner.",
+                                "x-order": 4,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "owner",
+                                  "json": "owner,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "additionalProperties": true,
+                                "description": "Free-form metadata associated with the team.",
+                                "x-go-type": "core.Map",
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-order": 5,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "metadata",
+                                  "json": "metadata,omitempty"
+                                }
+                              },
+                              "createdAt": {
+                                "description": "Timestamp when the team was created.",
+                                "x-order": 6,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "created_at",
+                                  "json": "createdAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "updatedAt": {
+                                "description": "Timestamp when the team was last updated.",
+                                "x-order": 7,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "updated_at",
+                                  "json": "updatedAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "deletedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true,
+                                "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                                "x-go-type": "core.NullTime",
+                                "x-order": 8,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "deleted_at",
+                                  "json": "deletedAt,omitempty"
+                                }
+                              },
+                              "roleNames": {
+                                "type": "array",
+                                "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-order": 9,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "role_names",
+                                  "json": "roleNames"
+                                }
+                              }
+                            }
                           },
                           "x-oapi-codegen-extra-tags": {
                             "db": "teams_with_roles",
@@ -12462,7 +13993,128 @@ const DesignSchema: Record<string, unknown> = {
                           "type": "array",
                           "description": "Organization memberships for the user with their assigned roles.",
                           "items": {
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                            "required": [
+                              "id",
+                              "name",
+                              "roleNames"
+                            ],
+                            "properties": {
+                              "id": {
+                                "description": "Unique identifier of the organization.",
+                                "x-go-name": "ID",
+                                "x-order": 1,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "id",
+                                  "json": "id,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Name of the organization.",
+                                "x-order": 2,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "name",
+                                  "json": "name,omitempty"
+                                }
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "Human readable description of the organization.",
+                                "x-order": 3,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "description",
+                                  "json": "description,omitempty"
+                                }
+                              },
+                              "country": {
+                                "type": "string",
+                                "description": "Country associated with the organization.",
+                                "x-order": 4,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "country",
+                                  "json": "country,omitempty"
+                                }
+                              },
+                              "region": {
+                                "type": "string",
+                                "description": "Region associated with the organization.",
+                                "x-order": 5,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "region",
+                                  "json": "region,omitempty"
+                                }
+                              },
+                              "owner": {
+                                "description": "Identifier of the organization owner.",
+                                "x-order": 6,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "owner",
+                                  "json": "owner,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "createdAt": {
+                                "description": "Timestamp when the organization was created.",
+                                "x-order": 7,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "created_at",
+                                  "json": "createdAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "updatedAt": {
+                                "description": "Timestamp when the organization was last updated.",
+                                "x-order": 8,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "updated_at",
+                                  "json": "updatedAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "deletedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true,
+                                "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                                "x-go-type": "core.NullTime",
+                                "x-order": 9,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "deleted_at",
+                                  "json": "deletedAt,omitempty"
+                                }
+                              },
+                              "roleNames": {
+                                "type": "array",
+                                "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-order": 10,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "role_names",
+                                  "json": "roleNames"
+                                }
+                              }
+                            }
                           },
                           "x-oapi-codegen-extra-tags": {
                             "db": "organizations_with_roles",
@@ -13776,7 +15428,122 @@ const DesignSchema: Record<string, unknown> = {
                           "type": "array",
                           "description": "Team memberships for the user with their assigned roles.",
                           "items": {
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                            "required": [
+                              "id",
+                              "name",
+                              "roleNames"
+                            ],
+                            "properties": {
+                              "id": {
+                                "description": "Unique identifier of the team.",
+                                "x-go-name": "ID",
+                                "x-order": 1,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "id",
+                                  "json": "id,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Name of the team.",
+                                "x-order": 2,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "name",
+                                  "json": "name,omitempty"
+                                }
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "Human readable description of the team.",
+                                "x-order": 3,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "description",
+                                  "json": "description,omitempty"
+                                }
+                              },
+                              "owner": {
+                                "description": "Identifier of the team owner.",
+                                "x-order": 4,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "owner",
+                                  "json": "owner,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "metadata": {
+                                "type": "object",
+                                "additionalProperties": true,
+                                "description": "Free-form metadata associated with the team.",
+                                "x-go-type": "core.Map",
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-order": 5,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "metadata",
+                                  "json": "metadata,omitempty"
+                                }
+                              },
+                              "createdAt": {
+                                "description": "Timestamp when the team was created.",
+                                "x-order": 6,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "created_at",
+                                  "json": "createdAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "updatedAt": {
+                                "description": "Timestamp when the team was last updated.",
+                                "x-order": 7,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "updated_at",
+                                  "json": "updatedAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "deletedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true,
+                                "description": "Timestamp when the team was soft-deleted (null if not deleted).",
+                                "x-go-type": "core.NullTime",
+                                "x-order": 8,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "deleted_at",
+                                  "json": "deletedAt,omitempty"
+                                }
+                              },
+                              "roleNames": {
+                                "type": "array",
+                                "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-order": 9,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "role_names",
+                                  "json": "roleNames"
+                                }
+                              }
+                            }
                           },
                           "x-oapi-codegen-extra-tags": {
                             "db": "teams_with_roles",
@@ -13806,7 +15573,128 @@ const DesignSchema: Record<string, unknown> = {
                           "type": "array",
                           "description": "Organization memberships for the user with their assigned roles.",
                           "items": {
-                            "type": "object"
+                            "type": "object",
+                            "additionalProperties": false,
+                            "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
+                            "required": [
+                              "id",
+                              "name",
+                              "roleNames"
+                            ],
+                            "properties": {
+                              "id": {
+                                "description": "Unique identifier of the organization.",
+                                "x-go-name": "ID",
+                                "x-order": 1,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "id",
+                                  "json": "id,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "name": {
+                                "type": "string",
+                                "description": "Name of the organization.",
+                                "x-order": 2,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "name",
+                                  "json": "name,omitempty"
+                                }
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "Human readable description of the organization.",
+                                "x-order": 3,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "description",
+                                  "json": "description,omitempty"
+                                }
+                              },
+                              "country": {
+                                "type": "string",
+                                "description": "Country associated with the organization.",
+                                "x-order": 4,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "country",
+                                  "json": "country,omitempty"
+                                }
+                              },
+                              "region": {
+                                "type": "string",
+                                "description": "Region associated with the organization.",
+                                "x-order": 5,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "region",
+                                  "json": "region,omitempty"
+                                }
+                              },
+                              "owner": {
+                                "description": "Identifier of the organization owner.",
+                                "x-order": 6,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "owner",
+                                  "json": "owner,omitempty"
+                                },
+                                "type": "string",
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                }
+                              },
+                              "createdAt": {
+                                "description": "Timestamp when the organization was created.",
+                                "x-order": 7,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "created_at",
+                                  "json": "createdAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "updatedAt": {
+                                "description": "Timestamp when the organization was last updated.",
+                                "x-order": 8,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "updated_at",
+                                  "json": "updatedAt,omitempty"
+                                },
+                                "type": "string",
+                                "format": "date-time",
+                                "x-go-type-skip-optional-pointer": true
+                              },
+                              "deletedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true,
+                                "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
+                                "x-go-type": "core.NullTime",
+                                "x-order": 9,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "deleted_at",
+                                  "json": "deletedAt,omitempty"
+                                }
+                              },
+                              "roleNames": {
+                                "type": "array",
+                                "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
+                                "items": {
+                                  "type": "string"
+                                },
+                                "x-go-type-skip-optional-pointer": true,
+                                "x-order": 10,
+                                "x-oapi-codegen-extra-tags": {
+                                  "db": "role_names",
+                                  "json": "roleNames"
+                                }
+                              }
+                            }
                           },
                           "x-oapi-codegen-extra-tags": {
                             "db": "organizations_with_roles",

--- a/typescript/generated/v1beta3/design/DesignSchema.ts
+++ b/typescript/generated/v1beta3/design/DesignSchema.ts
@@ -717,23 +717,18 @@ const DesignSchema: Record<string, unknown> = {
                               },
                               "roleNames": {
                                 "type": "array",
-                                "items": {
-                                  "type": "string",
-                                  "enum": [
-                                    "admin",
-                                    "meshmap",
-                                    "curator",
-                                    "team admin",
-                                    "workspace admin",
-                                    "workspace manager",
-                                    "organization admin",
-                                    "user"
-                                  ]
+                                "x-go-type": "pq.StringArray",
+                                "x-go-type-import": {
+                                  "path": "github.com/lib/pq"
                                 },
-                                "description": "List of global roles assigned to the user",
+                                "x-go-type-skip-optional-pointer": true,
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                                 "example": [
                                   "admin",
-                                  "meshmap"
+                                  "organization admin"
                                 ],
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "role_names",
@@ -1973,23 +1968,18 @@ const DesignSchema: Record<string, unknown> = {
                         },
                         "roleNames": {
                           "type": "array",
-                          "items": {
-                            "type": "string",
-                            "enum": [
-                              "admin",
-                              "meshmap",
-                              "curator",
-                              "team admin",
-                              "workspace admin",
-                              "workspace manager",
-                              "organization admin",
-                              "user"
-                            ]
+                          "x-go-type": "pq.StringArray",
+                          "x-go-type-import": {
+                            "path": "github.com/lib/pq"
                           },
-                          "description": "List of global roles assigned to the user",
+                          "x-go-type-skip-optional-pointer": true,
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                           "example": [
                             "admin",
-                            "meshmap"
+                            "organization admin"
                           ],
                           "x-oapi-codegen-extra-tags": {
                             "db": "role_names",
@@ -3376,23 +3366,18 @@ const DesignSchema: Record<string, unknown> = {
                         },
                         "roleNames": {
                           "type": "array",
-                          "items": {
-                            "type": "string",
-                            "enum": [
-                              "admin",
-                              "meshmap",
-                              "curator",
-                              "team admin",
-                              "workspace admin",
-                              "workspace manager",
-                              "organization admin",
-                              "user"
-                            ]
+                          "x-go-type": "pq.StringArray",
+                          "x-go-type-import": {
+                            "path": "github.com/lib/pq"
                           },
-                          "description": "List of global roles assigned to the user",
+                          "x-go-type-skip-optional-pointer": true,
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                           "example": [
                             "admin",
-                            "meshmap"
+                            "organization admin"
                           ],
                           "x-oapi-codegen-extra-tags": {
                             "db": "role_names",
@@ -4510,23 +4495,18 @@ const DesignSchema: Record<string, unknown> = {
                         },
                         "roleNames": {
                           "type": "array",
-                          "items": {
-                            "type": "string",
-                            "enum": [
-                              "admin",
-                              "meshmap",
-                              "curator",
-                              "team admin",
-                              "workspace admin",
-                              "workspace manager",
-                              "organization admin",
-                              "user"
-                            ]
+                          "x-go-type": "pq.StringArray",
+                          "x-go-type-import": {
+                            "path": "github.com/lib/pq"
                           },
-                          "description": "List of global roles assigned to the user",
+                          "x-go-type-skip-optional-pointer": true,
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                           "example": [
                             "admin",
-                            "meshmap"
+                            "organization admin"
                           ],
                           "x-oapi-codegen-extra-tags": {
                             "db": "role_names",
@@ -5978,23 +5958,18 @@ const DesignSchema: Record<string, unknown> = {
                               },
                               "roleNames": {
                                 "type": "array",
-                                "items": {
-                                  "type": "string",
-                                  "enum": [
-                                    "admin",
-                                    "meshmap",
-                                    "curator",
-                                    "team admin",
-                                    "workspace admin",
-                                    "workspace manager",
-                                    "organization admin",
-                                    "user"
-                                  ]
+                                "x-go-type": "pq.StringArray",
+                                "x-go-type-import": {
+                                  "path": "github.com/lib/pq"
                                 },
-                                "description": "List of global roles assigned to the user",
+                                "x-go-type-skip-optional-pointer": true,
+                                "items": {
+                                  "type": "string"
+                                },
+                                "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                                 "example": [
                                   "admin",
-                                  "meshmap"
+                                  "organization admin"
                                 ],
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "role_names",
@@ -12824,23 +12799,18 @@ const DesignSchema: Record<string, unknown> = {
               },
               "roleNames": {
                 "type": "array",
-                "items": {
-                  "type": "string",
-                  "enum": [
-                    "admin",
-                    "meshmap",
-                    "curator",
-                    "team admin",
-                    "workspace admin",
-                    "workspace manager",
-                    "organization admin",
-                    "user"
-                  ]
+                "x-go-type": "pq.StringArray",
+                "x-go-type-import": {
+                  "path": "github.com/lib/pq"
                 },
-                "description": "List of global roles assigned to the user",
+                "x-go-type-skip-optional-pointer": true,
+                "items": {
+                  "type": "string"
+                },
+                "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                 "example": [
                   "admin",
-                  "meshmap"
+                  "organization admin"
                 ],
                 "x-oapi-codegen-extra-tags": {
                   "db": "role_names",
@@ -13849,23 +13819,18 @@ const DesignSchema: Record<string, unknown> = {
                     },
                     "roleNames": {
                       "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": [
-                          "admin",
-                          "meshmap",
-                          "curator",
-                          "team admin",
-                          "workspace admin",
-                          "workspace manager",
-                          "organization admin",
-                          "user"
-                        ]
+                      "x-go-type": "pq.StringArray",
+                      "x-go-type-import": {
+                        "path": "github.com/lib/pq"
                       },
-                      "description": "List of global roles assigned to the user",
+                      "x-go-type-skip-optional-pointer": true,
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                       "example": [
                         "admin",
-                        "meshmap"
+                        "organization admin"
                       ],
                       "x-oapi-codegen-extra-tags": {
                         "db": "role_names",
@@ -15435,23 +15400,18 @@ const DesignSchema: Record<string, unknown> = {
                     },
                     "roleNames": {
                       "type": "array",
-                      "items": {
-                        "type": "string",
-                        "enum": [
-                          "admin",
-                          "meshmap",
-                          "curator",
-                          "team admin",
-                          "workspace admin",
-                          "workspace manager",
-                          "organization admin",
-                          "user"
-                        ]
+                      "x-go-type": "pq.StringArray",
+                      "x-go-type-import": {
+                        "path": "github.com/lib/pq"
                       },
-                      "description": "List of global roles assigned to the user",
+                      "x-go-type-skip-optional-pointer": true,
+                      "items": {
+                        "type": "string"
+                      },
+                      "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
                       "example": [
                         "admin",
-                        "meshmap"
+                        "organization admin"
                       ],
                       "x-oapi-codegen-extra-tags": {
                         "db": "role_names",

--- a/typescript/generated/v1beta3/design/DesignSchema.ts
+++ b/typescript/generated/v1beta3/design/DesignSchema.ts
@@ -856,11 +856,14 @@ const DesignSchema: Record<string, unknown> = {
                                         },
                                         "roleNames": {
                                           "type": "array",
+                                          "x-go-type": "pq.StringArray",
+                                          "x-go-type-import": {
+                                            "path": "github.com/lib/pq"
+                                          },
                                           "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "x-go-type-skip-optional-pointer": true,
                                           "x-order": 9,
                                           "x-oapi-codegen-extra-tags": {
                                             "db": "role_names",
@@ -1007,11 +1010,14 @@ const DesignSchema: Record<string, unknown> = {
                                         },
                                         "roleNames": {
                                           "type": "array",
+                                          "x-go-type": "pq.StringArray",
+                                          "x-go-type-import": {
+                                            "path": "github.com/lib/pq"
+                                          },
                                           "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "x-go-type-skip-optional-pointer": true,
                                           "x-order": 10,
                                           "x-oapi-codegen-extra-tags": {
                                             "db": "role_names",
@@ -2106,11 +2112,14 @@ const DesignSchema: Record<string, unknown> = {
                                   },
                                   "roleNames": {
                                     "type": "array",
+                                    "x-go-type": "pq.StringArray",
+                                    "x-go-type-import": {
+                                      "path": "github.com/lib/pq"
+                                    },
                                     "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "x-go-type-skip-optional-pointer": true,
                                     "x-order": 9,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "role_names",
@@ -2257,11 +2266,14 @@ const DesignSchema: Record<string, unknown> = {
                                   },
                                   "roleNames": {
                                     "type": "array",
+                                    "x-go-type": "pq.StringArray",
+                                    "x-go-type-import": {
+                                      "path": "github.com/lib/pq"
+                                    },
                                     "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "x-go-type-skip-optional-pointer": true,
                                     "x-order": 10,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "role_names",
@@ -3503,11 +3515,14 @@ const DesignSchema: Record<string, unknown> = {
                                   },
                                   "roleNames": {
                                     "type": "array",
+                                    "x-go-type": "pq.StringArray",
+                                    "x-go-type-import": {
+                                      "path": "github.com/lib/pq"
+                                    },
                                     "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "x-go-type-skip-optional-pointer": true,
                                     "x-order": 9,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "role_names",
@@ -3654,11 +3669,14 @@ const DesignSchema: Record<string, unknown> = {
                                   },
                                   "roleNames": {
                                     "type": "array",
+                                    "x-go-type": "pq.StringArray",
+                                    "x-go-type-import": {
+                                      "path": "github.com/lib/pq"
+                                    },
                                     "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "x-go-type-skip-optional-pointer": true,
                                     "x-order": 10,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "role_names",
@@ -4631,11 +4649,14 @@ const DesignSchema: Record<string, unknown> = {
                                   },
                                   "roleNames": {
                                     "type": "array",
+                                    "x-go-type": "pq.StringArray",
+                                    "x-go-type-import": {
+                                      "path": "github.com/lib/pq"
+                                    },
                                     "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "x-go-type-skip-optional-pointer": true,
                                     "x-order": 9,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "role_names",
@@ -4782,11 +4803,14 @@ const DesignSchema: Record<string, unknown> = {
                                   },
                                   "roleNames": {
                                     "type": "array",
+                                    "x-go-type": "pq.StringArray",
+                                    "x-go-type-import": {
+                                      "path": "github.com/lib/pq"
+                                    },
                                     "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "x-go-type-skip-optional-pointer": true,
                                     "x-order": 10,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "role_names",
@@ -6093,11 +6117,14 @@ const DesignSchema: Record<string, unknown> = {
                                         },
                                         "roleNames": {
                                           "type": "array",
+                                          "x-go-type": "pq.StringArray",
+                                          "x-go-type-import": {
+                                            "path": "github.com/lib/pq"
+                                          },
                                           "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "x-go-type-skip-optional-pointer": true,
                                           "x-order": 9,
                                           "x-oapi-codegen-extra-tags": {
                                             "db": "role_names",
@@ -6244,11 +6271,14 @@ const DesignSchema: Record<string, unknown> = {
                                         },
                                         "roleNames": {
                                           "type": "array",
+                                          "x-go-type": "pq.StringArray",
+                                          "x-go-type-import": {
+                                            "path": "github.com/lib/pq"
+                                          },
                                           "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                                           "items": {
                                             "type": "string"
                                           },
-                                          "x-go-type-skip-optional-pointer": true,
                                           "x-order": 10,
                                           "x-oapi-codegen-extra-tags": {
                                             "db": "role_names",
@@ -12933,11 +12963,14 @@ const DesignSchema: Record<string, unknown> = {
                         },
                         "roleNames": {
                           "type": "array",
+                          "x-go-type": "pq.StringArray",
+                          "x-go-type-import": {
+                            "path": "github.com/lib/pq"
+                          },
                           "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                           "items": {
                             "type": "string"
                           },
-                          "x-go-type-skip-optional-pointer": true,
                           "x-order": 9,
                           "x-oapi-codegen-extra-tags": {
                             "db": "role_names",
@@ -13084,11 +13117,14 @@ const DesignSchema: Record<string, unknown> = {
                         },
                         "roleNames": {
                           "type": "array",
+                          "x-go-type": "pq.StringArray",
+                          "x-go-type-import": {
+                            "path": "github.com/lib/pq"
+                          },
                           "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                           "items": {
                             "type": "string"
                           },
-                          "x-go-type-skip-optional-pointer": true,
                           "x-order": 10,
                           "x-oapi-codegen-extra-tags": {
                             "db": "role_names",
@@ -13952,11 +13988,14 @@ const DesignSchema: Record<string, unknown> = {
                               },
                               "roleNames": {
                                 "type": "array",
+                                "x-go-type": "pq.StringArray",
+                                "x-go-type-import": {
+                                  "path": "github.com/lib/pq"
+                                },
                                 "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "x-go-type-skip-optional-pointer": true,
                                 "x-order": 9,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "role_names",
@@ -14103,11 +14142,14 @@ const DesignSchema: Record<string, unknown> = {
                               },
                               "roleNames": {
                                 "type": "array",
+                                "x-go-type": "pq.StringArray",
+                                "x-go-type-import": {
+                                  "path": "github.com/lib/pq"
+                                },
                                 "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "x-go-type-skip-optional-pointer": true,
                                 "x-order": 10,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "role_names",
@@ -15532,11 +15574,14 @@ const DesignSchema: Record<string, unknown> = {
                               },
                               "roleNames": {
                                 "type": "array",
+                                "x-go-type": "pq.StringArray",
+                                "x-go-type-import": {
+                                  "path": "github.com/lib/pq"
+                                },
                                 "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "x-go-type-skip-optional-pointer": true,
                                 "x-order": 9,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "role_names",
@@ -15683,11 +15728,14 @@ const DesignSchema: Record<string, unknown> = {
                               },
                               "roleNames": {
                                 "type": "array",
+                                "x-go-type": "pq.StringArray",
+                                "x-go-type-import": {
+                                  "path": "github.com/lib/pq"
+                                },
                                 "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
                                 "items": {
                                   "type": "string"
                                 },
-                                "x-go-type-skip-optional-pointer": true,
                                 "x-order": 10,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "role_names",

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -3596,17 +3596,8 @@ export type GetUsersForOrgApiResponse = /** status 200 Paginated list of organiz
     }[];
     /** Timestamp when the user record was soft-deleted (null if not deleted) */
     deletedAt: string | null;
-    /** List of global roles assigned to the user */
-    roleNames?: (
-      | "admin"
-      | "meshmap"
-      | "curator"
-      | "team admin"
-      | "workspace admin"
-      | "workspace manager"
-      | "organization admin"
-      | "user"
-    )[];
+    /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+    roleNames?: string[];
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
@@ -3802,17 +3793,8 @@ export type GetUsersApiResponse = /** status 200 Paginated list of public users 
     }[];
     /** Timestamp when the user record was soft-deleted (null if not deleted) */
     deletedAt: string | null;
-    /** List of global roles assigned to the user */
-    roleNames?: (
-      | "admin"
-      | "meshmap"
-      | "curator"
-      | "team admin"
-      | "workspace admin"
-      | "workspace manager"
-      | "organization admin"
-      | "user"
-    )[];
+    /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+    roleNames?: string[];
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
@@ -3996,17 +3978,8 @@ export type GetUserProfileByIdApiResponse = /** status 200 User profile for the 
   }[];
   /** Timestamp when the user record was soft-deleted (null if not deleted) */
   deletedAt: string | null;
-  /** List of global roles assigned to the user */
-  roleNames?: (
-    | "admin"
-    | "meshmap"
-    | "curator"
-    | "team admin"
-    | "workspace admin"
-    | "workspace manager"
-    | "organization admin"
-    | "user"
-  )[];
+  /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+  roleNames?: string[];
   /** Teams the user belongs to with role information */
   teams?: {
     /** Team memberships for the user with their assigned roles. */
@@ -4181,17 +4154,8 @@ export type GetUserApiResponse = /** status 200 Current user profile and role co
   }[];
   /** Timestamp when the user record was soft-deleted (null if not deleted) */
   deletedAt: string | null;
-  /** List of global roles assigned to the user */
-  roleNames?: (
-    | "admin"
-    | "meshmap"
-    | "curator"
-    | "team admin"
-    | "workspace admin"
-    | "workspace manager"
-    | "organization admin"
-    | "user"
-  )[];
+  /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+  roleNames?: string[];
   /** Teams the user belongs to with role information */
   teams?: {
     /** Team memberships for the user with their assigned roles. */
@@ -8855,17 +8819,8 @@ export type GetPatternsApiResponse = /** status 200 Designs response */ {
       }[];
       /** Timestamp when the user record was soft-deleted (null if not deleted) */
       deletedAt: string | null;
-      /** List of global roles assigned to the user */
-      roleNames?: (
-        | "admin"
-        | "meshmap"
-        | "curator"
-        | "team admin"
-        | "workspace admin"
-        | "workspace manager"
-        | "organization admin"
-        | "user"
-      )[];
+      /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+      roleNames?: string[];
       /** Teams the user belongs to with role information */
       teams?: {
         /** Team memberships for the user with their assigned roles. */
@@ -9133,17 +9088,8 @@ export type UpsertPatternApiResponse = /** status 200 Design saved */ {
     }[];
     /** Timestamp when the user record was soft-deleted (null if not deleted) */
     deletedAt: string | null;
-    /** List of global roles assigned to the user */
-    roleNames?: (
-      | "admin"
-      | "meshmap"
-      | "curator"
-      | "team admin"
-      | "workspace admin"
-      | "workspace manager"
-      | "organization admin"
-      | "user"
-    )[];
+    /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+    roleNames?: string[];
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
@@ -9477,17 +9423,8 @@ export type GetPatternApiResponse = /** status 200 Design response */ {
     }[];
     /** Timestamp when the user record was soft-deleted (null if not deleted) */
     deletedAt: string | null;
-    /** List of global roles assigned to the user */
-    roleNames?: (
-      | "admin"
-      | "meshmap"
-      | "curator"
-      | "team admin"
-      | "workspace admin"
-      | "workspace manager"
-      | "organization admin"
-      | "user"
-    )[];
+    /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+    roleNames?: string[];
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
@@ -9737,17 +9674,8 @@ export type ClonePatternApiResponse = /** status 200 Design cloned */ {
     }[];
     /** Timestamp when the user record was soft-deleted (null if not deleted) */
     deletedAt: string | null;
-    /** List of global roles assigned to the user */
-    roleNames?: (
-      | "admin"
-      | "meshmap"
-      | "curator"
-      | "team admin"
-      | "workspace admin"
-      | "workspace manager"
-      | "organization admin"
-      | "user"
-    )[];
+    /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+    roleNames?: string[];
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
@@ -10031,17 +9959,8 @@ export type GetCatalogContentApiResponse = /** status 200 Catalog content page *
       }[];
       /** Timestamp when the user record was soft-deleted (null if not deleted) */
       deletedAt: string | null;
-      /** List of global roles assigned to the user */
-      roleNames?: (
-        | "admin"
-        | "meshmap"
-        | "curator"
-        | "team admin"
-        | "workspace admin"
-        | "workspace manager"
-        | "organization admin"
-        | "user"
-      )[];
+      /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+      roleNames?: string[];
       /** Teams the user belongs to with role information */
       teams?: {
         /** Team memberships for the user with their assigned roles. */

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -3610,14 +3610,56 @@ export type GetUsersForOrgApiResponse = /** status 200 Paginated list of organiz
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
-      teamsWithRoles?: object[];
+      teamsWithRoles?: {
+        /** Unique identifier of the team. */
+        id: string;
+        /** Name of the team. */
+        name: string;
+        /** Human readable description of the team. */
+        description?: string;
+        /** Identifier of the team owner. */
+        owner?: string;
+        /** Free-form metadata associated with the team. */
+        metadata?: {
+          [key: string]: any;
+        };
+        /** Timestamp when the team was created. */
+        createdAt?: string;
+        /** Timestamp when the team was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the team was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of team memberships returned for the user. */
       totalCount?: number;
     };
     /** Organizations the user belongs to with role information */
     organizations?: {
       /** Organization memberships for the user with their assigned roles. */
-      organizationsWithRoles?: object[];
+      organizationsWithRoles?: {
+        /** Unique identifier of the organization. */
+        id: string;
+        /** Name of the organization. */
+        name: string;
+        /** Human readable description of the organization. */
+        description?: string;
+        /** Country associated with the organization. */
+        country?: string;
+        /** Region associated with the organization. */
+        region?: string;
+        /** Identifier of the organization owner. */
+        owner?: string;
+        /** Timestamp when the organization was created. */
+        createdAt?: string;
+        /** Timestamp when the organization was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the organization was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of organization memberships returned for the user. */
       totalCount?: number;
     };
@@ -3774,14 +3816,56 @@ export type GetUsersApiResponse = /** status 200 Paginated list of public users 
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
-      teamsWithRoles?: object[];
+      teamsWithRoles?: {
+        /** Unique identifier of the team. */
+        id: string;
+        /** Name of the team. */
+        name: string;
+        /** Human readable description of the team. */
+        description?: string;
+        /** Identifier of the team owner. */
+        owner?: string;
+        /** Free-form metadata associated with the team. */
+        metadata?: {
+          [key: string]: any;
+        };
+        /** Timestamp when the team was created. */
+        createdAt?: string;
+        /** Timestamp when the team was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the team was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of team memberships returned for the user. */
       totalCount?: number;
     };
     /** Organizations the user belongs to with role information */
     organizations?: {
       /** Organization memberships for the user with their assigned roles. */
-      organizationsWithRoles?: object[];
+      organizationsWithRoles?: {
+        /** Unique identifier of the organization. */
+        id: string;
+        /** Name of the organization. */
+        name: string;
+        /** Human readable description of the organization. */
+        description?: string;
+        /** Country associated with the organization. */
+        country?: string;
+        /** Region associated with the organization. */
+        region?: string;
+        /** Identifier of the organization owner. */
+        owner?: string;
+        /** Timestamp when the organization was created. */
+        createdAt?: string;
+        /** Timestamp when the organization was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the organization was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of organization memberships returned for the user. */
       totalCount?: number;
     };
@@ -3926,14 +4010,56 @@ export type GetUserProfileByIdApiResponse = /** status 200 User profile for the 
   /** Teams the user belongs to with role information */
   teams?: {
     /** Team memberships for the user with their assigned roles. */
-    teamsWithRoles?: object[];
+    teamsWithRoles?: {
+      /** Unique identifier of the team. */
+      id: string;
+      /** Name of the team. */
+      name: string;
+      /** Human readable description of the team. */
+      description?: string;
+      /** Identifier of the team owner. */
+      owner?: string;
+      /** Free-form metadata associated with the team. */
+      metadata?: {
+        [key: string]: any;
+      };
+      /** Timestamp when the team was created. */
+      createdAt?: string;
+      /** Timestamp when the team was last updated. */
+      updatedAt?: string;
+      /** Timestamp when the team was soft-deleted (null if not deleted). */
+      deletedAt?: string | null;
+      /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+      roleNames: string[];
+    }[];
     /** Total number of team memberships returned for the user. */
     totalCount?: number;
   };
   /** Organizations the user belongs to with role information */
   organizations?: {
     /** Organization memberships for the user with their assigned roles. */
-    organizationsWithRoles?: object[];
+    organizationsWithRoles?: {
+      /** Unique identifier of the organization. */
+      id: string;
+      /** Name of the organization. */
+      name: string;
+      /** Human readable description of the organization. */
+      description?: string;
+      /** Country associated with the organization. */
+      country?: string;
+      /** Region associated with the organization. */
+      region?: string;
+      /** Identifier of the organization owner. */
+      owner?: string;
+      /** Timestamp when the organization was created. */
+      createdAt?: string;
+      /** Timestamp when the organization was last updated. */
+      updatedAt?: string;
+      /** Timestamp when the organization was soft-deleted (null if not deleted). */
+      deletedAt?: string | null;
+      /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+      roleNames: string[];
+    }[];
     /** Total number of organization memberships returned for the user. */
     totalCount?: number;
   };
@@ -4069,14 +4195,56 @@ export type GetUserApiResponse = /** status 200 Current user profile and role co
   /** Teams the user belongs to with role information */
   teams?: {
     /** Team memberships for the user with their assigned roles. */
-    teamsWithRoles?: object[];
+    teamsWithRoles?: {
+      /** Unique identifier of the team. */
+      id: string;
+      /** Name of the team. */
+      name: string;
+      /** Human readable description of the team. */
+      description?: string;
+      /** Identifier of the team owner. */
+      owner?: string;
+      /** Free-form metadata associated with the team. */
+      metadata?: {
+        [key: string]: any;
+      };
+      /** Timestamp when the team was created. */
+      createdAt?: string;
+      /** Timestamp when the team was last updated. */
+      updatedAt?: string;
+      /** Timestamp when the team was soft-deleted (null if not deleted). */
+      deletedAt?: string | null;
+      /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+      roleNames: string[];
+    }[];
     /** Total number of team memberships returned for the user. */
     totalCount?: number;
   };
   /** Organizations the user belongs to with role information */
   organizations?: {
     /** Organization memberships for the user with their assigned roles. */
-    organizationsWithRoles?: object[];
+    organizationsWithRoles?: {
+      /** Unique identifier of the organization. */
+      id: string;
+      /** Name of the organization. */
+      name: string;
+      /** Human readable description of the organization. */
+      description?: string;
+      /** Country associated with the organization. */
+      country?: string;
+      /** Region associated with the organization. */
+      region?: string;
+      /** Identifier of the organization owner. */
+      owner?: string;
+      /** Timestamp when the organization was created. */
+      createdAt?: string;
+      /** Timestamp when the organization was last updated. */
+      updatedAt?: string;
+      /** Timestamp when the organization was soft-deleted (null if not deleted). */
+      deletedAt?: string | null;
+      /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+      roleNames: string[];
+    }[];
     /** Total number of organization memberships returned for the user. */
     totalCount?: number;
   };
@@ -8701,14 +8869,56 @@ export type GetPatternsApiResponse = /** status 200 Designs response */ {
       /** Teams the user belongs to with role information */
       teams?: {
         /** Team memberships for the user with their assigned roles. */
-        teamsWithRoles?: object[];
+        teamsWithRoles?: {
+          /** Unique identifier of the team. */
+          id: string;
+          /** Name of the team. */
+          name: string;
+          /** Human readable description of the team. */
+          description?: string;
+          /** Identifier of the team owner. */
+          owner?: string;
+          /** Free-form metadata associated with the team. */
+          metadata?: {
+            [key: string]: any;
+          };
+          /** Timestamp when the team was created. */
+          createdAt?: string;
+          /** Timestamp when the team was last updated. */
+          updatedAt?: string;
+          /** Timestamp when the team was soft-deleted (null if not deleted). */
+          deletedAt?: string | null;
+          /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+          roleNames: string[];
+        }[];
         /** Total number of team memberships returned for the user. */
         totalCount?: number;
       };
       /** Organizations the user belongs to with role information */
       organizations?: {
         /** Organization memberships for the user with their assigned roles. */
-        organizationsWithRoles?: object[];
+        organizationsWithRoles?: {
+          /** Unique identifier of the organization. */
+          id: string;
+          /** Name of the organization. */
+          name: string;
+          /** Human readable description of the organization. */
+          description?: string;
+          /** Country associated with the organization. */
+          country?: string;
+          /** Region associated with the organization. */
+          region?: string;
+          /** Identifier of the organization owner. */
+          owner?: string;
+          /** Timestamp when the organization was created. */
+          createdAt?: string;
+          /** Timestamp when the organization was last updated. */
+          updatedAt?: string;
+          /** Timestamp when the organization was soft-deleted (null if not deleted). */
+          deletedAt?: string | null;
+          /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+          roleNames: string[];
+        }[];
         /** Total number of organization memberships returned for the user. */
         totalCount?: number;
       };
@@ -8937,14 +9147,56 @@ export type UpsertPatternApiResponse = /** status 200 Design saved */ {
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
-      teamsWithRoles?: object[];
+      teamsWithRoles?: {
+        /** Unique identifier of the team. */
+        id: string;
+        /** Name of the team. */
+        name: string;
+        /** Human readable description of the team. */
+        description?: string;
+        /** Identifier of the team owner. */
+        owner?: string;
+        /** Free-form metadata associated with the team. */
+        metadata?: {
+          [key: string]: any;
+        };
+        /** Timestamp when the team was created. */
+        createdAt?: string;
+        /** Timestamp when the team was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the team was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of team memberships returned for the user. */
       totalCount?: number;
     };
     /** Organizations the user belongs to with role information */
     organizations?: {
       /** Organization memberships for the user with their assigned roles. */
-      organizationsWithRoles?: object[];
+      organizationsWithRoles?: {
+        /** Unique identifier of the organization. */
+        id: string;
+        /** Name of the organization. */
+        name: string;
+        /** Human readable description of the organization. */
+        description?: string;
+        /** Country associated with the organization. */
+        country?: string;
+        /** Region associated with the organization. */
+        region?: string;
+        /** Identifier of the organization owner. */
+        owner?: string;
+        /** Timestamp when the organization was created. */
+        createdAt?: string;
+        /** Timestamp when the organization was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the organization was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of organization memberships returned for the user. */
       totalCount?: number;
     };
@@ -9239,14 +9491,56 @@ export type GetPatternApiResponse = /** status 200 Design response */ {
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
-      teamsWithRoles?: object[];
+      teamsWithRoles?: {
+        /** Unique identifier of the team. */
+        id: string;
+        /** Name of the team. */
+        name: string;
+        /** Human readable description of the team. */
+        description?: string;
+        /** Identifier of the team owner. */
+        owner?: string;
+        /** Free-form metadata associated with the team. */
+        metadata?: {
+          [key: string]: any;
+        };
+        /** Timestamp when the team was created. */
+        createdAt?: string;
+        /** Timestamp when the team was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the team was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of team memberships returned for the user. */
       totalCount?: number;
     };
     /** Organizations the user belongs to with role information */
     organizations?: {
       /** Organization memberships for the user with their assigned roles. */
-      organizationsWithRoles?: object[];
+      organizationsWithRoles?: {
+        /** Unique identifier of the organization. */
+        id: string;
+        /** Name of the organization. */
+        name: string;
+        /** Human readable description of the organization. */
+        description?: string;
+        /** Country associated with the organization. */
+        country?: string;
+        /** Region associated with the organization. */
+        region?: string;
+        /** Identifier of the organization owner. */
+        owner?: string;
+        /** Timestamp when the organization was created. */
+        createdAt?: string;
+        /** Timestamp when the organization was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the organization was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of organization memberships returned for the user. */
       totalCount?: number;
     };
@@ -9457,14 +9751,56 @@ export type ClonePatternApiResponse = /** status 200 Design cloned */ {
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
-      teamsWithRoles?: object[];
+      teamsWithRoles?: {
+        /** Unique identifier of the team. */
+        id: string;
+        /** Name of the team. */
+        name: string;
+        /** Human readable description of the team. */
+        description?: string;
+        /** Identifier of the team owner. */
+        owner?: string;
+        /** Free-form metadata associated with the team. */
+        metadata?: {
+          [key: string]: any;
+        };
+        /** Timestamp when the team was created. */
+        createdAt?: string;
+        /** Timestamp when the team was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the team was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of team memberships returned for the user. */
       totalCount?: number;
     };
     /** Organizations the user belongs to with role information */
     organizations?: {
       /** Organization memberships for the user with their assigned roles. */
-      organizationsWithRoles?: object[];
+      organizationsWithRoles?: {
+        /** Unique identifier of the organization. */
+        id: string;
+        /** Name of the organization. */
+        name: string;
+        /** Human readable description of the organization. */
+        description?: string;
+        /** Country associated with the organization. */
+        country?: string;
+        /** Region associated with the organization. */
+        region?: string;
+        /** Identifier of the organization owner. */
+        owner?: string;
+        /** Timestamp when the organization was created. */
+        createdAt?: string;
+        /** Timestamp when the organization was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the organization was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of organization memberships returned for the user. */
       totalCount?: number;
     };
@@ -9709,14 +10045,56 @@ export type GetCatalogContentApiResponse = /** status 200 Catalog content page *
       /** Teams the user belongs to with role information */
       teams?: {
         /** Team memberships for the user with their assigned roles. */
-        teamsWithRoles?: object[];
+        teamsWithRoles?: {
+          /** Unique identifier of the team. */
+          id: string;
+          /** Name of the team. */
+          name: string;
+          /** Human readable description of the team. */
+          description?: string;
+          /** Identifier of the team owner. */
+          owner?: string;
+          /** Free-form metadata associated with the team. */
+          metadata?: {
+            [key: string]: any;
+          };
+          /** Timestamp when the team was created. */
+          createdAt?: string;
+          /** Timestamp when the team was last updated. */
+          updatedAt?: string;
+          /** Timestamp when the team was soft-deleted (null if not deleted). */
+          deletedAt?: string | null;
+          /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+          roleNames: string[];
+        }[];
         /** Total number of team memberships returned for the user. */
         totalCount?: number;
       };
       /** Organizations the user belongs to with role information */
       organizations?: {
         /** Organization memberships for the user with their assigned roles. */
-        organizationsWithRoles?: object[];
+        organizationsWithRoles?: {
+          /** Unique identifier of the organization. */
+          id: string;
+          /** Name of the organization. */
+          name: string;
+          /** Human readable description of the organization. */
+          description?: string;
+          /** Country associated with the organization. */
+          country?: string;
+          /** Region associated with the organization. */
+          region?: string;
+          /** Identifier of the organization owner. */
+          owner?: string;
+          /** Timestamp when the organization was created. */
+          createdAt?: string;
+          /** Timestamp when the organization was last updated. */
+          updatedAt?: string;
+          /** Timestamp when the organization was soft-deleted (null if not deleted). */
+          deletedAt?: string | null;
+          /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+          roleNames: string[];
+        }[];
         /** Total number of organization memberships returned for the user. */
         totalCount?: number;
       };

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -4044,14 +4044,56 @@ export type GetUsersForOrgApiResponse = /** status 200 Paginated list of organiz
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
-      teamsWithRoles?: object[];
+      teamsWithRoles?: {
+        /** Unique identifier of the team. */
+        id: string;
+        /** Name of the team. */
+        name: string;
+        /** Human readable description of the team. */
+        description?: string;
+        /** Identifier of the team owner. */
+        owner?: string;
+        /** Free-form metadata associated with the team. */
+        metadata?: {
+          [key: string]: any;
+        };
+        /** Timestamp when the team was created. */
+        createdAt?: string;
+        /** Timestamp when the team was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the team was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of team memberships returned for the user. */
       totalCount?: number;
     };
     /** Organizations the user belongs to with role information */
     organizations?: {
       /** Organization memberships for the user with their assigned roles. */
-      organizationsWithRoles?: object[];
+      organizationsWithRoles?: {
+        /** Unique identifier of the organization. */
+        id: string;
+        /** Name of the organization. */
+        name: string;
+        /** Human readable description of the organization. */
+        description?: string;
+        /** Country associated with the organization. */
+        country?: string;
+        /** Region associated with the organization. */
+        region?: string;
+        /** Identifier of the organization owner. */
+        owner?: string;
+        /** Timestamp when the organization was created. */
+        createdAt?: string;
+        /** Timestamp when the organization was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the organization was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of organization memberships returned for the user. */
       totalCount?: number;
     };
@@ -4208,14 +4250,56 @@ export type GetUsersApiResponse = /** status 200 Paginated list of public users 
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
-      teamsWithRoles?: object[];
+      teamsWithRoles?: {
+        /** Unique identifier of the team. */
+        id: string;
+        /** Name of the team. */
+        name: string;
+        /** Human readable description of the team. */
+        description?: string;
+        /** Identifier of the team owner. */
+        owner?: string;
+        /** Free-form metadata associated with the team. */
+        metadata?: {
+          [key: string]: any;
+        };
+        /** Timestamp when the team was created. */
+        createdAt?: string;
+        /** Timestamp when the team was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the team was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of team memberships returned for the user. */
       totalCount?: number;
     };
     /** Organizations the user belongs to with role information */
     organizations?: {
       /** Organization memberships for the user with their assigned roles. */
-      organizationsWithRoles?: object[];
+      organizationsWithRoles?: {
+        /** Unique identifier of the organization. */
+        id: string;
+        /** Name of the organization. */
+        name: string;
+        /** Human readable description of the organization. */
+        description?: string;
+        /** Country associated with the organization. */
+        country?: string;
+        /** Region associated with the organization. */
+        region?: string;
+        /** Identifier of the organization owner. */
+        owner?: string;
+        /** Timestamp when the organization was created. */
+        createdAt?: string;
+        /** Timestamp when the organization was last updated. */
+        updatedAt?: string;
+        /** Timestamp when the organization was soft-deleted (null if not deleted). */
+        deletedAt?: string | null;
+        /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+        roleNames: string[];
+      }[];
       /** Total number of organization memberships returned for the user. */
       totalCount?: number;
     };
@@ -4360,14 +4444,56 @@ export type GetUserProfileByIdApiResponse = /** status 200 User profile for the 
   /** Teams the user belongs to with role information */
   teams?: {
     /** Team memberships for the user with their assigned roles. */
-    teamsWithRoles?: object[];
+    teamsWithRoles?: {
+      /** Unique identifier of the team. */
+      id: string;
+      /** Name of the team. */
+      name: string;
+      /** Human readable description of the team. */
+      description?: string;
+      /** Identifier of the team owner. */
+      owner?: string;
+      /** Free-form metadata associated with the team. */
+      metadata?: {
+        [key: string]: any;
+      };
+      /** Timestamp when the team was created. */
+      createdAt?: string;
+      /** Timestamp when the team was last updated. */
+      updatedAt?: string;
+      /** Timestamp when the team was soft-deleted (null if not deleted). */
+      deletedAt?: string | null;
+      /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+      roleNames: string[];
+    }[];
     /** Total number of team memberships returned for the user. */
     totalCount?: number;
   };
   /** Organizations the user belongs to with role information */
   organizations?: {
     /** Organization memberships for the user with their assigned roles. */
-    organizationsWithRoles?: object[];
+    organizationsWithRoles?: {
+      /** Unique identifier of the organization. */
+      id: string;
+      /** Name of the organization. */
+      name: string;
+      /** Human readable description of the organization. */
+      description?: string;
+      /** Country associated with the organization. */
+      country?: string;
+      /** Region associated with the organization. */
+      region?: string;
+      /** Identifier of the organization owner. */
+      owner?: string;
+      /** Timestamp when the organization was created. */
+      createdAt?: string;
+      /** Timestamp when the organization was last updated. */
+      updatedAt?: string;
+      /** Timestamp when the organization was soft-deleted (null if not deleted). */
+      deletedAt?: string | null;
+      /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+      roleNames: string[];
+    }[];
     /** Total number of organization memberships returned for the user. */
     totalCount?: number;
   };
@@ -4503,14 +4629,56 @@ export type GetUserApiResponse = /** status 200 Current user profile and role co
   /** Teams the user belongs to with role information */
   teams?: {
     /** Team memberships for the user with their assigned roles. */
-    teamsWithRoles?: object[];
+    teamsWithRoles?: {
+      /** Unique identifier of the team. */
+      id: string;
+      /** Name of the team. */
+      name: string;
+      /** Human readable description of the team. */
+      description?: string;
+      /** Identifier of the team owner. */
+      owner?: string;
+      /** Free-form metadata associated with the team. */
+      metadata?: {
+        [key: string]: any;
+      };
+      /** Timestamp when the team was created. */
+      createdAt?: string;
+      /** Timestamp when the team was last updated. */
+      updatedAt?: string;
+      /** Timestamp when the team was soft-deleted (null if not deleted). */
+      deletedAt?: string | null;
+      /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
+      roleNames: string[];
+    }[];
     /** Total number of team memberships returned for the user. */
     totalCount?: number;
   };
   /** Organizations the user belongs to with role information */
   organizations?: {
     /** Organization memberships for the user with their assigned roles. */
-    organizationsWithRoles?: object[];
+    organizationsWithRoles?: {
+      /** Unique identifier of the organization. */
+      id: string;
+      /** Name of the organization. */
+      name: string;
+      /** Human readable description of the organization. */
+      description?: string;
+      /** Country associated with the organization. */
+      country?: string;
+      /** Region associated with the organization. */
+      region?: string;
+      /** Identifier of the organization owner. */
+      owner?: string;
+      /** Timestamp when the organization was created. */
+      createdAt?: string;
+      /** Timestamp when the organization was last updated. */
+      updatedAt?: string;
+      /** Timestamp when the organization was soft-deleted (null if not deleted). */
+      deletedAt?: string | null;
+      /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
+      roleNames: string[];
+    }[];
     /** Total number of organization memberships returned for the user. */
     totalCount?: number;
   };

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -4030,17 +4030,8 @@ export type GetUsersForOrgApiResponse = /** status 200 Paginated list of organiz
     }[];
     /** Timestamp when the user record was soft-deleted (null if not deleted) */
     deletedAt: string | null;
-    /** List of global roles assigned to the user */
-    roleNames?: (
-      | "admin"
-      | "meshmap"
-      | "curator"
-      | "team admin"
-      | "workspace admin"
-      | "workspace manager"
-      | "organization admin"
-      | "user"
-    )[];
+    /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+    roleNames?: string[];
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
@@ -4236,17 +4227,8 @@ export type GetUsersApiResponse = /** status 200 Paginated list of public users 
     }[];
     /** Timestamp when the user record was soft-deleted (null if not deleted) */
     deletedAt: string | null;
-    /** List of global roles assigned to the user */
-    roleNames?: (
-      | "admin"
-      | "meshmap"
-      | "curator"
-      | "team admin"
-      | "workspace admin"
-      | "workspace manager"
-      | "organization admin"
-      | "user"
-    )[];
+    /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+    roleNames?: string[];
     /** Teams the user belongs to with role information */
     teams?: {
       /** Team memberships for the user with their assigned roles. */
@@ -4430,17 +4412,8 @@ export type GetUserProfileByIdApiResponse = /** status 200 User profile for the 
   }[];
   /** Timestamp when the user record was soft-deleted (null if not deleted) */
   deletedAt: string | null;
-  /** List of global roles assigned to the user */
-  roleNames?: (
-    | "admin"
-    | "meshmap"
-    | "curator"
-    | "team admin"
-    | "workspace admin"
-    | "workspace manager"
-    | "organization admin"
-    | "user"
-  )[];
+  /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+  roleNames?: string[];
   /** Teams the user belongs to with role information */
   teams?: {
     /** Team memberships for the user with their assigned roles. */
@@ -4615,17 +4588,8 @@ export type GetUserApiResponse = /** status 200 Current user profile and role co
   }[];
   /** Timestamp when the user record was soft-deleted (null if not deleted) */
   deletedAt: string | null;
-  /** List of global roles assigned to the user */
-  roleNames?: (
-    | "admin"
-    | "meshmap"
-    | "curator"
-    | "team admin"
-    | "workspace admin"
-    | "workspace manager"
-    | "organization admin"
-    | "user"
-  )[];
+  /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
+  roleNames?: string[];
   /** Teams the user belongs to with role information */
   teams?: {
     /** Team memberships for the user with their assigned roles. */


### PR DESCRIPTION
## What & why

`User.organizations.organizationsWithRoles` and `User.teams.teamsWithRoles` were
declared as opaque object arrays (`items: { type: object }`), so every downstream
consumer received an untyped `object[]` for a user's per-organization and per-team
role assignments. That is exactly the data the Meshery UI needs to display the roles
assigned to the signed-in user within their currently selected organization (e.g. the
error-404 "Current Session" panel), and today it can only be consumed via untyped
client-side parsing.

This PR defines two component schemas — `OrganizationWithRoles` and `TeamWithRoles` —
and references them from the `User` construct so the assigned role names are strongly
typed end to end (Go structs, TypeScript types, and the generated RTK clients).

### Notes
- **Role names are free-form.** `roleNames` is `array<string>` with **no `enum`**: org /
  workspace / team and custom roles are user-generated and created on the fly, so the
  set is intentionally open. The pre-existing **global** `User.roleNames` enum is left
  untouched.
- **In-place augmentation, no version bump.** This tightens existing fields on the
  already-published v1beta2 `user` construct. The wire shape is unchanged (the server
  already emits `{ id, name, …, roleNames }` per membership), so no new API version is
  warranted — only the schema's type declaration becomes precise.
- The field set mirrors what the Meshery Cloud profile endpoint actually emits
  (`OrganizationWithUserRoles` / `TeamWithUserRoles`).

## Generated artifacts
Regenerated with the repo's pinned `oapi-codegen` (v2.5.1) plus the TS/RTK generators.
The diff is scoped to the `user` construct and the `design` construct (which embeds
`User`).

## Test plan
- [x] `make validate-schemas` — no blocking violations
- [x] `node build/bundle-openapi.js` — bundles clean; new schemas inlined into both cloud + meshery outputs
- [x] `oapi-codegen` regen → `go build ./...` + `go test ./models/...` pass
- [x] Generated Go: `OrganizationWithRoles.RoleNames []string` and `TeamWithRoles.RoleNames []string` (free-form, no enum); global `User.RoleNames *[]UserRoleNames` unchanged
- [x] Generated TS/RTK: `organizationsWithRoles[]` / `teamsWithRoles[]` carry `roleNames: string[]`

## Downstream follow-ups (separate PRs)
- **meshery/meshery (UI):** consume the typed `organizations.organizationsWithRoles` from the existing `getLoggedInUser` query in the Current-Session panel; drop the locally-defined `useGetUserOrgRolesQuery`.
- **layer5io/meshery-cloud:** after this is released, bump the schemas dep and consume the generated `OrganizationWithRoles` / `TeamWithRoles` types (it already emits this shape).


## Follow-up: global `roleNames` de-enumerated (commit d975d71)

Review surfaced that the **pre-existing** top-level `User.roleNames` carried a hardcoded 8-value enum, while role names are actually sourced from `array_agg(DISTINCT role_name)` over the `roles` table (a free `varchar(50)`, dynamically populated). The generated `UserRoleNames` closed union was consumed by nobody — meshery-cloud overrides `roleNames` as `pq.StringArray`/`[]string`, meshery never references it — yet it mislabelled the contract and would reject any custom/future role.

Dropped the enum; the global field is now free-form `pq.StringArray`/`string[]`, consistent with the new per-org/per-team fields and the data model. Backward-compatible widening (seeded literals remain valid strings); no version bump.


## `getAllRoles` documented as the canonical role-listing source

Since `roleNames` is now free-form, tooling must enumerate an org's roles dynamically rather than hard-code a set. The `role` construct's `getAllRoles` (`GET /api/identity/orgs/{orgId}/roles`) description is expanded to state it returns the seeded **plus** custom roles and is the canonical, drift-free source for role pickers / dropdown defaults / docs. No new static enum is introduced (that would just recreate the drift). Downstream doc: `meshery-cloud/docs/roles-reference.md`.
