### PR TITLE
feat(validation): detect broken $ref targets (Rule 48)

### DIFF
--- a/validation/audit.go
+++ b/validation/audit.go
@@ -336,33 +336,33 @@ func auditTemplateFiles(constructDir, constructName string, opts AuditOptions,
 func auditAPISpec(apiYmlPath, constructDir string, opts AuditOptions,
 	baseline map[string]bool, result *AuditResult,
 	fingerprints map[string][]schemaLocation, enumBaselineRef string,
-	doc *openapi3.T,loadErr error) {
+	doc *openapi3.T, loadErr error) {
 
 	relPath := relativeToRoot(apiYmlPath, opts.RootDir)
 
 	if doc == nil {
 		// Structural load failure — report as blocking.
 		rule48 := checkRule48(
-        relPath,
-        loadErr,
-        opts,
-    )
+			relPath,
+			loadErr,
+			opts,
+		)
 
-    if len(rule48) > 0 {
-        for _, v := range rule48 {
-            addViolation(result, v, baseline)
-        }
-        return
-    }
+		if len(rule48) > 0 {
+			for _, v := range rule48 {
+				addViolation(result, v, baseline)
+			}
+			return
+		}
 
-    addViolation(result, Violation{
-        File:       relPath,
-        Message:    "Failed to load api.yml",
-        Severity:   SeverityBlocking,
-        RuleNumber: 12,
-    }, baseline)
+		addViolation(result, Violation{
+			File:       relPath,
+			Message:    "Failed to load api.yml",
+			Severity:   SeverityBlocking,
+			RuleNumber: 12,
+		}, baseline)
 
-    return
+		return
 	}
 
 	// Load the raw YAML doc once for rules that need $ref sibling access

--- a/validation/audit.go
+++ b/validation/audit.go
@@ -162,7 +162,7 @@ func Audit(opts AuditOptions) AuditResult {
 		// auditAPISpec handles nil docs by reporting a blocking violation.
 		if spec.APIExists {
 			auditAPISpec(spec.APIYMLPath, spec.ConstructDir, opts, baseline, &result,
-				fingerprints, enumBaselineRef, spec.Doc)
+				fingerprints, enumBaselineRef, spec.Doc, spec.LoadErr)
 			// Collect Rule 46 cross-file parity candidates from this
 			// api.yml. The file's version prefix (e.g. "v1beta1") defines
 			// the comparison group.
@@ -336,19 +336,33 @@ func auditTemplateFiles(constructDir, constructName string, opts AuditOptions,
 func auditAPISpec(apiYmlPath, constructDir string, opts AuditOptions,
 	baseline map[string]bool, result *AuditResult,
 	fingerprints map[string][]schemaLocation, enumBaselineRef string,
-	doc *openapi3.T) {
+	doc *openapi3.T,loadErr error) {
 
 	relPath := relativeToRoot(apiYmlPath, opts.RootDir)
 
 	if doc == nil {
 		// Structural load failure — report as blocking.
-		addViolation(result, Violation{
-			File:       relPath,
-			Message:    "Failed to load api.yml",
-			Severity:   SeverityBlocking,
-			RuleNumber: 12,
-		}, baseline)
-		return
+		rule48 := checkRule48(
+        relPath,
+        loadErr,
+        opts,
+    )
+
+    if len(rule48) > 0 {
+        for _, v := range rule48 {
+            addViolation(result, v, baseline)
+        }
+        return
+    }
+
+    addViolation(result, Violation{
+        File:       relPath,
+        Message:    "Failed to load api.yml",
+        Severity:   SeverityBlocking,
+        RuleNumber: 12,
+    }, baseline)
+
+    return
 	}
 
 	// Load the raw YAML doc once for rules that need $ref sibling access

--- a/validation/audit.go
+++ b/validation/audit.go
@@ -355,9 +355,13 @@ func auditAPISpec(apiYmlPath, constructDir string, opts AuditOptions,
 			return
 		}
 
+		msg := "Failed to load api.yml"
+		if loadErr != nil {
+			msg += ": " + loadErr.Error()
+		}
 		addViolation(result, Violation{
 			File:       relPath,
-			Message:    "Failed to load api.yml",
+			Message:    msg,
 			Severity:   SeverityBlocking,
 			RuleNumber: 12,
 		}, baseline)

--- a/validation/rules_design.go
+++ b/validation/rules_design.go
@@ -701,29 +701,29 @@ func checkRule47(filePath string, doc *openapi3.T, opts AuditOptions) []Violatio
 }
 
 func checkRule48(
-    filePath string,
-    loadErr error,
-    opts AuditOptions,
+	filePath string,
+	loadErr error,
+	opts AuditOptions,
 ) []Violation {
 
-    if loadErr == nil {
-        return nil
-    }
+	if loadErr == nil {
+		return nil
+	}
 
-    msg := loadErr.Error()
+	msg := loadErr.Error()
 
-    if strings.Contains(msg, "map key") &&
-       strings.Contains(msg, "not found") {
+	if strings.Contains(msg, "map key") &&
+		strings.Contains(msg, "not found") {
 
-        return []Violation{
-            {
-                File:       filePath,
-                Message:    fmt.Sprintf("Broken $ref detected: %s", msg),
-                Severity:   SeverityBlocking,
-                RuleNumber: 48,
-            },
-        }
-    }
+		return []Violation{
+			{
+				File:       filePath,
+				Message:    fmt.Sprintf("Broken $ref detected: %s", msg),
+				Severity:   SeverityBlocking,
+				RuleNumber: 48,
+			},
+		}
+	}
 
-    return nil
+	return nil
 }

--- a/validation/rules_design.go
+++ b/validation/rules_design.go
@@ -699,3 +699,31 @@ func checkRule47(filePath string, doc *openapi3.T, opts AuditOptions) []Violatio
 	}
 	return out
 }
+
+func checkRule48(
+    filePath string,
+    loadErr error,
+    opts AuditOptions,
+) []Violation {
+
+    if loadErr == nil {
+        return nil
+    }
+
+    msg := loadErr.Error()
+
+    if strings.Contains(msg, "map key") &&
+       strings.Contains(msg, "not found") {
+
+        return []Violation{
+            {
+                File:       filePath,
+                Message:    fmt.Sprintf("Broken $ref detected: %s", msg),
+                Severity:   SeverityBlocking,
+                RuleNumber: 48,
+            },
+        }
+    }
+
+    return nil
+}

--- a/validation/rules_design_test.go
+++ b/validation/rules_design_test.go
@@ -1,6 +1,7 @@
 package validation
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -891,4 +892,22 @@ func TestCheckRule47_Valid205(t *testing.T) {
 	if len(vs) != 0 {
 		t.Errorf("expected 0 violations for 205 response without content, got %d", len(vs))
 	}
+}
+
+func TestCheckRule48_BrokenRefLoadError(t *testing.T) {
+    err := errors.New(`map key "Role" not found`)
+
+    vs := checkRule48(
+        "api.yml",
+        err,
+        AuditOptions{},
+    )
+
+    if len(vs) != 1 {
+        t.Fatalf("expected 1 violation, got %d", len(vs))
+    }
+
+    if vs[0].RuleNumber != 48 {
+        t.Fatalf("expected Rule 48")
+    }
 }

--- a/validation/rules_design_test.go
+++ b/validation/rules_design_test.go
@@ -895,19 +895,19 @@ func TestCheckRule47_Valid205(t *testing.T) {
 }
 
 func TestCheckRule48_BrokenRefLoadError(t *testing.T) {
-    err := errors.New(`map key "Role" not found`)
+	err := errors.New(`map key "Role" not found`)
 
-    vs := checkRule48(
-        "api.yml",
-        err,
-        AuditOptions{},
-    )
+	vs := checkRule48(
+		"api.yml",
+		err,
+		AuditOptions{},
+	)
 
-    if len(vs) != 1 {
-        t.Fatalf("expected 1 violation, got %d", len(vs))
-    }
+	if len(vs) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(vs))
+	}
 
-    if vs[0].RuleNumber != 48 {
-        t.Fatalf("expected Rule 48")
-    }
+	if vs[0].RuleNumber != 48 {
+		t.Fatalf("expected Rule 48")
+	}
 }


### PR DESCRIPTION
**Notes for Reviewers**

Part of #720

Detect broken OpenAPI $ref targets during schema validation.

Surface unresolved kin-openapi reference errors as Rule 48 violations instead of reporting a generic "Failed to load api.yml" error.

Note: Circular $ref detection is not included in this change.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.