### PR TITLE
fix(connection): make ConnectionDefinition a distinct type so its TableName doesn't leak onto Connection

### DIFF
--- a/models/v1beta3/connection/connection_definition_helper.go
+++ b/models/v1beta3/connection/connection_definition_helper.go
@@ -13,6 +13,28 @@ import (
 	"gorm.io/gorm/clause"
 )
 
+// ConnectionDefinition is the registry-entity form of a connection - an
+// uninitialized connection authored per-model and registered alongside
+// components and relationships. It is a DISTINCT defined type, NOT an alias of
+// Connection.
+//
+// The distinction is load-bearing: the entity.Entity methods below (notably
+// TableName, which returns "connection_definition_dbs") attach only to this
+// type. Were ConnectionDefinition a `= Connection` alias, those methods would
+// share Connection's method set and every Pop/GORM persistence of a runtime
+// Connection - which lives in the `connections` table - would be redirected to
+// the registry-only `connection_definition_dbs` table, 500-ing connection
+// writes (e.g. Meshery Server saving its connection to the remote provider).
+//
+// The generated alias is suppressed via a self-referential x-go-type in the
+// connection api.yml; see that spec and the generator's
+// removeSelfReferentialAliases pass.
+type ConnectionDefinition Connection
+
+// ConnectionDefinition is a registry entity; persistence and registration go
+// through the meshkit registry via this interface.
+var _ entity.Entity = (*ConnectionDefinition)(nil)
+
 func (c ConnectionDefinition) TableName() string {
 	return "connection_definition_dbs"
 }

--- a/models/v1beta3/connection/connection_definition_leak_test.go
+++ b/models/v1beta3/connection/connection_definition_leak_test.go
@@ -19,13 +19,17 @@ type tableNameAble interface{ TableName() string }
 // provider.
 //
 // Connection MUST NOT implement TableName(); ConnectionDefinition is a distinct
-// defined type that does.
+// defined type that does. The assertions use the pointer types (*Connection,
+// *ConnectionDefinition) because pop/GORM operate on pointers and a pointer's
+// method set includes both value- and pointer-receiver methods, whereas a
+// value's includes only value-receiver methods. Checking the pointer therefore
+// catches a re-leaked TableName() regardless of which receiver form it takes.
 func TestConnectionDoesNotInheritDefinitionTableName(t *testing.T) {
-	if tn, leaked := any(Connection{}).(tableNameAble); leaked {
+	if tn, leaked := any(&Connection{}).(tableNameAble); leaked {
 		t.Fatalf("Connection unexpectedly implements TableName() => %q; it must use pop's default \"connections\" table. ConnectionDefinition must be a distinct type, not a `= Connection` alias.", tn.TableName())
 	}
 
-	if got := (ConnectionDefinition{}).TableName(); got != "connection_definition_dbs" {
+	if got := (&ConnectionDefinition{}).TableName(); got != "connection_definition_dbs" {
 		t.Fatalf("ConnectionDefinition.TableName() = %q, want \"connection_definition_dbs\"", got)
 	}
 }

--- a/models/v1beta3/connection/connection_definition_leak_test.go
+++ b/models/v1beta3/connection/connection_definition_leak_test.go
@@ -1,0 +1,31 @@
+package connection
+
+import "testing"
+
+// tableNameAble mirrors gobuffalo/pop's (and GORM's) interface for overriding a
+// model's default table name. Pop consults it before falling back to the
+// pluralized struct name ("connections" for Connection).
+type tableNameAble interface{ TableName() string }
+
+// TestConnectionDoesNotInheritDefinitionTableName guards a regression in which
+// ConnectionDefinition was declared as a type ALIAS of Connection
+// (`type ConnectionDefinition = Connection`). Go aliases share one method set,
+// so the registry-entity TableName() => "connection_definition_dbs" defined on
+// ConnectionDefinition leaked onto Connection itself. Every Pop/GORM persistence
+// of a runtime Connection (which lives in the `connections` table) was then
+// redirected to the registry-only `connection_definition_dbs` table, producing
+// `pq: relation "connection_definition_dbs" does not exist` and 500-ing
+// connection writes - e.g. Meshery Server saving its connection to the remote
+// provider.
+//
+// Connection MUST NOT implement TableName(); ConnectionDefinition is a distinct
+// defined type that does.
+func TestConnectionDoesNotInheritDefinitionTableName(t *testing.T) {
+	if tn, leaked := any(Connection{}).(tableNameAble); leaked {
+		t.Fatalf("Connection unexpectedly implements TableName() => %q; it must use pop's default \"connections\" table. ConnectionDefinition must be a distinct type, not a `= Connection` alias.", tn.TableName())
+	}
+
+	if got := (ConnectionDefinition{}).TableName(); got != "connection_definition_dbs" {
+		t.Fatalf("ConnectionDefinition.TableName() = %q, want \"connection_definition_dbs\"", got)
+	}
+}

--- a/schemas/constructs/v1beta3/connection/api.yml
+++ b/schemas/constructs/v1beta3/connection/api.yml
@@ -526,7 +526,16 @@ components:
 
     ConnectionDefinition:
       description: A connection definition is an uninitialized connection, authored per-model (in a model's `connections/` folder) and registered into the registry alongside components and relationships. It conforms to the connection schema; the dynamic, kind-specific shape is carried in `metadata`. The `model` association scopes the definition to its owning model.
-      x-go-type: "Connection"
+      # Self-referential x-go-type: oapi-codegen emits `type ConnectionDefinition =
+      # ConnectionDefinition`, which the generator's removeSelfReferentialAliases pass
+      # comments out, deferring to the hand-written definition in
+      # connection_definition_helper.go. ConnectionDefinition MUST be a DISTINCT Go type
+      # (not an alias of Connection): the registry-entity methods on it - notably
+      # TableName() => "connection_definition_dbs" - would otherwise leak onto the
+      # wire/runtime Connection type via Go's type-alias method-set sharing, redirecting
+      # every Pop/GORM save of a Connection (the `connections` table) to the
+      # registry-only `connection_definition_dbs` table and 500-ing connection writes.
+      x-go-type: "ConnectionDefinition"
 
     ConnectionDefinitionPage:
       description: Represents a page of connection definitions with meta information about the total count


### PR DESCRIPTION
## Symptom
Saving a connection to the remote provider (Meshery Cloud) 500s:
`pq: relation "connection_definition_dbs" does not exist (42P01)`. Cloud's Postgres has a `connections` table, not `connection_definition_dbs`, so every connection write the remote provider receives fails (e.g. Meshery Server's `TokenHandler` saving its `meshery`-kind connection). Meshery Server is exposed to the same bug via `server/models/connection_persister.go` (GORM `Save` in `SaveConnection` / `UpdateConnectionStatusByID`).

## Root cause
`ConnectionDefinition` is a Go type **alias** of `Connection` (`type ConnectionDefinition = Connection`). The registry-entity helper attaches `func (ConnectionDefinition) TableName() string { return "connection_definition_dbs" }` (added in f02a183c). Because a Go alias shares one method set, that `TableName()` becomes a method on `Connection` itself. pop/GORM honor `TableNameAble`, so every persistence of a runtime `Connection` — which lives in the `connections` table — is redirected to the registry-only `connection_definition_dbs` table.

## Fix
Make `ConnectionDefinition` a **distinct** defined type (`type ConnectionDefinition Connection`) so the registry-entity methods attach only to it, freeing `Connection` to resolve to its default `connections` table. The wire shape is identical (same fields/tags), so meshery + meshkit + meshery-cloud consume it unchanged — they reference `ConnectionDefinition` by name only. The construct stays **v1beta3**.

Mechanics mirror the existing `core.NullTime` manual-helper pattern:
- `api.yml`: `ConnectionDefinition` uses a self-referential `x-go-type: "ConnectionDefinition"`, so oapi-codegen emits `type ConnectionDefinition = ConnectionDefinition`, which the generator's `removeSelfReferentialAliases` pass comments out — deferring to the hand-written definition.
- `connection_definition_helper.go`: adds `type ConnectionDefinition Connection` + a compile-time `entity.Entity` assertion.
- Adds a regression test asserting `Connection` does not implement `TableName()`.

## Generated models (intentionally source-only)
This PR commits **source only** — no generated Go models. On merge to `master`, `generate-artifacts-from-schemas.yml` regenerates them (oapi-codegen v2.5.1) and auto-commits; the only change to `models/v1beta3/connection/connection.go` is the `ConnectionDefinition` alias line becoming `// type ConnectionDefinition — defined in manual helper file`. master compiles after that auto-commit lands.

## Verification
- Regression test passes; `make validate-schemas` clean.
- meshery-cloud's full server and meshery both build, with connection DAO/handler tests passing, against v1.3.15 + this fix (verified locally via a `replace`).

## Rollout
Ships as **v1.3.16** (Release Drafter, next patch). After merge + the artifact auto-commit, publish the v1.3.16 release, then bump `github.com/meshery/schemas` to v1.3.16 in meshery and meshery-cloud — no consumer code changes (wire contract unchanged; no meshkit bump needed).

## Recurrence
Isolated to v1beta3; no other aliased struct type carries ORM/entity methods.
