### PR TITLE
feat(connection): complete and align the v1beta3 connection sample templates

### DIFF
--- a/schemas/constructs/v1beta3/connection/templates/connection_template.json
+++ b/schemas/constructs/v1beta3/connection/templates/connection_template.json
@@ -1,13 +1,40 @@
 {
   "id": "00000000-0000-0000-0000-000000000000",
   "name": "",
+  "description": "",
+  "url": "",
   "credentialId": "00000000-0000-0000-0000-000000000000",
   "type": "platform",
   "subType": "orchestration",
   "kind": "kubernetes",
+  "model": null,
+  "modelReference": null,
   "metadata": {},
+  "credentialSchema": {},
+  "connectionSchema": {},
+  "styles": null,
   "status": "discovered",
-  "userId": "00000000-0000-0000-0000-000000000000",
+  "transitionMap": {
+    "discovered": [
+      {
+        "nextState": "registered",
+        "description": "A discovered connection is registered by a user to begin managing it."
+      }
+    ],
+    "registered": [
+      {
+        "nextState": "connected",
+        "description": "Meshery establishes connectivity to the registered resource."
+      }
+    ],
+    "connected": [
+      {
+        "nextState": "disconnected",
+        "description": "Connectivity to the resource is lost or intentionally torn down."
+      }
+    ]
+  },
+  "owner": "00000000-0000-0000-0000-000000000000",
   "createdAt": "0001-01-01T00:00:00Z",
   "updatedAt": "0001-01-01T00:00:00Z",
   "deletedAt": null,

--- a/schemas/constructs/v1beta3/connection/templates/connection_template.yaml
+++ b/schemas/constructs/v1beta3/connection/templates/connection_template.yaml
@@ -1,11 +1,28 @@
 id: 00000000-0000-0000-0000-000000000000
 name: ''
+description: ''
+url: ''
 credentialId: 00000000-0000-0000-0000-000000000000
 type: platform
 subType: orchestration
 kind: kubernetes
+model: null
+modelReference: null
 metadata: {}
+credentialSchema: {}
+connectionSchema: {}
+styles: null
 status: discovered
+transitionMap:
+  discovered:
+    - nextState: registered
+      description: A discovered connection is registered by a user to begin managing it.
+  registered:
+    - nextState: connected
+      description: Meshery establishes connectivity to the registered resource.
+  connected:
+    - nextState: disconnected
+      description: Connectivity to the resource is lost or intentionally torn down.
 owner: 00000000-0000-0000-0000-000000000000
 createdAt: '0001-01-01T00:00:00Z'
 updatedAt: '0001-01-01T00:00:00Z'


### PR DESCRIPTION
Follow-up to #952 (which landed the `ConnectionDefinition` distinct-type fix). This sample-template enhancement was prepared on that branch but landed after the PR head desynced from the branch ref, so it missed the merge — re-landing it here off master.

## What changed
Both `schemas/constructs/v1beta3/connection/templates/connection_template.{yaml,json}` are brought in line with the current v1beta3 `Connection` schema:

- **Fix drift:** `connection_template.json` used `userId`, which is not a `Connection` property (the schema is `additionalProperties: false`); the canonical field is `owner`. The YAML template was already correct. The stale name dated to the v1beta3 canonical-casing recase (858cea89).
- **Sync YAML ↔ JSON:** both templates now carry identical content in canonical schema (declaration) order.
- **Add the v1beta3 fields they lacked:** `description`, `url`, `model`, `modelReference`, `credentialSchema`, `connectionSchema`, `styles`, and a representative `transitionMap` demonstrating the connection state machine (discovered → registered → connected → disconnected).

## Validation
- Both files parse and are data-equivalent; only schema-allowed properties are present (no stray `userId`); required fields present; `transitionMap` conforms to `ConnectionStateTransition`.
- Hand-authored sample files (not generated).