### PR TITLE
fix: open schema version links on GitHub instead of downloading YAML

### DIFF
--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
           {% for schema in site.data.latest_schema_versions %}
           <tr>
             <th scope="row">{{ schema.construct }}</th>
-            <td><a href="{{ schema.href | relative_url }}">{{ schema.version }}</a></td>
+            <td><a href="https://github.com/meshery/schemas/blob/master{{ schema.href }}" target="_blank" rel="noopener noreferrer">{{ schema.version }}</a></td>
             <td class="classification">
               {% if schema.core %}<span class="yes" aria-hidden="true">✓</span><span class="sr-only">Core</span>{% else %}<span class="no" aria-hidden="true">·</span><span class="sr-only">Not Core</span>{% endif %}
             </td>


### PR DESCRIPTION
**Notes for Reviewers**
Schema version links on schemas.meshery.io were triggering YAML file downloads instead of opening the file on GitHub. The fix updates `index.html` to construct a GitHub blob URL (`https://github.com/meshery/schemas/blob/master{{ schema.href }}`) instead of using the relative path with `relative_url`. 

This PR fixes #960



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.