### PR TITLE
Hyperlink construct names to their documentation pages

### DIFF
--- a/_data/latest_schema_versions.json
+++ b/_data/latest_schema_versions.json
@@ -38,6 +38,7 @@
     "construct": "component",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/component/component.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/components",
     "core": false,
     "extension": false
   },
@@ -45,6 +46,7 @@
     "construct": "connection",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/connection/connection.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/connections",
     "core": true,
     "extension": true
   },
@@ -59,6 +61,7 @@
     "construct": "credential",
     "version": "v1beta2",
     "href": "/schemas/constructs/v1beta2/credential/api.yml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/credentials",
     "core": true,
     "extension": true
   },
@@ -66,6 +69,7 @@
     "construct": "design",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/design/design.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/designs",
     "core": true,
     "extension": true
   },
@@ -73,6 +77,7 @@
     "construct": "environment",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/environment/environment.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/environments",
     "core": true,
     "extension": true
   },
@@ -129,6 +134,7 @@
     "construct": "model",
     "version": "v1beta2",
     "href": "/schemas/constructs/v1beta2/model/model.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/models",
     "core": true,
     "extension": true
   },
@@ -136,6 +142,7 @@
     "construct": "organization",
     "version": "v1beta2",
     "href": "/schemas/constructs/v1beta2/organization/organization.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/organizations",
     "core": true,
     "extension": true
   },
@@ -157,6 +164,7 @@
     "construct": "relationship",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/relationship/relationship.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/relationships",
     "core": false,
     "extension": false
   },
@@ -234,6 +242,7 @@
     "construct": "workspace",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/workspace/workspace.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/workspaces",
     "core": true,
     "extension": true
   }

--- a/index.html
+++ b/index.html
@@ -226,7 +226,7 @@
           {% for schema in site.data.latest_schema_versions %}
           <tr>
             <th scope="row">{{ schema.construct }}</th>
-            <td><a href="{{ schema.href | relative_url }}">{{ schema.version }}</a></td>
+            <td><a href="https://github.com/meshery/schemas/blob/master{{ schema.href }}" target="_blank" rel="noopener noreferrer">{{ schema.version }}</a></td>
             <td class="classification">
               {% if schema.core %}<span class="yes" aria-hidden="true">✓</span><span class="sr-only">Core</span>{% else %}<span class="no" aria-hidden="true">·</span><span class="sr-only">Not Core</span>{% endif %}
             </td>

--- a/index.html
+++ b/index.html
@@ -225,7 +225,7 @@
         <tbody>
           {% for schema in site.data.latest_schema_versions %}
           <tr>
-            <th scope="row">{{ schema.construct }}</th>
+            <th scope="row">{% if schema.docs_href %}<a href="{{ schema.docs_href }}" target="_blank" rel="noopener noreferrer">{{ schema.construct }}</a>{% else %}{{ schema.construct }}{% endif %}</th>
             <td><a href="https://github.com/meshery/schemas/blob/master{{ schema.href }}" target="_blank" rel="noopener noreferrer">{{ schema.version }}</a></td>
             <td class="classification">
               {% if schema.core %}<span class="yes" aria-hidden="true">✓</span><span class="sr-only">Core</span>{% else %}<span class="no" aria-hidden="true">·</span><span class="sr-only">Not Core</span>{% endif %}


### PR DESCRIPTION
**Notes for Reviewers**

Adds hyperlinks from construct names in the schema versions table on schemas.meshery.io to their corresponding documentation pages on docs.meshery.io.

Adds hyperlinks from construct names in the schema versions table on schemas.meshery.io to their corresponding documentation pages on docs.meshery.io.

- `docs_href` field added to 9 constructs in `_data/latest_schema_versions.json` (component, connection, credential, design, environment, model, organization, relationship, workspace) 
- `index.html` updated to conditionally render the construct name as a link when `docs_href` is present, plain text otherwise

Constructs without a known docs page are unchanged (plain text).

This PR fixes #962 



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
