### PR TITLE
Hyperlink construct names to their documentation pages

### DIFF
--- a/site/_data/latest_schema_versions.json
+++ b/site/_data/latest_schema_versions.json
@@ -38,6 +38,7 @@
     "construct": "component",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/component/component.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/components",
     "core": false,
     "extension": false
   },
@@ -45,6 +46,7 @@
     "construct": "connection",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/connection/connection.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/connections",
     "core": true,
     "extension": true
   },
@@ -66,6 +68,7 @@
     "construct": "credential",
     "version": "v1beta2",
     "href": "/schemas/constructs/v1beta2/credential/api.yml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/credentials",
     "core": true,
     "extension": true
   },
@@ -73,6 +76,7 @@
     "construct": "design",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/design/design.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/designs",
     "core": true,
     "extension": true
   },
@@ -80,6 +84,7 @@
     "construct": "environment",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/environment/environment.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/environments",
     "core": true,
     "extension": true
   },
@@ -136,6 +141,7 @@
     "construct": "model",
     "version": "v1beta2",
     "href": "/schemas/constructs/v1beta2/model/model.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/models",
     "core": true,
     "extension": true
   },
@@ -143,6 +149,7 @@
     "construct": "organization",
     "version": "v1beta2",
     "href": "/schemas/constructs/v1beta2/organization/organization.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/organizations",
     "core": true,
     "extension": true
   },
@@ -171,6 +178,7 @@
     "construct": "relationship",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/relationship/relationship.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/relationships",
     "core": false,
     "extension": false
   },
@@ -248,6 +256,7 @@
     "construct": "workspace",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/workspace/workspace.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/workspaces",
     "core": true,
     "extension": true
   }

--- a/site/index.html
+++ b/site/index.html
@@ -326,7 +326,7 @@ permalink: /
           <tbody role="rowgroup">
             {% for schema in site.data.latest_schema_versions %}
             <tr role="row">
-              <th scope="row" role="rowheader">{% if schema.docs_href %}<a href="{{ schema.docs_href }}" target="_blank" rel="noopener noreferrer">{{ schema.construct }}</a>{% else %}{{ schema.construct }}{% endif %}</th>
+              <th scope="row" role="rowheader">{% if schema.docs_href != blank %}<a href="{{ schema.docs_href }}" target="_blank" rel="noopener noreferrer">{{ schema.construct }}</a>{% else %}{{ schema.construct }}{% endif %}</th>
               <td role="cell" data-label="Latest schema"><a href="https://github.com/meshery/schemas/blob/master{{ schema.href }}" target="_blank" rel="noopener noreferrer">{{ schema.version }}</a></td>
               <td role="cell" class="classification" data-label="Core">
                 {% if schema.core %}<span class="yes" aria-hidden="true">✓</span><span class="sr-only">Core</span>{% else %}<span class="no" aria-hidden="true">·</span><span class="sr-only">Not Core</span>{% endif %}

--- a/site/index.html
+++ b/site/index.html
@@ -326,7 +326,7 @@ permalink: /
           <tbody role="rowgroup">
             {% for schema in site.data.latest_schema_versions %}
             <tr role="row">
-              <th scope="row" role="rowheader">{{ schema.construct }}</th>
+              <th scope="row" role="rowheader">{% if schema.docs_href %}<a href="{{ schema.docs_href }}" target="_blank" rel="noopener noreferrer">{{ schema.construct }}</a>{% else %}{{ schema.construct }}{% endif %}</th>
               <td role="cell" data-label="Latest schema"><a href="https://github.com/meshery/schemas/blob/master{{ schema.href }}" target="_blank" rel="noopener noreferrer">{{ schema.version }}</a></td>
               <td role="cell" class="classification" data-label="Core">
                 {% if schema.core %}<span class="yes" aria-hidden="true">✓</span><span class="sr-only">Core</span>{% else %}<span class="no" aria-hidden="true">·</span><span class="sr-only">Not Core</span>{% endif %}


### PR DESCRIPTION
**Notes for Reviewers**

Adds hyperlinks from construct names in the schema versions table on schemas.meshery.io to their corresponding documentation pages on docs.meshery.io.

Adds hyperlinks from construct names in the schema versions table on schemas.meshery.io to their corresponding documentation pages on docs.meshery.io.

- `docs_href` field added to 9 constructs in `_data/latest_schema_versions.json` (component, connection, credential, design, environment, model, organization, relationship, workspace) 
- `index.html` updated to conditionally render the construct name as a link when `docs_href` is present, plain text otherwise

Constructs without a known docs page are unchanged (plain text).

This PR fixes #962 



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
