### PR TITLE
Mobile responsiveness of website

### DIFF
--- a/index.html
+++ b/index.html
@@ -101,9 +101,14 @@
         color: var(--primary-hover);
       }
 
+      .table-wrapper {
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+        margin: 1.5rem 0;
+      }
+
       table {
         width: 100%;
-        margin: 1.5rem 0;
         border-collapse: collapse;
         background: var(--surface-card-light);
       }
@@ -171,6 +176,75 @@
         margin-top: 0.25rem;
       }
 
+      @media (max-width: 36rem) {
+        body {
+          padding: 12px 8px;
+        }
+
+        main {
+          padding: 16px;
+        }
+
+        h1 {
+          font-size: 1.5rem;
+        }
+
+        table,
+        thead,
+        tbody,
+        tr,
+        th,
+        td {
+          display: block;
+        }
+
+        thead tr {
+          position: absolute;
+          top: -9999px;
+          left: -9999px;
+        }
+
+        tbody tr {
+          margin-bottom: 0.75rem;
+          border: 1px solid var(--border-light);
+          border-radius: 4px;
+          overflow: hidden;
+        }
+
+        tbody th[scope="row"] {
+          background: var(--surface-muted-light);
+          font-weight: 600;
+          border: none;
+          border-bottom: 1px solid var(--border-light);
+        }
+
+        tbody td {
+          display: flex;
+          align-items: center;
+          gap: 0.5rem;
+          border: none;
+          border-bottom: 1px solid var(--border-light);
+          text-align: left;
+        }
+
+        tbody td:last-child {
+          border-bottom: none;
+        }
+
+        tbody td::before {
+          content: attr(data-label);
+          font-weight: 600;
+          font-size: 0.8rem;
+          color: var(--secondary);
+          min-width: 7.5rem;
+          flex-shrink: 0;
+        }
+
+        .classification {
+          text-align: left;
+        }
+      }
+
       @media (prefers-color-scheme: dark) {
         body {
           background: var(--surface-muted-dark);
@@ -199,6 +273,25 @@
           color: var(--primary-hover);
         }
       }
+
+      @media (max-width: 36rem) and (prefers-color-scheme: dark) {
+        tbody tr {
+          border-color: var(--border-dark);
+        }
+
+        tbody th[scope="row"] {
+          background: var(--surface-muted-dark);
+          border-color: var(--border-dark);
+        }
+
+        tbody td {
+          border-color: var(--border-dark);
+        }
+
+        tbody td::before {
+          color: var(--primary-hover);
+        }
+      }
     </style>
   </head>
   <body>
@@ -213,30 +306,32 @@
         resources are served by Meshery Cloud. A resource can be both.
       </p>
 
-      <table aria-label="Latest Meshery schema versions">
-        <thead>
-          <tr>
-            <th scope="col">Resource</th>
-            <th scope="col">Latest schema</th>
-            <th scope="col" class="classification">Core</th>
-            <th scope="col" class="classification">Extension</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for schema in site.data.latest_schema_versions %}
-          <tr>
-            <th scope="row">{{ schema.construct }}</th>
-            <td><a href="https://github.com/meshery/schemas/blob/master{{ schema.href }}" target="_blank" rel="noopener noreferrer">{{ schema.version }}</a></td>
-            <td class="classification">
-              {% if schema.core %}<span class="yes" aria-hidden="true">✓</span><span class="sr-only">Core</span>{% else %}<span class="no" aria-hidden="true">·</span><span class="sr-only">Not Core</span>{% endif %}
-            </td>
-            <td class="classification">
-              {% if schema.extension %}<span class="yes" aria-hidden="true">✓</span><span class="sr-only">Extension</span>{% else %}<span class="no" aria-hidden="true">·</span><span class="sr-only">Not Extension</span>{% endif %}
-            </td>
-          </tr>
-          {% endfor %}
-        </tbody>
-      </table>
+      <div class="table-wrapper">
+        <table aria-label="Latest Meshery schema versions">
+          <thead>
+            <tr>
+              <th scope="col">Resource</th>
+              <th scope="col">Latest schema</th>
+              <th scope="col" class="classification">Core</th>
+              <th scope="col" class="classification">Extension</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for schema in site.data.latest_schema_versions %}
+            <tr>
+              <th scope="row">{{ schema.construct }}</th>
+              <td data-label="Latest schema"><a href="https://github.com/meshery/schemas/blob/master{{ schema.href }}" target="_blank" rel="noopener noreferrer">{{ schema.version }}</a></td>
+              <td class="classification" data-label="Core">
+                {% if schema.core %}<span class="yes" aria-hidden="true">✓</span><span class="sr-only">Core</span>{% else %}<span class="no" aria-hidden="true">·</span><span class="sr-only">Not Core</span>{% endif %}
+              </td>
+              <td class="classification" data-label="Extension">
+                {% if schema.extension %}<span class="yes" aria-hidden="true">✓</span><span class="sr-only">Extension</span>{% else %}<span class="no" aria-hidden="true">·</span><span class="sr-only">Not Extension</span>{% endif %}
+              </td>
+            </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+      </div>
 
       <section class="docs-links" aria-labelledby="contributor-guides-title">
         <h2 id="contributor-guides-title">Contributor guides</h2>

--- a/index.html
+++ b/index.html
@@ -198,10 +198,16 @@
           display: block;
         }
 
-        thead tr {
+        thead {
           position: absolute;
-          top: -9999px;
-          left: -9999px;
+          width: 1px;
+          height: 1px;
+          padding: 0;
+          margin: -1px;
+          overflow: hidden;
+          clip: rect(0, 0, 0, 0);
+          white-space: nowrap;
+          border: 0;
         }
 
         tbody tr {
@@ -307,24 +313,24 @@
       </p>
 
       <div class="table-wrapper">
-        <table aria-label="Latest Meshery schema versions">
-          <thead>
-            <tr>
-              <th scope="col">Resource</th>
-              <th scope="col">Latest schema</th>
-              <th scope="col" class="classification">Core</th>
-              <th scope="col" class="classification">Extension</th>
+        <table role="table" aria-label="Latest Meshery schema versions">
+          <thead role="rowgroup">
+            <tr role="row">
+              <th scope="col" role="columnheader">Resource</th>
+              <th scope="col" role="columnheader">Latest schema</th>
+              <th scope="col" role="columnheader" class="classification">Core</th>
+              <th scope="col" role="columnheader" class="classification">Extension</th>
             </tr>
           </thead>
-          <tbody>
+          <tbody role="rowgroup">
             {% for schema in site.data.latest_schema_versions %}
-            <tr>
-              <th scope="row">{{ schema.construct }}</th>
-              <td data-label="Latest schema"><a href="https://github.com/meshery/schemas/blob/master{{ schema.href }}" target="_blank" rel="noopener noreferrer">{{ schema.version }}</a></td>
-              <td class="classification" data-label="Core">
+            <tr role="row">
+              <th scope="row" role="rowheader">{{ schema.construct }}</th>
+              <td role="cell" data-label="Latest schema"><a href="https://github.com/meshery/schemas/blob/master{{ schema.href }}" target="_blank" rel="noopener noreferrer">{{ schema.version }}</a></td>
+              <td role="cell" class="classification" data-label="Core">
                 {% if schema.core %}<span class="yes" aria-hidden="true">✓</span><span class="sr-only">Core</span>{% else %}<span class="no" aria-hidden="true">·</span><span class="sr-only">Not Core</span>{% endif %}
               </td>
-              <td class="classification" data-label="Extension">
+              <td role="cell" class="classification" data-label="Extension">
                 {% if schema.extension %}<span class="yes" aria-hidden="true">✓</span><span class="sr-only">Extension</span>{% else %}<span class="no" aria-hidden="true">·</span><span class="sr-only">Not Extension</span>{% endif %}
               </td>
             </tr>


### PR DESCRIPTION
**Notes for Reviewers**

The schema versions table on schemas.meshery.io was not friendly on mobile screens. This PR makes it responsive using a CSS card-stack layout for small screen.

This PR fixes #968

<img width="1703" height="1219" alt="Screenshot 2026-06-26 at 22 57 09" src="https://github.com/user-attachments/assets/b6079bd6-109e-44f1-8b4c-05f364049a2c" />



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.