### PR TITLE
feat(permissions): generate PermissionDetails metadata for TypeScript constants

### DIFF
--- a/build/lib/permissions.js
+++ b/build/lib/permissions.js
@@ -77,7 +77,10 @@ function parsePermissions(csvContent, options = {}) {
       name: constantName,
       uuid: keyId,
       feature: feature,
-      subject: func,
+      category: category,
+      subcategory: fields[1] || "",
+      function: func,
+      description: feature,
     });
   }
 
@@ -220,6 +223,17 @@ function generateTypeScriptFile(permissions, indexId) {
     "export type PermissionKey = string & { readonly __brand: 'PermissionKey' };",
     "",
     "/**",
+    " * Interface representing a Key conforming to the Key schema.",
+    " */",
+    "export interface Key {",
+    "  readonly id: PermissionKey;",
+    "  readonly category: string;",
+    "  readonly subcategory: string;",
+    "  readonly function: string;",
+    "  readonly description: string;",
+    "}",
+    "",
+    "/**",
     " * Permissions Index ID used for this generated file.",
     " */",
     `export const PERMISSIONS_INDEX_ID = "${indexId}" as const;`,
@@ -234,10 +248,9 @@ function generateTypeScriptFile(permissions, indexId) {
     "}",
     "",
     "/**",
-    " * Permission key constants.",
-    " * Each key represents a unique permission identified by its UUID.",
+    " * Keys conforming to the Key schema.",
     " */",
-    "export const PermissionKeys = {",
+    "export const Keys = {",
   ];
 
   for (let i = 0; i < permissions.length; i++) {
@@ -247,10 +260,16 @@ function generateTypeScriptFile(permissions, indexId) {
 
     lines.push(`  /**`);
     lines.push(
-      `   * ${escapeJSDocComment(perm.feature || "No description available")}`,
+      `   * ${escapeJSDocComment(perm.description || perm.feature || "No description available")}`,
     );
     lines.push(`   */`);
-    lines.push(`  ${perm.name}: "${perm.uuid}" as PermissionKey${comma}`);
+    lines.push(`  ${perm.name}: {`);
+    lines.push(`    id: "${perm.uuid}" as PermissionKey,`);
+    lines.push(`    category: "${perm.category ? perm.category.replace(/"/g, '\\"') : ""}",`);
+    lines.push(`    subcategory: "${perm.subcategory ? perm.subcategory.replace(/"/g, '\\"') : ""}",`);
+    lines.push(`    function: "${perm.function ? perm.function.replace(/"/g, '\\"') : ""}",`);
+    lines.push(`    description: "${perm.description || perm.feature ? (perm.description || perm.feature).replace(/"/g, '\\"') : ""}"`);
+    lines.push(`  }${comma}`);
     if (!isLast) {
       lines.push("");
     }
@@ -259,9 +278,10 @@ function generateTypeScriptFile(permissions, indexId) {
   lines.push("} as const;");
   lines.push("");
   lines.push("/**");
-  lines.push(" * Detailed permission key metadata including the human-readable subject name.");
+  lines.push(" * Permission key constants.");
+  lines.push(" * Each key represents a unique permission identified by its UUID.");
   lines.push(" */");
-  lines.push("export const PermissionDetails = {");
+  lines.push("export const PermissionKeys = {");
 
   for (let i = 0; i < permissions.length; i++) {
     const perm = permissions[i];
@@ -270,14 +290,10 @@ function generateTypeScriptFile(permissions, indexId) {
 
     lines.push(`  /**`);
     lines.push(
-      `   * ${escapeJSDocComment(perm.feature || "No description available")}`,
+      `   * ${escapeJSDocComment(perm.description || perm.feature || "No description available")}`,
     );
     lines.push(`   */`);
-    lines.push(`  ${perm.name}: {`);
-    lines.push(`    action: "${perm.uuid}" as PermissionKey,`);
-    lines.push(`    subject: "${perm.subject ? perm.subject.replace(/"/g, '\\"') : ""}"`);
-    lines.push(`  }${comma}`);
-
+    lines.push(`  ${perm.name}: "${perm.uuid}" as PermissionKey${comma}`);
     if (!isLast) {
       lines.push("");
     }
@@ -343,7 +359,10 @@ function buildIndex(permissions) {
       name: p.name,
       uuid: p.uuid,
       feature: p.feature,
-      subject: p.subject,
+      category: p.category,
+      subcategory: p.subcategory,
+      function: p.function,
+      description: p.description,
     })),
   };
 }

--- a/build/lib/permissions.js
+++ b/build/lib/permissions.js
@@ -77,6 +77,7 @@ function parsePermissions(csvContent, options = {}) {
       name: constantName,
       uuid: keyId,
       feature: feature,
+      subject: func,
     });
   }
 
@@ -258,6 +259,33 @@ function generateTypeScriptFile(permissions, indexId) {
   lines.push("} as const;");
   lines.push("");
   lines.push("/**");
+  lines.push(" * Detailed permission key metadata including the human-readable subject name.");
+  lines.push(" */");
+  lines.push("export const PermissionDetails = {");
+
+  for (let i = 0; i < permissions.length; i++) {
+    const perm = permissions[i];
+    const isLast = i === permissions.length - 1;
+    const comma = isLast ? "" : ",";
+
+    lines.push(`  /**`);
+    lines.push(
+      `   * ${escapeJSDocComment(perm.feature || "No description available")}`,
+    );
+    lines.push(`   */`);
+    lines.push(`  ${perm.name}: {`);
+    lines.push(`    action: "${perm.uuid}" as PermissionKey,`);
+    lines.push(`    subject: "${perm.subject ? perm.subject.replace(/"/g, '\\"') : ""}"`);
+    lines.push(`  }${comma}`);
+
+    if (!isLast) {
+      lines.push("");
+    }
+  }
+
+  lines.push("} as const;");
+  lines.push("");
+  lines.push("/**");
   lines.push(" * Type representing all valid permission key names.");
   lines.push(" */");
   lines.push("export type PermissionKeyName = keyof typeof PermissionKeys;");
@@ -315,6 +343,7 @@ function buildIndex(permissions) {
       name: p.name,
       uuid: p.uuid,
       feature: p.feature,
+      subject: p.subject,
     })),
   };
 }


### PR DESCRIPTION
### Description

This PR updates the TypeScript permission keys code generator (`build/lib/permissions.js`) to generate and export a `PermissionDetails` object in `typescript/permissions.ts`. Each canonical `PascalCase` permission key is mapped to:
* `action`: The branded `PermissionKey` (UUID).
* `subject`: The human-readable function name (parsed from the `Function` column in the permissions CSV).

This allows downstream UI repositories to dynamically resolve permission metadata at runtime instead of maintaining copy-pasted lists.

### Why are we adding the `subject` field to schemas?

Meshery UI uses **CASL** for UI-level permission checks (such as disabling buttons or hiding menus). CASL checks require **two** parameters to authorize an action:
1. The **`action`** (the UUID of the permission).
2. The **`subject`** (the human-readable function string, e.g., `"View Profile"`, `"Share Design"`).

Previously, `@meshery/schemas` only exported raw UUID strings (as `PermissionKeys`), which forced the UI to manually maintain a duplicate, copy-pasted mapping file (`ui/utils/permission_constants.ts`) to pair each UUID with its human-readable subject.

By exporting both `action` and `subject` directly from the schemas package under `PermissionDetails`, we allow the UI to resolve the full metadata dynamically at runtime. This completely eliminates manual maintenance and prevents desynchronization bugs.

### Impact Analysis

#### 1. Meshery
* **UI:** Once this change is published and `@meshery/schemas` is bumped, the UI's local `permission_constants.ts` can be refactored to dynamically bridge legacy keys to the schemas package:
  ```typescript
  import { PermissionDetails } from '@meshery/schemas/permissions';
  
  const legacyToPascal = {
    EDIT_ORGANIZATION: 'IdentityAccessManagementEditOrganization',
    // ... maps all legacy keys
  };
  
  export const keys = Object.entries(legacyToPascal).reduce((acc, [legacy, pascal]) => {
    const detail = PermissionDetails[pascal];
    if (detail) acc[legacy] = detail;
    return acc;
  }, {});
  
This will eliminate ~400 lines of hardcoded UUIDs.

- Go Server: No impact. models/permissions/permissions.go is generated separately and remains identical.

#### 2. Meshery Cloud

- Go Server / Router: No impact. Drift tests (seed_registry_drift_test.go) validating route protection compile and run successfully.
- UI: No impact. This lays the groundwork to similarly refactor Meshery Cloud's UI to resolve permission keys dynamically in the future.



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
