### PR TITLE
feat(user): account self-deletion eligibility + org hard-delete wire contract

### DIFF
--- a/models/v1beta2/user/user.go
+++ b/models/v1beta2/user/user.go
@@ -20,6 +20,60 @@ const (
 	Pending   UserStatus = "pending"
 )
 
+// AccountDeletionEligibility Pre-check result returned before an account self-deletion is confirmed. Describes whether deleting the caller's account would also require or permit hard-deleting their organization and quantifies the blast radius. All fields are always present so the client can render the confirmation state deterministically.
+type AccountDeletionEligibility struct {
+	// CrossTenantSharedResourceCount Count of resources reachable from this organization that are also shared into a different, surviving organization; destroying them affects other tenants. When greater than zero the client must set confirmSharedResourceDestruction to proceed.
+	CrossTenantSharedResourceCount int `json:"crossTenantSharedResourceCount" yaml:"crossTenantSharedResourceCount"`
+
+	// HasActivePaidSubscription True when the organization has an active paid (non-"Personal"/free) plan subscription that must be cancelled before the organization can be hard-deleted.
+	HasActivePaidSubscription bool `json:"hasActivePaidSubscription" yaml:"hasActivePaidSubscription"`
+
+	// Impact Per-resource counts of the objects that would be destroyed when an organization is hard-deleted alongside the account.
+	Impact AccountDeletionImpact `json:"impact" yaml:"impact"`
+
+	// IsProviderOrg True when this is the shared Layer5 provider organization, which is never deletable regardless of membership.
+	IsProviderOrg bool `json:"isProviderOrg" yaml:"isProviderOrg"`
+
+	// IsSoleActiveMember True when the caller is the only active member of the organization, so deleting their account would leave the organization without any active members.
+	IsSoleActiveMember bool `json:"isSoleActiveMember" yaml:"isSoleActiveMember"`
+
+	// OrganizationId Unique identifier of the organization evaluated for deletion.
+	OrganizationId uuid.UUID `json:"organizationId" yaml:"organizationId"`
+
+	// OrganizationName Human-readable name of the organization evaluated for deletion. The client echoes this value back as organizationNameConfirmation when requesting deletion.
+	OrganizationName string `json:"organizationName" yaml:"organizationName"`
+}
+
+// AccountDeletionImpact Per-resource counts of the objects that would be destroyed when an organization is hard-deleted alongside the account.
+type AccountDeletionImpact struct {
+	// AcademyRecords Number of academy records (challenges, certifications) that would be destroyed.
+	AcademyRecords int `json:"academyRecords" yaml:"academyRecords"`
+
+	// Connections Number of connections that would be destroyed.
+	Connections int `json:"connections" yaml:"connections"`
+
+	// Credentials Number of credentials that would be destroyed.
+	Credentials int `json:"credentials" yaml:"credentials"`
+
+	// Designs Number of designs that would be destroyed.
+	Designs int `json:"designs" yaml:"designs"`
+
+	// Environments Number of environments that would be destroyed.
+	Environments int `json:"environments" yaml:"environments"`
+
+	// Invitations Number of pending invitations that would be revoked.
+	Invitations int `json:"invitations" yaml:"invitations"`
+
+	// Members Number of organization members that would lose access.
+	Members int `json:"members" yaml:"members"`
+
+	// Views Number of views that would be destroyed.
+	Views int `json:"views" yaml:"views"`
+
+	// Workspaces Number of workspaces that would be destroyed.
+	Workspaces int `json:"workspaces" yaml:"workspaces"`
+}
+
 // Adapter Placeholder for Adapter struct definition.
 type Adapter = map[string]interface{}
 

--- a/schemas/constructs/v1beta2/user/api.yml
+++ b/schemas/constructs/v1beta2/user/api.yml
@@ -123,6 +123,115 @@ paths:
           $ref: "#/components/responses/401"
         "500":
           $ref: "#/components/responses/500"
+
+  /api/identity/users/self/account-deletion-eligibility:
+    get:
+      x-internal: ["cloud"]
+      tags:
+        - users
+      operationId: getAccountDeletionEligibility
+      summary: Get account deletion eligibility
+      description: >-
+        Pre-check evaluated before an account self-deletion is confirmed.
+        Reports whether deleting the caller's account would also require or
+        permit hard-deleting their organization, whether that organization is
+        the shared Layer5 provider organization or carries an active paid
+        subscription, how many of its resources are also shared into other
+        surviving organizations, and the per-resource blast radius of the
+        deletion.
+      parameters:
+        - name: organizationId
+          in: query
+          required: false
+          description: >-
+            Organization to evaluate for deletion alongside the account. When
+            omitted, the caller's currently selected organization is evaluated.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Account deletion eligibility for the caller
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AccountDeletionEligibility"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /api/identity/users/self:
+    delete:
+      x-internal: ["cloud"]
+      tags:
+        - users
+      operationId: deleteUserAccount
+      summary: Delete the caller's own account
+      description: >-
+        Soft-deletes the caller's Layer5 Cloud user record and hard-deletes the
+        backing identity. When deleteOrganization is true, the caller's
+        organization is hard-deleted in the same operation, subject to
+        server-side re-validation: the organization must not be the shared
+        Layer5 provider organization, must not have an active paid subscription,
+        and organizationNameConfirmation must match the stored organization
+        name. When the organization shares resources into other surviving
+        organizations, confirmSharedResourceDestruction must also be true.
+        Inputs are passed as query parameters because DELETE request bodies are
+        unreliable across the extension proxy and intermediate HTTP clients.
+      parameters:
+        - name: deleteOrganization
+          in: query
+          required: false
+          description: >-
+            When true, hard-delete the caller's organization along with the
+            account. Defaults to false (delete only the account).
+          schema:
+            type: boolean
+        - name: organizationId
+          in: query
+          required: false
+          description: >-
+            Identifier of the organization to hard-delete. Required by the
+            server when deleteOrganization is true.
+          schema:
+            type: string
+            format: uuid
+        - name: organizationNameConfirmation
+          in: query
+          required: false
+          description: >-
+            User-typed organization name. The server re-validates this against
+            the stored organization name when deleteOrganization is true and
+            rejects the request on mismatch.
+          schema:
+            type: string
+        - name: confirmSharedResourceDestruction
+          in: query
+          required: false
+          description: >-
+            Explicit acknowledgement that resources shared into other surviving
+            organizations will be destroyed. Required by the server when the
+            organization's crossTenantSharedResourceCount is greater than zero.
+          schema:
+            type: boolean
+      responses:
+        "204":
+          description: Account (and organization, when requested) deleted
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "409":
+          $ref: "#/components/responses/409"
+        "500":
+          $ref: "#/components/responses/500"
 components:
   responses:
     400:
@@ -131,6 +240,8 @@ components:
       $ref: "../core/api.yml#/components/responses/401"
     404:
       $ref: "../core/api.yml#/components/responses/404"
+    409:
+      $ref: "../core/api.yml#/components/responses/409"
     500:
       $ref: "../core/api.yml#/components/responses/500"
 
@@ -800,3 +911,116 @@ components:
           format: uri
           description: The link of the social.
       required: ["site", "link"]
+
+    AccountDeletionEligibility:
+      type: object
+      additionalProperties: false
+      description: >-
+        Pre-check result returned before an account self-deletion is confirmed.
+        Describes whether deleting the caller's account would also require or
+        permit hard-deleting their organization and quantifies the blast
+        radius. All fields are always present so the client can render the
+        confirmation state deterministically.
+      required:
+        - isSoleActiveMember
+        - organizationId
+        - organizationName
+        - isProviderOrg
+        - hasActivePaidSubscription
+        - crossTenantSharedResourceCount
+        - impact
+      properties:
+        isSoleActiveMember:
+          type: boolean
+          description: >-
+            True when the caller is the only active member of the organization,
+            so deleting their account would leave the organization without any
+            active members.
+        organizationId:
+          type: string
+          format: uuid
+          description: Unique identifier of the organization evaluated for deletion.
+        organizationName:
+          type: string
+          maxLength: 255
+          description: >-
+            Human-readable name of the organization evaluated for deletion. The
+            client echoes this value back as organizationNameConfirmation when
+            requesting deletion.
+        isProviderOrg:
+          type: boolean
+          description: >-
+            True when this is the shared Layer5 provider organization, which is
+            never deletable regardless of membership.
+        hasActivePaidSubscription:
+          type: boolean
+          description: >-
+            True when the organization has an active paid (non-"Personal"/free)
+            plan subscription that must be cancelled before the organization can
+            be hard-deleted.
+        crossTenantSharedResourceCount:
+          type: integer
+          minimum: 0
+          description: >-
+            Count of resources reachable from this organization that are also
+            shared into a different, surviving organization; destroying them
+            affects other tenants. When greater than zero the client must set
+            confirmSharedResourceDestruction to proceed.
+        impact:
+          $ref: "#/components/schemas/AccountDeletionImpact"
+
+    AccountDeletionImpact:
+      type: object
+      additionalProperties: false
+      description: >-
+        Per-resource counts of the objects that would be destroyed when an
+        organization is hard-deleted alongside the account.
+      required:
+        - workspaces
+        - environments
+        - designs
+        - views
+        - connections
+        - credentials
+        - members
+        - invitations
+        - academyRecords
+      properties:
+        workspaces:
+          type: integer
+          minimum: 0
+          description: Number of workspaces that would be destroyed.
+        environments:
+          type: integer
+          minimum: 0
+          description: Number of environments that would be destroyed.
+        designs:
+          type: integer
+          minimum: 0
+          description: Number of designs that would be destroyed.
+        views:
+          type: integer
+          minimum: 0
+          description: Number of views that would be destroyed.
+        connections:
+          type: integer
+          minimum: 0
+          description: Number of connections that would be destroyed.
+        credentials:
+          type: integer
+          minimum: 0
+          description: Number of credentials that would be destroyed.
+        members:
+          type: integer
+          minimum: 0
+          description: Number of organization members that would lose access.
+        invitations:
+          type: integer
+          minimum: 0
+          description: Number of pending invitations that would be revoked.
+        academyRecords:
+          type: integer
+          minimum: 0
+          description: >-
+            Number of academy records (challenges, certifications) that would be
+            destroyed.

--- a/typescript/generated/v1beta2/user/User.ts
+++ b/typescript/generated/v1beta2/user/User.ts
@@ -78,6 +78,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/identity/users/self/account-deletion-eligibility": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get account deletion eligibility
+         * @description Pre-check evaluated before an account self-deletion is confirmed. Reports whether deleting the caller's account would also require or permit hard-deleting their organization, whether that organization is the shared Layer5 provider organization or carries an active paid subscription, how many of its resources are also shared into other surviving organizations, and the per-resource blast radius of the deletion.
+         */
+        get: operations["getAccountDeletionEligibility"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/identity/users/self": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Delete the caller's own account
+         * @description Soft-deletes the caller's Layer5 Cloud user record and hard-deletes the backing identity. When deleteOrganization is true, the caller's organization is hard-deleted in the same operation, subject to server-side re-validation: the organization must not be the shared Layer5 provider organization, must not have an active paid subscription, and organizationNameConfirmation must match the stored organization name. When the organization shares resources into other surviving organizations, confirmSharedResourceDestruction must also be true. Inputs are passed as query parameters because DELETE request bodies are unreliable across the extension proxy and intermediate HTTP clients.
+         */
+        delete: operations["deleteUserAccount"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -1087,6 +1127,66 @@ export interface components {
              */
             link: string;
         };
+        /** @description Pre-check result returned before an account self-deletion is confirmed. Describes whether deleting the caller's account would also require or permit hard-deleting their organization and quantifies the blast radius. All fields are always present so the client can render the confirmation state deterministically. */
+        AccountDeletionEligibility: {
+            /** @description True when the caller is the only active member of the organization, so deleting their account would leave the organization without any active members. */
+            isSoleActiveMember: boolean;
+            /**
+             * Format: uuid
+             * @description Unique identifier of the organization evaluated for deletion.
+             */
+            organizationId: string;
+            /** @description Human-readable name of the organization evaluated for deletion. The client echoes this value back as organizationNameConfirmation when requesting deletion. */
+            organizationName: string;
+            /** @description True when this is the shared Layer5 provider organization, which is never deletable regardless of membership. */
+            isProviderOrg: boolean;
+            /** @description True when the organization has an active paid (non-"Personal"/free) plan subscription that must be cancelled before the organization can be hard-deleted. */
+            hasActivePaidSubscription: boolean;
+            /** @description Count of resources reachable from this organization that are also shared into a different, surviving organization; destroying them affects other tenants. When greater than zero the client must set confirmSharedResourceDestruction to proceed. */
+            crossTenantSharedResourceCount: number;
+            /** @description Per-resource counts of the objects that would be destroyed when an organization is hard-deleted alongside the account. */
+            impact: {
+                /** @description Number of workspaces that would be destroyed. */
+                workspaces: number;
+                /** @description Number of environments that would be destroyed. */
+                environments: number;
+                /** @description Number of designs that would be destroyed. */
+                designs: number;
+                /** @description Number of views that would be destroyed. */
+                views: number;
+                /** @description Number of connections that would be destroyed. */
+                connections: number;
+                /** @description Number of credentials that would be destroyed. */
+                credentials: number;
+                /** @description Number of organization members that would lose access. */
+                members: number;
+                /** @description Number of pending invitations that would be revoked. */
+                invitations: number;
+                /** @description Number of academy records (challenges, certifications) that would be destroyed. */
+                academyRecords: number;
+            };
+        };
+        /** @description Per-resource counts of the objects that would be destroyed when an organization is hard-deleted alongside the account. */
+        AccountDeletionImpact: {
+            /** @description Number of workspaces that would be destroyed. */
+            workspaces: number;
+            /** @description Number of environments that would be destroyed. */
+            environments: number;
+            /** @description Number of designs that would be destroyed. */
+            designs: number;
+            /** @description Number of views that would be destroyed. */
+            views: number;
+            /** @description Number of connections that would be destroyed. */
+            connections: number;
+            /** @description Number of credentials that would be destroyed. */
+            credentials: number;
+            /** @description Number of organization members that would lose access. */
+            members: number;
+            /** @description Number of pending invitations that would be revoked. */
+            invitations: number;
+            /** @description Number of academy records (challenges, certifications) that would be destroyed. */
+            academyRecords: number;
+        };
     };
     responses: {
         /** @description Invalid request body or request param */
@@ -1109,6 +1209,15 @@ export interface components {
         };
         /** @description Result not found */
         404: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "text/plain": string;
+            };
+        };
+        /** @description Publish request already exists */
+        409: {
             headers: {
                 [name: string]: unknown;
             };
@@ -2405,6 +2514,174 @@ export interface operations {
             };
             /** @description Expired JWT token used or insufficient privilege */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    getAccountDeletionEligibility: {
+        parameters: {
+            query?: {
+                /** @description Organization to evaluate for deletion alongside the account. When omitted, the caller's currently selected organization is evaluated. */
+                organizationId?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Account deletion eligibility for the caller */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        /** @description True when the caller is the only active member of the organization, so deleting their account would leave the organization without any active members. */
+                        isSoleActiveMember: boolean;
+                        /**
+                         * Format: uuid
+                         * @description Unique identifier of the organization evaluated for deletion.
+                         */
+                        organizationId: string;
+                        /** @description Human-readable name of the organization evaluated for deletion. The client echoes this value back as organizationNameConfirmation when requesting deletion. */
+                        organizationName: string;
+                        /** @description True when this is the shared Layer5 provider organization, which is never deletable regardless of membership. */
+                        isProviderOrg: boolean;
+                        /** @description True when the organization has an active paid (non-"Personal"/free) plan subscription that must be cancelled before the organization can be hard-deleted. */
+                        hasActivePaidSubscription: boolean;
+                        /** @description Count of resources reachable from this organization that are also shared into a different, surviving organization; destroying them affects other tenants. When greater than zero the client must set confirmSharedResourceDestruction to proceed. */
+                        crossTenantSharedResourceCount: number;
+                        /** @description Per-resource counts of the objects that would be destroyed when an organization is hard-deleted alongside the account. */
+                        impact: {
+                            /** @description Number of workspaces that would be destroyed. */
+                            workspaces: number;
+                            /** @description Number of environments that would be destroyed. */
+                            environments: number;
+                            /** @description Number of designs that would be destroyed. */
+                            designs: number;
+                            /** @description Number of views that would be destroyed. */
+                            views: number;
+                            /** @description Number of connections that would be destroyed. */
+                            connections: number;
+                            /** @description Number of credentials that would be destroyed. */
+                            credentials: number;
+                            /** @description Number of organization members that would lose access. */
+                            members: number;
+                            /** @description Number of pending invitations that would be revoked. */
+                            invitations: number;
+                            /** @description Number of academy records (challenges, certifications) that would be destroyed. */
+                            academyRecords: number;
+                        };
+                    };
+                };
+            };
+            /** @description Invalid request body or request param */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Expired JWT token used or insufficient privilege */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Result not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Internal server error */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+        };
+    };
+    deleteUserAccount: {
+        parameters: {
+            query?: {
+                /** @description When true, hard-delete the caller's organization along with the account. Defaults to false (delete only the account). */
+                deleteOrganization?: boolean;
+                /** @description Identifier of the organization to hard-delete. Required by the server when deleteOrganization is true. */
+                organizationId?: string;
+                /** @description User-typed organization name. The server re-validates this against the stored organization name when deleteOrganization is true and rejects the request on mismatch. */
+                organizationNameConfirmation?: string;
+                /** @description Explicit acknowledgement that resources shared into other surviving organizations will be destroyed. Required by the server when the organization's crossTenantSharedResourceCount is greater than zero. */
+                confirmSharedResourceDestruction?: boolean;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Account (and organization, when requested) deleted */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Invalid request body or request param */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Expired JWT token used or insufficient privilege */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Result not found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Publish request already exists */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/typescript/generated/v1beta2/user/UserSchema.ts
+++ b/typescript/generated/v1beta2/user/UserSchema.ts
@@ -3374,6 +3374,293 @@ const UserSchema: Record<string, unknown> = {
           }
         }
       }
+    },
+    "/api/identity/users/self/account-deletion-eligibility": {
+      "get": {
+        "x-internal": [
+          "cloud"
+        ],
+        "tags": [
+          "users"
+        ],
+        "operationId": "getAccountDeletionEligibility",
+        "summary": "Get account deletion eligibility",
+        "description": "Pre-check evaluated before an account self-deletion is confirmed. Reports whether deleting the caller's account would also require or permit hard-deleting their organization, whether that organization is the shared Layer5 provider organization or carries an active paid subscription, how many of its resources are also shared into other surviving organizations, and the per-resource blast radius of the deletion.",
+        "parameters": [
+          {
+            "name": "organizationId",
+            "in": "query",
+            "required": false,
+            "description": "Organization to evaluate for deletion alongside the account. When omitted, the caller's currently selected organization is evaluated.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Account deletion eligibility for the caller",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "Pre-check result returned before an account self-deletion is confirmed. Describes whether deleting the caller's account would also require or permit hard-deleting their organization and quantifies the blast radius. All fields are always present so the client can render the confirmation state deterministically.",
+                  "required": [
+                    "isSoleActiveMember",
+                    "organizationId",
+                    "organizationName",
+                    "isProviderOrg",
+                    "hasActivePaidSubscription",
+                    "crossTenantSharedResourceCount",
+                    "impact"
+                  ],
+                  "properties": {
+                    "isSoleActiveMember": {
+                      "type": "boolean",
+                      "description": "True when the caller is the only active member of the organization, so deleting their account would leave the organization without any active members."
+                    },
+                    "organizationId": {
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "Unique identifier of the organization evaluated for deletion."
+                    },
+                    "organizationName": {
+                      "type": "string",
+                      "maxLength": 255,
+                      "description": "Human-readable name of the organization evaluated for deletion. The client echoes this value back as organizationNameConfirmation when requesting deletion."
+                    },
+                    "isProviderOrg": {
+                      "type": "boolean",
+                      "description": "True when this is the shared Layer5 provider organization, which is never deletable regardless of membership."
+                    },
+                    "hasActivePaidSubscription": {
+                      "type": "boolean",
+                      "description": "True when the organization has an active paid (non-\"Personal\"/free) plan subscription that must be cancelled before the organization can be hard-deleted."
+                    },
+                    "crossTenantSharedResourceCount": {
+                      "type": "integer",
+                      "minimum": 0,
+                      "description": "Count of resources reachable from this organization that are also shared into a different, surviving organization; destroying them affects other tenants. When greater than zero the client must set confirmSharedResourceDestruction to proceed."
+                    },
+                    "impact": {
+                      "type": "object",
+                      "additionalProperties": false,
+                      "description": "Per-resource counts of the objects that would be destroyed when an organization is hard-deleted alongside the account.",
+                      "required": [
+                        "workspaces",
+                        "environments",
+                        "designs",
+                        "views",
+                        "connections",
+                        "credentials",
+                        "members",
+                        "invitations",
+                        "academyRecords"
+                      ],
+                      "properties": {
+                        "workspaces": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Number of workspaces that would be destroyed."
+                        },
+                        "environments": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Number of environments that would be destroyed."
+                        },
+                        "designs": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Number of designs that would be destroyed."
+                        },
+                        "views": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Number of views that would be destroyed."
+                        },
+                        "connections": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Number of connections that would be destroyed."
+                        },
+                        "credentials": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Number of credentials that would be destroyed."
+                        },
+                        "members": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Number of organization members that would lose access."
+                        },
+                        "invitations": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Number of pending invitations that would be revoked."
+                        },
+                        "academyRecords": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "description": "Number of academy records (challenges, certifications) that would be destroyed."
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body or request param",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Expired JWT token used or insufficient privilege",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Result not found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/identity/users/self": {
+      "delete": {
+        "x-internal": [
+          "cloud"
+        ],
+        "tags": [
+          "users"
+        ],
+        "operationId": "deleteUserAccount",
+        "summary": "Delete the caller's own account",
+        "description": "Soft-deletes the caller's Layer5 Cloud user record and hard-deletes the backing identity. When deleteOrganization is true, the caller's organization is hard-deleted in the same operation, subject to server-side re-validation: the organization must not be the shared Layer5 provider organization, must not have an active paid subscription, and organizationNameConfirmation must match the stored organization name. When the organization shares resources into other surviving organizations, confirmSharedResourceDestruction must also be true. Inputs are passed as query parameters because DELETE request bodies are unreliable across the extension proxy and intermediate HTTP clients.",
+        "parameters": [
+          {
+            "name": "deleteOrganization",
+            "in": "query",
+            "required": false,
+            "description": "When true, hard-delete the caller's organization along with the account. Defaults to false (delete only the account).",
+            "schema": {
+              "type": "boolean"
+            }
+          },
+          {
+            "name": "organizationId",
+            "in": "query",
+            "required": false,
+            "description": "Identifier of the organization to hard-delete. Required by the server when deleteOrganization is true.",
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            }
+          },
+          {
+            "name": "organizationNameConfirmation",
+            "in": "query",
+            "required": false,
+            "description": "User-typed organization name. The server re-validates this against the stored organization name when deleteOrganization is true and rejects the request on mismatch.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "confirmSharedResourceDestruction",
+            "in": "query",
+            "required": false,
+            "description": "Explicit acknowledgement that resources shared into other surviving organizations will be destroyed. Required by the server when the organization's crossTenantSharedResourceCount is greater than zero.",
+            "schema": {
+              "type": "boolean"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "Account (and organization, when requested) deleted"
+          },
+          "400": {
+            "description": "Invalid request body or request param",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Expired JWT token used or insufficient privilege",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Result not found",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Publish request already exists",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -3400,6 +3687,16 @@ const UserSchema: Record<string, unknown> = {
       },
       "404": {
         "description": "Result not found",
+        "content": {
+          "text/plain": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "409": {
+        "description": "Publish request already exists",
         "content": {
           "text/plain": {
             "schema": {
@@ -6352,6 +6649,175 @@ const UserSchema: Record<string, unknown> = {
           "site",
           "link"
         ]
+      },
+      "AccountDeletionEligibility": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Pre-check result returned before an account self-deletion is confirmed. Describes whether deleting the caller's account would also require or permit hard-deleting their organization and quantifies the blast radius. All fields are always present so the client can render the confirmation state deterministically.",
+        "required": [
+          "isSoleActiveMember",
+          "organizationId",
+          "organizationName",
+          "isProviderOrg",
+          "hasActivePaidSubscription",
+          "crossTenantSharedResourceCount",
+          "impact"
+        ],
+        "properties": {
+          "isSoleActiveMember": {
+            "type": "boolean",
+            "description": "True when the caller is the only active member of the organization, so deleting their account would leave the organization without any active members."
+          },
+          "organizationId": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Unique identifier of the organization evaluated for deletion."
+          },
+          "organizationName": {
+            "type": "string",
+            "maxLength": 255,
+            "description": "Human-readable name of the organization evaluated for deletion. The client echoes this value back as organizationNameConfirmation when requesting deletion."
+          },
+          "isProviderOrg": {
+            "type": "boolean",
+            "description": "True when this is the shared Layer5 provider organization, which is never deletable regardless of membership."
+          },
+          "hasActivePaidSubscription": {
+            "type": "boolean",
+            "description": "True when the organization has an active paid (non-\"Personal\"/free) plan subscription that must be cancelled before the organization can be hard-deleted."
+          },
+          "crossTenantSharedResourceCount": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Count of resources reachable from this organization that are also shared into a different, surviving organization; destroying them affects other tenants. When greater than zero the client must set confirmSharedResourceDestruction to proceed."
+          },
+          "impact": {
+            "type": "object",
+            "additionalProperties": false,
+            "description": "Per-resource counts of the objects that would be destroyed when an organization is hard-deleted alongside the account.",
+            "required": [
+              "workspaces",
+              "environments",
+              "designs",
+              "views",
+              "connections",
+              "credentials",
+              "members",
+              "invitations",
+              "academyRecords"
+            ],
+            "properties": {
+              "workspaces": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of workspaces that would be destroyed."
+              },
+              "environments": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of environments that would be destroyed."
+              },
+              "designs": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of designs that would be destroyed."
+              },
+              "views": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of views that would be destroyed."
+              },
+              "connections": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of connections that would be destroyed."
+              },
+              "credentials": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of credentials that would be destroyed."
+              },
+              "members": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of organization members that would lose access."
+              },
+              "invitations": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of pending invitations that would be revoked."
+              },
+              "academyRecords": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Number of academy records (challenges, certifications) that would be destroyed."
+              }
+            }
+          }
+        }
+      },
+      "AccountDeletionImpact": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Per-resource counts of the objects that would be destroyed when an organization is hard-deleted alongside the account.",
+        "required": [
+          "workspaces",
+          "environments",
+          "designs",
+          "views",
+          "connections",
+          "credentials",
+          "members",
+          "invitations",
+          "academyRecords"
+        ],
+        "properties": {
+          "workspaces": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of workspaces that would be destroyed."
+          },
+          "environments": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of environments that would be destroyed."
+          },
+          "designs": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of designs that would be destroyed."
+          },
+          "views": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of views that would be destroyed."
+          },
+          "connections": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of connections that would be destroyed."
+          },
+          "credentials": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of credentials that would be destroyed."
+          },
+          "members": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of organization members that would lose access."
+          },
+          "invitations": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of pending invitations that would be revoked."
+          },
+          "academyRecords": {
+            "type": "integer",
+            "minimum": 0,
+            "description": "Number of academy records (challenges, certifications) that would be destroyed."
+          }
+        }
       }
     }
   }

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -493,6 +493,31 @@ const injectedRtkApi = api
         query: () => ({ url: `/api/identity/users/profile` }),
         providesTags: ["User_users"],
       }),
+      getAccountDeletionEligibility: build.query<
+        GetAccountDeletionEligibilityApiResponse,
+        GetAccountDeletionEligibilityApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/identity/users/self/account-deletion-eligibility`,
+          params: {
+            organizationId: queryArg?.organizationId,
+          },
+        }),
+        providesTags: ["User_users"],
+      }),
+      deleteUserAccount: build.mutation<DeleteUserAccountApiResponse, DeleteUserAccountApiArg>({
+        query: (queryArg) => ({
+          url: `/api/identity/users/self`,
+          method: "DELETE",
+          params: {
+            deleteOrganization: queryArg?.deleteOrganization,
+            organizationId: queryArg?.organizationId,
+            organizationNameConfirmation: queryArg?.organizationNameConfirmation,
+            confirmSharedResourceDestruction: queryArg?.confirmSharedResourceDestruction,
+          },
+        }),
+        invalidatesTags: ["User_users"],
+      }),
       createView: build.mutation<CreateViewApiResponse, CreateViewApiArg>({
         query: (queryArg) => ({ url: `/api/content/views`, method: "POST", body: queryArg.body }),
         invalidatesTags: ["View_views"],
@@ -4214,6 +4239,56 @@ export type GetUserApiResponse = /** status 200 Current user profile and role co
   };
 };
 export type GetUserApiArg = void;
+export type GetAccountDeletionEligibilityApiResponse = /** status 200 Account deletion eligibility for the caller */ {
+  /** True when the caller is the only active member of the organization, so deleting their account would leave the organization without any active members. */
+  isSoleActiveMember: boolean;
+  /** Unique identifier of the organization evaluated for deletion. */
+  organizationId: string;
+  /** Human-readable name of the organization evaluated for deletion. The client echoes this value back as organizationNameConfirmation when requesting deletion. */
+  organizationName: string;
+  /** True when this is the shared Layer5 provider organization, which is never deletable regardless of membership. */
+  isProviderOrg: boolean;
+  /** True when the organization has an active paid (non-"Personal"/free) plan subscription that must be cancelled before the organization can be hard-deleted. */
+  hasActivePaidSubscription: boolean;
+  /** Count of resources reachable from this organization that are also shared into a different, surviving organization; destroying them affects other tenants. When greater than zero the client must set confirmSharedResourceDestruction to proceed. */
+  crossTenantSharedResourceCount: number;
+  /** Per-resource counts of the objects that would be destroyed when an organization is hard-deleted alongside the account. */
+  impact: {
+    /** Number of workspaces that would be destroyed. */
+    workspaces: number;
+    /** Number of environments that would be destroyed. */
+    environments: number;
+    /** Number of designs that would be destroyed. */
+    designs: number;
+    /** Number of views that would be destroyed. */
+    views: number;
+    /** Number of connections that would be destroyed. */
+    connections: number;
+    /** Number of credentials that would be destroyed. */
+    credentials: number;
+    /** Number of organization members that would lose access. */
+    members: number;
+    /** Number of pending invitations that would be revoked. */
+    invitations: number;
+    /** Number of academy records (challenges, certifications) that would be destroyed. */
+    academyRecords: number;
+  };
+};
+export type GetAccountDeletionEligibilityApiArg = {
+  /** Organization to evaluate for deletion alongside the account. When omitted, the caller's currently selected organization is evaluated. */
+  organizationId?: string;
+};
+export type DeleteUserAccountApiResponse = unknown;
+export type DeleteUserAccountApiArg = {
+  /** When true, hard-delete the caller's organization along with the account. Defaults to false (delete only the account). */
+  deleteOrganization?: boolean;
+  /** Identifier of the organization to hard-delete. Required by the server when deleteOrganization is true. */
+  organizationId?: string;
+  /** User-typed organization name. The server re-validates this against the stored organization name when deleteOrganization is true and rejects the request on mismatch. */
+  organizationNameConfirmation?: string;
+  /** Explicit acknowledgement that resources shared into other surviving organizations will be destroyed. Required by the server when the organization's crossTenantSharedResourceCount is greater than zero. */
+  confirmSharedResourceDestruction?: boolean;
+};
 export type CreateViewApiResponse = /** status 201 Created view */ {
   /** Unique identifier for the view. */
   id: string;
@@ -12739,6 +12814,8 @@ export const {
   useGetUsersQuery,
   useGetUserProfileByIdQuery,
   useGetUserQuery,
+  useGetAccountDeletionEligibilityQuery,
+  useDeleteUserAccountMutation,
   useCreateViewMutation,
   useGetViewsQuery,
   useShareViewMutation,


### PR DESCRIPTION
## Description

Adds the wire contract for meshery-cloud's self-service **account deletion with conditional organization deletion** feature. Additive only (no changes to existing constructs), placed on the `user` construct `v1beta2`, which already owns `/api/identity/users/*`.

### What's added
- **`AccountDeletionEligibility`** schema (+ nested **`AccountDeletionImpact`**) - the pre-check the UI calls before showing the delete confirmation. Fields (camelCase): `isSoleActiveMember`, `organizationId`, `organizationName`, `isProviderOrg`, `hasActivePaidSubscription`, `crossTenantSharedResourceCount`, and `impact` counts (workspaces, environments, designs, views, connections, credentials, members, invitations, academyRecords).
- **`getAccountDeletionEligibility`** - `GET`, returns `AccountDeletionEligibility`, optional `organizationId` query param (falls back to the caller's current org).
- The existing **`DELETE /api/identity/users/self`** operation (previously not in the schema) with query-param inputs: `deleteOrganization`, `organizationId`, `organizationNameConfirmation`, `confirmSharedResourceDestruction`.

### Notes
- DELETE uses **query params, no request body** (per `docs/http-api-design.md` / validate-schemas Rule 5; proxy-safe).
- Status codes: GET `400/401/404/500`; DELETE `204/400/401/404/409/500`. `204` is canonical for the delete; `409` covers precondition refusals (provider org / not sole member / unconfirmed shared-resource destruction).
- Both operations are `x-internal: ["cloud"]` (present in `cloud_openapi.yml`, absent from `meshery_openapi.yml`).
- Regenerated Go (`models/v1beta2/user`) + TS + cloud RTK client with the CI-pinned `oapi-codegen@v2.5.1`.
- `make validate-schemas` passes.

### Consumer
meshery-cloud will consume `useGetAccountDeletionEligibilityQuery` and `useDeleteUserAccountMutation` from `@meshery/schemas/cloudApi` after this releases.

### Follow-up for the consumer
The current meshery-cloud handler returns `201`; it will be reconciled to the canonical `204` during the handler rework for this feature.
