### PR TITLE
fix(user): canonical Uuid refs + deletion-specific 409 for account-deletion contract

### DIFF
--- a/schemas/constructs/v1beta2/user/api.yml
+++ b/schemas/constructs/v1beta2/user/api.yml
@@ -147,8 +147,7 @@ paths:
             Organization to evaluate for deletion alongside the account. When
             omitted, the caller's currently selected organization is evaluated.
           schema:
-            type: string
-            format: uuid
+            $ref: "../core/api.yml#/components/schemas/Uuid"
       responses:
         "200":
           description: Account deletion eligibility for the caller
@@ -199,8 +198,7 @@ paths:
             Identifier of the organization to hard-delete. Required by the
             server when deleteOrganization is true.
           schema:
-            type: string
-            format: uuid
+            $ref: "../core/api.yml#/components/schemas/Uuid"
         - name: organizationNameConfirmation
           in: query
           required: false
@@ -241,7 +239,16 @@ components:
     404:
       $ref: "../core/api.yml#/components/responses/404"
     409:
-      $ref: "../core/api.yml#/components/responses/409"
+      description: >-
+        Deletion preconditions were not met. Returned when the target
+        organization is the shared Layer5 provider organization, has an active
+        paid subscription, the caller is not its sole active member, the typed
+        organizationNameConfirmation did not match, or destruction of shared
+        resources was required but not confirmed.
+      content:
+        text/plain:
+          schema:
+            type: string
     500:
       $ref: "../core/api.yml#/components/responses/500"
 
@@ -937,8 +944,7 @@ components:
             so deleting their account would leave the organization without any
             active members.
         organizationId:
-          type: string
-          format: uuid
+          $ref: "../core/api.yml#/components/schemas/Uuid"
           description: Unique identifier of the organization evaluated for deletion.
         organizationName:
           type: string

--- a/schemas/constructs/v1beta2/user/api.yml
+++ b/schemas/constructs/v1beta2/user/api.yml
@@ -227,7 +227,7 @@ paths:
         "404":
           $ref: "#/components/responses/404"
         "409":
-          $ref: "#/components/responses/409"
+          $ref: "#/components/responses/AccountDeletionConflict"
         "500":
           $ref: "#/components/responses/500"
 components:
@@ -239,6 +239,10 @@ components:
     404:
       $ref: "../core/api.yml#/components/responses/404"
     409:
+      $ref: "../core/api.yml#/components/responses/409"
+    500:
+      $ref: "../core/api.yml#/components/responses/500"
+    AccountDeletionConflict:
       description: >-
         Deletion preconditions were not met. Returned when the target
         organization is the shared Layer5 provider organization, has an active
@@ -249,8 +253,6 @@ components:
         text/plain:
           schema:
             type: string
-    500:
-      $ref: "../core/api.yml#/components/responses/500"
 
   parameters:
     id:


### PR DESCRIPTION
## Description

Addresses review feedback from #988 (already merged) on the `user` construct's account-deletion contract. Source-only (`schemas/constructs/v1beta2/user/api.yml`); generated Go/TS/RTK artifacts are intentionally left to the `Generate Artifacts from schemas` workflow to refresh on merge.

### Changes
- **Reference the canonical `Uuid` schema** instead of inline `type: string, format: uuid` for the two `organizationId` query parameters (`getAccountDeletionEligibility`, `deleteUserAccount`) and the `AccountDeletionEligibility.organizationId` property. Centralizes the definition and its `x-go-type` per repo convention. The generated Go type is unchanged (`uuid.UUID`), since core `Uuid` already carries `x-go-type: uuid.UUID`.
- **Give the account-deletion `409` a deletion-specific description.** It previously `$ref`'d the core `409` ("Publish request already exists"), which is unrelated to deletion preconditions and would surface in generated docs/clients. Now a construct-local `409` with a description covering the real precondition failures (provider org, active paid subscription, not the sole active member, name-confirmation mismatch, unconfirmed shared-resource destruction), keeping the same `text/plain` string shape.

### Notes
- `make validate-schemas` passes.
- Source-only by design: per review guidance, schema PRs change the OpenAPI source and let the artifacts automation regenerate `models/`, `typescript/`, and the RTK client on merge.

Resolves the review threads on #988 (canonical `Uuid` references ×3; deletion-specific `409`; and the generated-artifacts convention).
