### PR TITLE
fix(token): correct v1beta3 required fields, deprecation marker, and operationId

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -273,9 +273,12 @@ ifeq (,$(findstring $(GOVERSION), $(INSTALLED_GO_VERSION)))
 endif
 
 # oapi-codegen
+# Pinned to the same version installed by CI (see .github/workflows/generate-artifacts-from-schemas.yml
+# and publish-openapi-docs.yml). Using @latest here would let a newer codegen version regenerate
+# every committed model with an unrelated diff on any contributor's machine that lacks a local install.
 ifeq (,$(shell command -v oapi-codegen))
 	@echo "Dependency missing: oapi-codegen. Install oapi-codegen"
 	@echo "installing oapi-codegen"
 	# for the binary install
-	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@latest
+	go install github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen@v2.5.1
 endif

--- a/models/v1beta3/token/token.go
+++ b/models/v1beta3/token/token.go
@@ -36,19 +36,19 @@ type UserToken struct {
 	Provider string `db:"provider" json:"provider" yaml:"provider"`
 
 	// AccessToken Access token value.
-	AccessToken *string `db:"access_token" json:"accessToken" yaml:"accessToken"`
+	AccessToken string `db:"access_token" json:"accessToken" yaml:"accessToken"`
 
 	// RefreshToken Refresh token value when applicable.
 	RefreshToken *string `db:"refresh_token" json:"refreshToken" yaml:"refreshToken"`
 
 	// Name Human-readable token name.
-	Name *string `db:"name" json:"name" yaml:"name"`
+	Name string `db:"name" json:"name" yaml:"name"`
 
 	// Purpose Purpose for which the token was created.
-	Purpose *string `db:"purpose" json:"purpose" yaml:"purpose"`
+	Purpose string `db:"purpose" json:"purpose" yaml:"purpose"`
 
 	// IsOAuth Whether this entry represents an OAuth session.
-	IsOAuth *bool `db:"is_oauth" json:"isOauth" yaml:"isOauth"`
+	IsOAuth bool `db:"is_oauth" json:"isOauth" yaml:"isOauth"`
 
 	// CreatedAt Timestamp when the token was created.
 	CreatedAt time.Time `db:"created_at" json:"createdAt" yaml:"createdAt"`

--- a/schemas/constructs/v1beta2/token/api.yml
+++ b/schemas/constructs/v1beta2/token/api.yml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   title: token
   x-deprecated: true
+  x-superseded-by: v1beta3
   description: Documentation for Meshery Cloud REST APIs for user tokens and sessions
   contact:
     name: Meshery Maintainers

--- a/schemas/constructs/v1beta3/token/api.yml
+++ b/schemas/constructs/v1beta3/token/api.yml
@@ -102,9 +102,9 @@ paths:
       - cloud
       tags:
       - tokens
-      summary: Get token by ID
-      operationId: getUserTokensById
-      description: Retrieves a specific token by its ID.
+      summary: Download token
+      operationId: downloadToken
+      description: Downloads a specific token by its ID for use as a local credential file (e.g. mesheryctl's auth.json). Gated by the Download Token permission and recorded as a distinct audit event from viewing or listing tokens.
       parameters:
       - $ref: '#/components/parameters/tokenId'
       responses:

--- a/schemas/constructs/v1beta3/token/templates/token_template.json
+++ b/schemas/constructs/v1beta3/token/templates/token_template.json
@@ -1,6 +1,6 @@
 {
   "id": "",
-  "userId": "",
+  "owner": "",
   "provider": "",
   "accessToken": "",
   "refreshToken": "",

--- a/schemas/constructs/v1beta3/token/token.yaml
+++ b/schemas/constructs/v1beta3/token/token.yaml
@@ -5,6 +5,12 @@ required:
 - id
 - owner
 - provider
+- accessToken
+- name
+- purpose
+- isOauth
+- createdAt
+- updatedAt
 properties:
   id:
     $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid

--- a/typescript/generated/v1beta2/token/TokenSchema.ts
+++ b/typescript/generated/v1beta2/token/TokenSchema.ts
@@ -8,6 +8,7 @@ const TokenSchema: Record<string, unknown> = {
   "info": {
     "title": "token",
     "x-deprecated": true,
+    "x-superseded-by": "v1beta3",
     "description": "Documentation for Meshery Cloud REST APIs for user tokens and sessions",
     "contact": {
       "name": "Meshery Maintainers",

--- a/typescript/generated/v1beta3/token/Token.ts
+++ b/typescript/generated/v1beta3/token/Token.ts
@@ -40,10 +40,10 @@ export interface paths {
             cookie?: never;
         };
         /**
-         * Get token by ID
-         * @description Retrieves a specific token by its ID.
+         * Download token
+         * @description Downloads a specific token by its ID for use as a local credential file (e.g. mesheryctl's auth.json). Gated by the Download Token permission and recorded as a distinct audit event from viewing or listing tokens.
          */
-        get: operations["getUserTokensById"];
+        get: operations["downloadToken"];
         put?: never;
         post?: never;
         delete?: never;
@@ -91,25 +91,25 @@ export interface components {
             /** @description Authentication provider associated with the token. */
             provider: string;
             /** @description Access token value. */
-            accessToken?: string;
+            accessToken: string;
             /** @description Refresh token value when applicable. */
             refreshToken?: string;
             /** @description Human-readable token name. */
-            name?: string;
+            name: string;
             /** @description Purpose for which the token was created. */
-            purpose?: string;
+            purpose: string;
             /** @description Whether this entry represents an OAuth session. */
-            isOauth?: boolean;
+            isOauth: boolean;
             /**
              * Format: date-time
              * @description Timestamp when the token was created.
              */
-            createdAt?: string;
+            createdAt: string;
             /**
              * Format: date-time
              * @description Timestamp when the token was last updated.
              */
-            updatedAt?: string;
+            updatedAt: string;
         };
         /** @description A paginated list of tokens. */
         TokenPage: {
@@ -128,25 +128,25 @@ export interface components {
                 /** @description Authentication provider associated with the token. */
                 provider: string;
                 /** @description Access token value. */
-                accessToken?: string;
+                accessToken: string;
                 /** @description Refresh token value when applicable. */
                 refreshToken?: string;
                 /** @description Human-readable token name. */
-                name?: string;
+                name: string;
                 /** @description Purpose for which the token was created. */
-                purpose?: string;
+                purpose: string;
                 /** @description Whether this entry represents an OAuth session. */
-                isOauth?: boolean;
+                isOauth: boolean;
                 /**
                  * Format: date-time
                  * @description Timestamp when the token was created.
                  */
-                createdAt?: string;
+                createdAt: string;
                 /**
                  * Format: date-time
                  * @description Timestamp when the token was last updated.
                  */
-                updatedAt?: string;
+                updatedAt: string;
             }[];
             /** @description Total number of tokens across all pages. */
             totalCount: number;
@@ -266,25 +266,25 @@ export interface operations {
                             /** @description Authentication provider associated with the token. */
                             provider: string;
                             /** @description Access token value. */
-                            accessToken?: string;
+                            accessToken: string;
                             /** @description Refresh token value when applicable. */
                             refreshToken?: string;
                             /** @description Human-readable token name. */
-                            name?: string;
+                            name: string;
                             /** @description Purpose for which the token was created. */
-                            purpose?: string;
+                            purpose: string;
                             /** @description Whether this entry represents an OAuth session. */
-                            isOauth?: boolean;
+                            isOauth: boolean;
                             /**
                              * Format: date-time
                              * @description Timestamp when the token was created.
                              */
-                            createdAt?: string;
+                            createdAt: string;
                             /**
                              * Format: date-time
                              * @description Timestamp when the token was last updated.
                              */
-                            updatedAt?: string;
+                            updatedAt: string;
                         }[];
                         /** @description Total number of tokens across all pages. */
                         totalCount: number;
@@ -351,25 +351,25 @@ export interface operations {
                             /** @description Authentication provider associated with the token. */
                             provider: string;
                             /** @description Access token value. */
-                            accessToken?: string;
+                            accessToken: string;
                             /** @description Refresh token value when applicable. */
                             refreshToken?: string;
                             /** @description Human-readable token name. */
-                            name?: string;
+                            name: string;
                             /** @description Purpose for which the token was created. */
-                            purpose?: string;
+                            purpose: string;
                             /** @description Whether this entry represents an OAuth session. */
-                            isOauth?: boolean;
+                            isOauth: boolean;
                             /**
                              * Format: date-time
                              * @description Timestamp when the token was created.
                              */
-                            createdAt?: string;
+                            createdAt: string;
                             /**
                              * Format: date-time
                              * @description Timestamp when the token was last updated.
                              */
-                            updatedAt?: string;
+                            updatedAt: string;
                         }[];
                         /** @description Total number of tokens across all pages. */
                         totalCount: number;
@@ -443,25 +443,25 @@ export interface operations {
                             /** @description Authentication provider associated with the token. */
                             provider: string;
                             /** @description Access token value. */
-                            accessToken?: string;
+                            accessToken: string;
                             /** @description Refresh token value when applicable. */
                             refreshToken?: string;
                             /** @description Human-readable token name. */
-                            name?: string;
+                            name: string;
                             /** @description Purpose for which the token was created. */
-                            purpose?: string;
+                            purpose: string;
                             /** @description Whether this entry represents an OAuth session. */
-                            isOauth?: boolean;
+                            isOauth: boolean;
                             /**
                              * Format: date-time
                              * @description Timestamp when the token was created.
                              */
-                            createdAt?: string;
+                            createdAt: string;
                             /**
                              * Format: date-time
                              * @description Timestamp when the token was last updated.
                              */
-                            updatedAt?: string;
+                            updatedAt: string;
                         }[];
                         /** @description Total number of tokens across all pages. */
                         totalCount: number;
@@ -501,7 +501,7 @@ export interface operations {
             };
         };
     };
-    getUserTokensById: {
+    downloadToken: {
         parameters: {
             query?: never;
             header?: never;
@@ -533,25 +533,25 @@ export interface operations {
                         /** @description Authentication provider associated with the token. */
                         provider: string;
                         /** @description Access token value. */
-                        accessToken?: string;
+                        accessToken: string;
                         /** @description Refresh token value when applicable. */
                         refreshToken?: string;
                         /** @description Human-readable token name. */
-                        name?: string;
+                        name: string;
                         /** @description Purpose for which the token was created. */
-                        purpose?: string;
+                        purpose: string;
                         /** @description Whether this entry represents an OAuth session. */
-                        isOauth?: boolean;
+                        isOauth: boolean;
                         /**
                          * Format: date-time
                          * @description Timestamp when the token was created.
                          */
-                        createdAt?: string;
+                        createdAt: string;
                         /**
                          * Format: date-time
                          * @description Timestamp when the token was last updated.
                          */
-                        updatedAt?: string;
+                        updatedAt: string;
                     };
                 };
             };
@@ -620,25 +620,25 @@ export interface operations {
                             /** @description Authentication provider associated with the token. */
                             provider: string;
                             /** @description Access token value. */
-                            accessToken?: string;
+                            accessToken: string;
                             /** @description Refresh token value when applicable. */
                             refreshToken?: string;
                             /** @description Human-readable token name. */
-                            name?: string;
+                            name: string;
                             /** @description Purpose for which the token was created. */
-                            purpose?: string;
+                            purpose: string;
                             /** @description Whether this entry represents an OAuth session. */
-                            isOauth?: boolean;
+                            isOauth: boolean;
                             /**
                              * Format: date-time
                              * @description Timestamp when the token was created.
                              */
-                            createdAt?: string;
+                            createdAt: string;
                             /**
                              * Format: date-time
                              * @description Timestamp when the token was last updated.
                              */
-                            updatedAt?: string;
+                            updatedAt: string;
                         }[];
                         /** @description Total number of tokens across all pages. */
                         totalCount: number;

--- a/typescript/generated/v1beta3/token/TokenSchema.ts
+++ b/typescript/generated/v1beta3/token/TokenSchema.ts
@@ -123,7 +123,13 @@ const TokenSchema: Record<string, unknown> = {
                         "required": [
                           "id",
                           "owner",
-                          "provider"
+                          "provider",
+                          "accessToken",
+                          "name",
+                          "purpose",
+                          "isOauth",
+                          "createdAt",
+                          "updatedAt"
                         ],
                         "properties": {
                           "id": {
@@ -356,7 +362,13 @@ const TokenSchema: Record<string, unknown> = {
                         "required": [
                           "id",
                           "owner",
-                          "provider"
+                          "provider",
+                          "accessToken",
+                          "name",
+                          "purpose",
+                          "isOauth",
+                          "createdAt",
+                          "updatedAt"
                         ],
                         "properties": {
                           "id": {
@@ -594,7 +606,13 @@ const TokenSchema: Record<string, unknown> = {
                         "required": [
                           "id",
                           "owner",
-                          "provider"
+                          "provider",
+                          "accessToken",
+                          "name",
+                          "purpose",
+                          "isOauth",
+                          "createdAt",
+                          "updatedAt"
                         ],
                         "properties": {
                           "id": {
@@ -789,9 +807,9 @@ const TokenSchema: Record<string, unknown> = {
         "tags": [
           "tokens"
         ],
-        "summary": "Get token by ID",
-        "operationId": "getUserTokensById",
-        "description": "Retrieves a specific token by its ID.",
+        "summary": "Download token",
+        "operationId": "downloadToken",
+        "description": "Downloads a specific token by its ID for use as a local credential file (e.g. mesheryctl's auth.json). Gated by the Download Token permission and recorded as a distinct audit event from viewing or listing tokens.",
         "parameters": [
           {
             "name": "tokenId",
@@ -821,7 +839,13 @@ const TokenSchema: Record<string, unknown> = {
                   "required": [
                     "id",
                     "owner",
-                    "provider"
+                    "provider",
+                    "accessToken",
+                    "name",
+                    "purpose",
+                    "isOauth",
+                    "createdAt",
+                    "updatedAt"
                   ],
                   "properties": {
                     "id": {
@@ -1039,7 +1063,13 @@ const TokenSchema: Record<string, unknown> = {
                         "required": [
                           "id",
                           "owner",
-                          "provider"
+                          "provider",
+                          "accessToken",
+                          "name",
+                          "purpose",
+                          "isOauth",
+                          "createdAt",
+                          "updatedAt"
                         ],
                         "properties": {
                           "id": {
@@ -1402,7 +1432,13 @@ const TokenSchema: Record<string, unknown> = {
         "required": [
           "id",
           "owner",
-          "provider"
+          "provider",
+          "accessToken",
+          "name",
+          "purpose",
+          "isOauth",
+          "createdAt",
+          "updatedAt"
         ],
         "properties": {
           "id": {
@@ -1541,7 +1577,13 @@ const TokenSchema: Record<string, unknown> = {
               "required": [
                 "id",
                 "owner",
-                "provider"
+                "provider",
+                "accessToken",
+                "name",
+                "purpose",
+                "isOauth",
+                "createdAt",
+                "updatedAt"
               ],
               "properties": {
                 "id": {

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -1404,7 +1404,7 @@ const injectedRtkApi = api
         }),
         invalidatesTags: ["token_tokens"],
       }),
-      getUserTokensById: build.query<GetUserTokensByIdApiResponse, GetUserTokensByIdApiArg>({
+      downloadToken: build.query<DownloadTokenApiResponse, DownloadTokenApiArg>({
         query: (queryArg) => ({ url: `/api/identity/tokens/${queryArg.tokenId}` }),
         providesTags: ["token_tokens"],
       }),
@@ -11159,19 +11159,19 @@ export type GetUserTokensApiResponse = /** status 200 Tokens response */ {
     /** Authentication provider associated with the token. */
     provider: string;
     /** Access token value. */
-    accessToken?: string;
+    accessToken: string;
     /** Refresh token value when applicable. */
     refreshToken?: string;
     /** Human-readable token name. */
-    name?: string;
+    name: string;
     /** Purpose for which the token was created. */
-    purpose?: string;
+    purpose: string;
     /** Whether this entry represents an OAuth session. */
-    isOauth?: boolean;
+    isOauth: boolean;
     /** Timestamp when the token was created. */
-    createdAt?: string;
+    createdAt: string;
     /** Timestamp when the token was last updated. */
-    updatedAt?: string;
+    updatedAt: string;
   }[];
   /** Total number of tokens across all pages. */
   totalCount: number;
@@ -11202,19 +11202,19 @@ export type GenerateTokenApiResponse = /** status 201 Token generated */ {
     /** Authentication provider associated with the token. */
     provider: string;
     /** Access token value. */
-    accessToken?: string;
+    accessToken: string;
     /** Refresh token value when applicable. */
     refreshToken?: string;
     /** Human-readable token name. */
-    name?: string;
+    name: string;
     /** Purpose for which the token was created. */
-    purpose?: string;
+    purpose: string;
     /** Whether this entry represents an OAuth session. */
-    isOauth?: boolean;
+    isOauth: boolean;
     /** Timestamp when the token was created. */
-    createdAt?: string;
+    createdAt: string;
     /** Timestamp when the token was last updated. */
-    updatedAt?: string;
+    updatedAt: string;
   }[];
   /** Total number of tokens across all pages. */
   totalCount: number;
@@ -11239,19 +11239,19 @@ export type DeleteUserTokenApiResponse = /** status 200 Token deleted */ {
     /** Authentication provider associated with the token. */
     provider: string;
     /** Access token value. */
-    accessToken?: string;
+    accessToken: string;
     /** Refresh token value when applicable. */
     refreshToken?: string;
     /** Human-readable token name. */
-    name?: string;
+    name: string;
     /** Purpose for which the token was created. */
-    purpose?: string;
+    purpose: string;
     /** Whether this entry represents an OAuth session. */
-    isOauth?: boolean;
+    isOauth: boolean;
     /** Timestamp when the token was created. */
-    createdAt?: string;
+    createdAt: string;
     /** Timestamp when the token was last updated. */
-    updatedAt?: string;
+    updatedAt: string;
   }[];
   /** Total number of tokens across all pages. */
   totalCount: number;
@@ -11264,7 +11264,7 @@ export type DeleteUserTokenApiArg = {
   /** ID of the token to delete. */
   tokenId: string;
 };
-export type GetUserTokensByIdApiResponse = /** status 200 Token response */ {
+export type DownloadTokenApiResponse = /** status 200 Token response */ {
   /** Unique identifier for the token. */
   id: string;
   /** UUID of the user who owns the token. */
@@ -11272,21 +11272,21 @@ export type GetUserTokensByIdApiResponse = /** status 200 Token response */ {
   /** Authentication provider associated with the token. */
   provider: string;
   /** Access token value. */
-  accessToken?: string;
+  accessToken: string;
   /** Refresh token value when applicable. */
   refreshToken?: string;
   /** Human-readable token name. */
-  name?: string;
+  name: string;
   /** Purpose for which the token was created. */
-  purpose?: string;
+  purpose: string;
   /** Whether this entry represents an OAuth session. */
-  isOauth?: boolean;
+  isOauth: boolean;
   /** Timestamp when the token was created. */
-  createdAt?: string;
+  createdAt: string;
   /** Timestamp when the token was last updated. */
-  updatedAt?: string;
+  updatedAt: string;
 };
-export type GetUserTokensByIdApiArg = {
+export type DownloadTokenApiArg = {
   /** Token ID */
   tokenId: string;
 };
@@ -11300,19 +11300,19 @@ export type IssueIndefiniteLifetimeTokenApiResponse = /** status 200 Token gener
     /** Authentication provider associated with the token. */
     provider: string;
     /** Access token value. */
-    accessToken?: string;
+    accessToken: string;
     /** Refresh token value when applicable. */
     refreshToken?: string;
     /** Human-readable token name. */
-    name?: string;
+    name: string;
     /** Purpose for which the token was created. */
-    purpose?: string;
+    purpose: string;
     /** Whether this entry represents an OAuth session. */
-    isOauth?: boolean;
+    isOauth: boolean;
     /** Timestamp when the token was created. */
-    createdAt?: string;
+    createdAt: string;
     /** Timestamp when the token was last updated. */
-    updatedAt?: string;
+    updatedAt: string;
   }[];
   /** Total number of tokens across all pages. */
   totalCount: number;
@@ -12955,7 +12955,7 @@ export const {
   useGetUserTokensQuery,
   useGenerateTokenMutation,
   useDeleteUserTokenMutation,
-  useGetUserTokensByIdQuery,
+  useDownloadTokenQuery,
   useIssueIndefiniteLifetimeTokenQuery,
   useGetWorkspacesQuery,
   useCreateWorkspaceMutation,


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #980

Verified the existing v1beta2/v1beta3 `token` construct (issue #980 asked to create it, but it already existed in a more advanced state than the issue anticipated) field-by-field against the real `layer5io/meshery-cloud` router, handlers, DAO, and DB migrations.

- `token.yaml`: `accessToken`, `name`, `purpose`, `isOauth`, `createdAt`, and `updatedAt` are all `NOT NULL` in the real `user_tokens` table but were missing from `required`, generating as unnecessarily optional/pointer fields in Go and TypeScript.
- `v1beta2/api.yml`: add the `x-superseded-by: v1beta3` marker present on every sibling construct that went through the same deprecation, absent here.
- `v1beta3/api.yml`: rename operationId `getUserTokensById` -> `downloadToken` for `GET /api/identity/tokens/{tokenId}`. The real handler is `DownloadToken`, a distinctly audit-logged, RBAC-gated ("Download Token" vs "View Tokens") action, not a generic get-by-id lookup.
- `token_template.json`: fix a stale `"userId"` key left over from an earlier `owner` rename (`token_template.yaml` already had the correct key).
- `Makefile`: pin the local oapi-codegen fallback to `v2.5.1`, matching what CI already installs. The previous `@latest` fallback silently regenerates every committed Go model with a newer, mismatched tool version's output on any machine without oapi-codegen pre-installed (this is exactly what happened while preparing this PR; the diff below is hand-reconciled down to just the 9 token-related files after isolating the tool-version noise).

Two follow-ups filed, not part of this PR:
- #997: the real, deployed token routes live under `/api/identity/tokens*`, but `docs/http-api-design.md`'s resource-grouping convention (and the `key`/`keychain` siblings) say tokens belong under `/api/auth/`. Fixing this is a breaking, coordinated cross-repo change, not a schema-only edit.
- layer5io/meshery-cloud#5615: the ownership-consolidation migration renamed the wire field for 5 other constructs (`connection`, `event`, `filter`, `invitation`, `performance_profile`) the same way it did for `token`; only `token`'s Go struct was confirmed to have a stale JSON tag (fixed in the companion layer5io/meshery-cloud#5618), the other 5 need the same audit.

Companion `meshery-cloud` fix (`UserToken.UserID` -> `Owner` JSON tag, `GetTokenByID` column completeness, and a token-download ownership check): layer5io/meshery-cloud#5618

`go build`, `go test ./...`, `npm run build`, and `make validate-schemas` all pass. `make audit-schemas` and `make consumer-audit` (run against a local `meshery-cloud` checkout) show zero token-related findings.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.