### PR TITLE
[schemas] Close remaining gaps from issue #973 schema $ref audit

### DIFF
--- a/schemas/constructs/v1beta1/model/api.yml
+++ b/schemas/constructs/v1beta1/model/api.yml
@@ -282,6 +282,5 @@ components:
         models:
           type: array
           items:
-            type: object
-            additionalProperties: true
-          description: The models of the meshmodelmodelspage.
+            $ref: "#/components/schemas/Model"
+          description: The models matching the list-endpoint query.

--- a/schemas/constructs/v1beta1/user/api.yml
+++ b/schemas/constructs/v1beta1/user/api.yml
@@ -370,7 +370,7 @@ components:
               type: array
               description: Team memberships for the user with their assigned roles.
               items:
-                type: object
+                $ref: "#/components/schemas/TeamWithRoles"
               x-oapi-codegen-extra-tags:
                 db: "teams_with_roles"
                 json: "teams_with_roles"
@@ -392,7 +392,7 @@ components:
               type: array
               description: Organization memberships for the user with their assigned roles.
               items:
-                type: object
+                $ref: "#/components/schemas/OrganizationWithRoles"
               x-oapi-codegen-extra-tags:
                 db: "organizations_with_roles"
                 json: "organizations_with_roles"
@@ -404,6 +404,126 @@ components:
                 db: "total_count"
                 json: "total_count"
       additionalProperties: false
+
+    TeamWithRoles:
+      type: object
+      additionalProperties: false
+      description: >-
+        A team the user is a member of, together with the names of the roles
+        assigned to that user within the team. Returned as an item of
+        User.teams.teams_with_roles. The role names are dynamic,
+        user-generated values (no fixed enumeration).
+      required:
+        - id
+        - name
+        - role_names
+      properties:
+        id:
+          $ref: "../core/api.yml#/components/schemas/uuid"
+          description: Unique identifier of the team.
+          x-oapi-codegen-extra-tags:
+            db: "id"
+            json: "id"
+        name:
+          type: string
+          description: Name of the team.
+          x-oapi-codegen-extra-tags:
+            db: "name"
+            json: "name"
+        description:
+          type: string
+          description: Human readable description of the team.
+          x-oapi-codegen-extra-tags:
+            db: "description"
+            json: "description"
+        owner:
+          $ref: "../core/api.yml#/components/schemas/uuid"
+          description: Identifier of the team owner.
+          x-oapi-codegen-extra-tags:
+            db: "owner"
+            json: "owner"
+        created_at:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the team was created.
+          x-oapi-codegen-extra-tags:
+            db: "created_at"
+            json: "created_at"
+        updated_at:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the team was last updated.
+          x-oapi-codegen-extra-tags:
+            db: "updated_at"
+            json: "updated_at"
+        role_names:
+          type: array
+          items:
+            type: string
+          description: >-
+            Names of the roles assigned to the user within this team.
+            Free-form, user-generated role names; not a fixed enumeration.
+          x-oapi-codegen-extra-tags:
+            db: "role_names"
+            json: "role_names"
+
+    OrganizationWithRoles:
+      type: object
+      additionalProperties: false
+      description: >-
+        An organization the user is a member of, together with the names of
+        the roles assigned to that user within the organization. Returned as
+        an item of User.organizations.organizations_with_roles. The role
+        names are dynamic, user-generated values (no fixed enumeration).
+      required:
+        - id
+        - name
+        - role_names
+      properties:
+        id:
+          $ref: "../core/api.yml#/components/schemas/uuid"
+          description: Unique identifier of the organization.
+          x-oapi-codegen-extra-tags:
+            db: "id"
+            json: "id"
+        name:
+          type: string
+          description: Name of the organization.
+          x-oapi-codegen-extra-tags:
+            db: "name"
+            json: "name"
+        description:
+          type: string
+          description: Human readable description of the organization.
+          x-oapi-codegen-extra-tags:
+            db: "description"
+            json: "description"
+        owner:
+          $ref: "../core/api.yml#/components/schemas/uuid"
+          description: Identifier of the organization owner.
+          x-oapi-codegen-extra-tags:
+            db: "owner"
+            json: "owner"
+        created_at:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the organization was created.
+          x-oapi-codegen-extra-tags:
+            db: "created_at"
+            json: "created_at"
+        updated_at:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the organization was last updated.
+          x-oapi-codegen-extra-tags:
+            db: "updated_at"
+            json: "updated_at"
+        role_names:
+          type: array
+          items:
+            type: string
+          description: >-
+            Names of the roles assigned to the user within this organization.
+            Free-form, user-generated role names; not a fixed enumeration.
+          x-oapi-codegen-extra-tags:
+            db: "role_names"
+            json: "role_names"
 
     UsersPageForAdmin:
       type: object

--- a/schemas/constructs/v1beta2/model/api.yml
+++ b/schemas/constructs/v1beta2/model/api.yml
@@ -294,9 +294,8 @@ components:
         models:
           type: array
           items:
-            type: object
-            additionalProperties: true
-          description: The models of the meshmodelmodelspage.
+            $ref: "#/components/schemas/Model"
+          description: The models matching the list-endpoint query.
 
     MesheryModelImportFormPayload:
       type: object


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes the remaining items from #973 that #975 didn't address (found while reviewing #975):

- `MeshModelModelsPage.models` (v1beta1, v1beta2) — issue #973 listed this as item 2 of 6, but it was left as a generic `type: object` / `additionalProperties: true` placeholder. Now references the `Model` schema, matching the same pattern used elsewhere in #973's fixes.
- `User.teams.teams_with_roles` / `User.organizations.organizations_with_roles` (v1beta1) — these were pointed at the bare `Team`/`Organization` entity schemas, which have no role field, losing the per-membership role data the field names and descriptions ("...with their assigned roles") promise. Adds `TeamWithRoles`/`OrganizationWithRoles` schemas to v1beta1 (snake_case, matching v1beta1's existing wire casing) mirroring the pattern `v1beta2/user/api.yml` already uses correctly for the identical fields, and points both fields at them instead.

Verified with `go run ./cmd/validate-schemas`, `node build/bundle-openapi.js`, `node build/generate-golang.js`, and `go test ./...` — all pass.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.