### PR TITLE
feat(identifier-uniformity): additive foundation (pageSize param, TeamPayload fields) + complete #1000

### DIFF
--- a/models/v1beta1/model/model.go
+++ b/models/v1beta1/model/model.go
@@ -85,8 +85,8 @@ type ImportRequestUploadType string
 
 // MeshModelModelsPage defines model for MeshModelModelsPage.
 type MeshModelModelsPage struct {
-	// Models The models of the meshmodelmodelspage.
-	Models *[]map[string]interface{} `json:"models,omitempty" yaml:"models,omitempty"`
+	// Models The models matching the list-endpoint query.
+	Models *[]Model `json:"models,omitempty" yaml:"models,omitempty"`
 
 	// Page Current page number of the result set.
 	Page *int `json:"page,omitempty" yaml:"page,omitempty"`

--- a/models/v1beta1/user/user.go
+++ b/models/v1beta1/user/user.go
@@ -64,6 +64,27 @@ type LoadTestPreferences struct {
 	T *string `json:"t,omitempty" yaml:"t,omitempty"`
 }
 
+// OrganizationWithRoles An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizations_with_roles. The role names are dynamic, user-generated values (no fixed enumeration).
+type OrganizationWithRoles struct {
+	CreatedAt core.Time `db:"created_at" json:"created_at" yaml:"created_at,omitempty"`
+
+	// Description Human readable description of the organization.
+	Description *string `db:"description" json:"description" yaml:"description"`
+
+	// Id A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	ID core.Uuid `db:"id" json:"id" yaml:"id"`
+
+	// Name Name of the organization.
+	Name string `db:"name" json:"name" yaml:"name"`
+
+	// Owner A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	Owner *core.Uuid `db:"owner" json:"owner" yaml:"owner,omitempty"`
+
+	// RoleNames Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.
+	RoleNames []string          `db:"role_names" json:"role_names" yaml:"role_names"`
+	UpdatedAt core.Time `db:"updated_at" json:"updated_at" yaml:"updated_at,omitempty"`
+}
+
 // Panel Grafana panel structure imported from github.com/grafana-tools/sdk
 type Panel = map[string]interface{}
 
@@ -130,6 +151,27 @@ type Social struct {
 	Site string `json:"site" yaml:"site"`
 }
 
+// TeamWithRoles A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teams_with_roles. The role names are dynamic, user-generated values (no fixed enumeration).
+type TeamWithRoles struct {
+	CreatedAt core.Time `db:"created_at" json:"created_at" yaml:"created_at,omitempty"`
+
+	// Description Human readable description of the team.
+	Description *string `db:"description" json:"description" yaml:"description"`
+
+	// Id A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	ID core.Uuid `db:"id" json:"id" yaml:"id"`
+
+	// Name Name of the team.
+	Name string `db:"name" json:"name" yaml:"name"`
+
+	// Owner A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	Owner *core.Uuid `db:"owner" json:"owner" yaml:"owner,omitempty"`
+
+	// RoleNames Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.
+	RoleNames []string          `db:"role_names" json:"role_names" yaml:"role_names"`
+	UpdatedAt core.Time `db:"updated_at" json:"updated_at" yaml:"updated_at,omitempty"`
+}
+
 // User Represents a user
 type User struct {
 	AcceptedTermsAt core.Time `db:"accepted_terms_at" json:"accepted_terms_at" yaml:"accepted_terms_at,omitempty"`
@@ -164,7 +206,7 @@ type User struct {
 	// Organizations Organizations the user belongs to with role information
 	Organizations *struct {
 		// OrganizationsWithRoles Organization memberships for the user with their assigned roles.
-		OrganizationsWithRoles *[]map[string]interface{} `db:"organizations_with_roles" json:"organizations_with_roles" yaml:"organizations_with_roles"`
+		OrganizationsWithRoles *[]OrganizationWithRoles `db:"organizations_with_roles" json:"organizations_with_roles" yaml:"organizations_with_roles"`
 
 		// TotalCount Total number of organization memberships returned for the user.
 		TotalCount *int `db:"total_count" json:"total_count" yaml:"total_count"`
@@ -189,7 +231,7 @@ type User struct {
 	// Teams Teams the user belongs to with role information
 	Teams *struct {
 		// TeamsWithRoles Team memberships for the user with their assigned roles.
-		TeamsWithRoles *[]map[string]interface{} `db:"teams_with_roles" json:"teams_with_roles" yaml:"teams_with_roles"`
+		TeamsWithRoles *[]TeamWithRoles `db:"teams_with_roles" json:"teams_with_roles" yaml:"teams_with_roles"`
 
 		// TotalCount Total number of team memberships returned for the user.
 		TotalCount *int `db:"total_count" json:"total_count" yaml:"total_count"`

--- a/models/v1beta2/core/core.go
+++ b/models/v1beta2/core/core.go
@@ -935,6 +935,9 @@ type Os = string
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/models/v1beta2/model/model.go
+++ b/models/v1beta2/model/model.go
@@ -92,8 +92,8 @@ type ImportRequestUploadType string
 
 // MeshModelModelsPage Page of mesh models matching the list-endpoint query.
 type MeshModelModelsPage struct {
-	// Models The models of the meshmodelmodelspage.
-	Models *[]map[string]interface{} `json:"models,omitempty" yaml:"models,omitempty"`
+	// Models The models matching the list-endpoint query.
+	Models *[]Model `json:"models,omitempty" yaml:"models,omitempty"`
 
 	// Page Current page number of the result set.
 	Page *int `json:"page,omitempty" yaml:"page,omitempty"`

--- a/models/v1beta2/team/team.go
+++ b/models/v1beta2/team/team.go
@@ -73,7 +73,13 @@ type TeamPage struct {
 // TeamPayload Payload for creating a new team
 type TeamPayload struct {
 	Description core.Text `json:"description,omitempty" yaml:"description,omitempty"`
-	Name        core.Text `json:"name" yaml:"name"`
+
+	// Metadata Additional client-supplied metadata for the team.
+	Metadata *map[string]interface{} `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Name     core.Text       `json:"name" yaml:"name"`
+
+	// NotifyTeamUpdate Whether to notify team members when the team is created or updated.
+	NotifyTeamUpdate *bool `json:"notifyTeamUpdate,omitempty" yaml:"notifyTeamUpdate,omitempty"`
 }
 
 // TeamUpdatePayload Payload for updating an existing team

--- a/schemas/constructs/v1beta1/model/api.yml
+++ b/schemas/constructs/v1beta1/model/api.yml
@@ -282,6 +282,5 @@ components:
         models:
           type: array
           items:
-            type: object
-            additionalProperties: true
-          description: The models of the meshmodelmodelspage.
+            $ref: "#/components/schemas/Model"
+          description: The models matching the list-endpoint query.

--- a/schemas/constructs/v1beta1/user/api.yml
+++ b/schemas/constructs/v1beta1/user/api.yml
@@ -370,7 +370,7 @@ components:
               type: array
               description: Team memberships for the user with their assigned roles.
               items:
-                type: object
+                $ref: "#/components/schemas/TeamWithRoles"
               x-oapi-codegen-extra-tags:
                 db: "teams_with_roles"
                 json: "teams_with_roles"
@@ -392,7 +392,7 @@ components:
               type: array
               description: Organization memberships for the user with their assigned roles.
               items:
-                type: object
+                $ref: "#/components/schemas/OrganizationWithRoles"
               x-oapi-codegen-extra-tags:
                 db: "organizations_with_roles"
                 json: "organizations_with_roles"
@@ -404,6 +404,126 @@ components:
                 db: "total_count"
                 json: "total_count"
       additionalProperties: false
+
+    TeamWithRoles:
+      type: object
+      additionalProperties: false
+      description: >-
+        A team the user is a member of, together with the names of the roles
+        assigned to that user within the team. Returned as an item of
+        User.teams.teams_with_roles. The role names are dynamic,
+        user-generated values (no fixed enumeration).
+      required:
+        - id
+        - name
+        - role_names
+      properties:
+        id:
+          $ref: "../core/api.yml#/components/schemas/uuid"
+          description: Unique identifier of the team.
+          x-oapi-codegen-extra-tags:
+            db: "id"
+            json: "id"
+        name:
+          type: string
+          description: Name of the team.
+          x-oapi-codegen-extra-tags:
+            db: "name"
+            json: "name"
+        description:
+          type: string
+          description: Human readable description of the team.
+          x-oapi-codegen-extra-tags:
+            db: "description"
+            json: "description"
+        owner:
+          $ref: "../core/api.yml#/components/schemas/uuid"
+          description: Identifier of the team owner.
+          x-oapi-codegen-extra-tags:
+            db: "owner"
+            json: "owner"
+        created_at:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the team was created.
+          x-oapi-codegen-extra-tags:
+            db: "created_at"
+            json: "created_at"
+        updated_at:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the team was last updated.
+          x-oapi-codegen-extra-tags:
+            db: "updated_at"
+            json: "updated_at"
+        role_names:
+          type: array
+          items:
+            type: string
+          description: >-
+            Names of the roles assigned to the user within this team.
+            Free-form, user-generated role names; not a fixed enumeration.
+          x-oapi-codegen-extra-tags:
+            db: "role_names"
+            json: "role_names"
+
+    OrganizationWithRoles:
+      type: object
+      additionalProperties: false
+      description: >-
+        An organization the user is a member of, together with the names of
+        the roles assigned to that user within the organization. Returned as
+        an item of User.organizations.organizations_with_roles. The role
+        names are dynamic, user-generated values (no fixed enumeration).
+      required:
+        - id
+        - name
+        - role_names
+      properties:
+        id:
+          $ref: "../core/api.yml#/components/schemas/uuid"
+          description: Unique identifier of the organization.
+          x-oapi-codegen-extra-tags:
+            db: "id"
+            json: "id"
+        name:
+          type: string
+          description: Name of the organization.
+          x-oapi-codegen-extra-tags:
+            db: "name"
+            json: "name"
+        description:
+          type: string
+          description: Human readable description of the organization.
+          x-oapi-codegen-extra-tags:
+            db: "description"
+            json: "description"
+        owner:
+          $ref: "../core/api.yml#/components/schemas/uuid"
+          description: Identifier of the organization owner.
+          x-oapi-codegen-extra-tags:
+            db: "owner"
+            json: "owner"
+        created_at:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the organization was created.
+          x-oapi-codegen-extra-tags:
+            db: "created_at"
+            json: "created_at"
+        updated_at:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the organization was last updated.
+          x-oapi-codegen-extra-tags:
+            db: "updated_at"
+            json: "updated_at"
+        role_names:
+          type: array
+          items:
+            type: string
+          description: >-
+            Names of the roles assigned to the user within this organization.
+            Free-form, user-generated role names; not a fixed enumeration.
+          x-oapi-codegen-extra-tags:
+            db: "role_names"
+            json: "role_names"
 
     UsersPageForAdmin:
       type: object

--- a/schemas/constructs/v1beta2/core/api.yml
+++ b/schemas/constructs/v1beta2/core/api.yml
@@ -975,6 +975,13 @@ components:
       description: Get responses by pagesize (pass all to get all responses)
       schema:
         type: string
+    pageSize:
+      name: pageSize
+      in: query
+      description: Number of responses to return per page. Canonical camelCase pagination parameter; prefer this over the deprecated all-lowercase `pagesize`.
+      schema:
+        type: integer
+        minimum: 1
     order:
       name: order
       in: query

--- a/schemas/constructs/v1beta2/model/api.yml
+++ b/schemas/constructs/v1beta2/model/api.yml
@@ -294,9 +294,8 @@ components:
         models:
           type: array
           items:
-            type: object
-            additionalProperties: true
-          description: The models of the meshmodelmodelspage.
+            $ref: "#/components/schemas/Model"
+          description: The models matching the list-endpoint query.
 
     MesheryModelImportFormPayload:
       type: object

--- a/schemas/constructs/v1beta2/team/api.yml
+++ b/schemas/constructs/v1beta2/team/api.yml
@@ -91,6 +91,13 @@ components:
         description:
           $ref: ../../v1alpha1/core/api.yml#/components/schemas/Text
           description: A detailed description of the team's purpose and responsibilities.
+        notifyTeamUpdate:
+          type: boolean
+          description: Whether to notify team members when the team is created or updated.
+        metadata:
+          type: object
+          additionalProperties: true
+          description: Additional client-supplied metadata for the team.
 
     TeamUpdatePayload:
       type: object


### PR DESCRIPTION
## What

Schemas-first **additive foundation** for the identifier-naming & schema-driven uniformity program (surfaced by a ~100-agent cross-repo audit; full plan lives in `meshery-cloud/docs/plans/schemas-cloud-identifier-uniformity-remediation.md`). Every change here is **non-breaking**; the wire-breaking recasings are deferred to their own versioned PRs.

### Changes
- **core v1beta2:** add a canonical `pageSize` query parameter alongside the deprecated all-lowercase `pagesize`, so constructs can migrate request params to camelCase without a version bump.
- **team v1beta2:** extend `TeamPayload` with `notifyTeamUpdate` (bool) and `metadata` (object) so meshery-cloud can retire its hand-rolled `server/models/model_team_payload.go` and consume `team.TeamPayload`.
- **Incorporates and completes #1000** (issue #973 `$ref` gaps): `MeshModelModelsPage.models` → `Model` ref (v1beta1/v1beta2); v1beta1 `TeamWithRoles`/`OrganizationWithRoles` schemas for the with-roles user fields. #1000 changed only the OpenAPI YAML and left the generated Go stale — this PR **regenerates the Go models** it omitted, so `models/v1beta1/{model,user}` and `models/v1beta2/model` match the spec. Supersedes #1000.

## Why
meshery-cloud hand-rolls wire/DB constructs and RTK endpoints instead of consuming `@meshery/schemas`; local and canonical types drift independently and the wire contract silently forks (the Teams/credentials/keychains count regressions were live instances). These additive changes unblock cloud consuming the canonical types.

## Verification
- `make generate-golang` — deterministic (verified zero-diff on a clean tree); Go models regenerated.
- `make validate-schemas` — pass.
- `go run ./cmd/consumer-audit --cloud-repo ../meshery-cloud --meshery-repo ../meshery` — 0 blocking violations.
- TypeScript/dist regeneration intentionally omitted: the local `openapi-typescript` (5.4.2) rewrites every generated `.ts` with version-drift noise; leave TS regen to the canonical toolchain/CI.

## Notes
- A draft filter `owner` db-tag change was dropped: a fresh production schema dump proved the live column is `owner`, not `user_id` (the committed cloud-schema snapshot was stale, pre owner-consolidation). The existing `db:"owner"` is correct.

Signed-off-by per DCO.
