### PR TITLE
[connection] fix: add ConnectionDefinitionPayload for POST/PUT request bodies (section 2C)

### DIFF
--- a/models/v1beta3/connection/connection.go
+++ b/models/v1beta3/connection/connection.go
@@ -118,6 +118,54 @@ type ConnectionDefinitionPage struct {
 	PageSize int `json:"pageSize" yaml:"pageSize"`
 }
 
+// ConnectionDefinitionPayload Payload for registering (creating) or updating a connection definition. Contains only client-settable fields; server-generated fields such as createdAt, updatedAt, and deletedAt are excluded.
+type ConnectionDefinitionPayload struct {
+	// ConnectionSchema Schema for connections of this kind.
+	ConnectionSchema core.Map `json:"connectionSchema" yaml:"connectionSchema"`
+
+	// CredentialSchema Schema for the credential associated with connections of this kind.
+	CredentialSchema core.Map `json:"credentialSchema" yaml:"credentialSchema"`
+
+	// Description Human-readable description of the connection definition and its purpose.
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// ID Existing connection definition ID for updates; omit on create.
+	ID *uuid.UUID `json:"id,omitempty" yaml:"id,omitempty"`
+
+	// Kind Connection kind (e.g., kubernetes, prometheus, grafana)
+	Kind string `json:"kind" yaml:"kind"`
+
+	// Metadata Kind-specific connection metadata
+	Metadata core.Map `json:"metadata" yaml:"metadata"`
+
+	// ModelReference Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models
+	ModelReference *modelv1beta1.ModelReference `json:"modelReference,omitempty" yaml:"modelReference,omitempty"`
+
+	// Name Connection definition name
+	Name string `json:"name" yaml:"name"`
+
+	// SchemaVersion API version of the object, optionally prefixed with an API group (e.g. "group.example.io/v1beta1" or bare "v1beta1").
+	SchemaVersion *core.VersionString `json:"schemaVersion,omitempty" yaml:"schemaVersion,omitempty"`
+
+	// ConnectionStatusValue Connection Status Value
+	Status ConnectionStatusValue `json:"status" yaml:"status"`
+
+	// Styles Visualization styles for a component
+	Styles *core.ComponentStyles `json:"styles,omitempty" yaml:"styles,omitempty"`
+
+	// SubType Connection sub-type (cloud, identity, metrics, chat, git, orchestration)
+	SubType string `json:"subType" yaml:"subType"`
+
+	// TransitionMap Map describing the connection state machine. Each key is a current connection status and its value is the list of states the connection may transition to from that status.
+	TransitionMap map[string][]ConnectionStateTransition `json:"transitionMap,omitempty" yaml:"transitionMap,omitempty"`
+
+	// Type Connection type (platform, telemetry, collaboration)
+	Type string `json:"type" yaml:"type"`
+
+	// Url URL of the remote resource connections of this kind point to.
+	Url *string `json:"url,omitempty" yaml:"url,omitempty"`
+}
+
 // ConnectionPage Represents a page of connections with meta information about connections count
 type ConnectionPage struct {
 	// Connections List of connections on this page

--- a/schemas/constructs/v1beta3/connection/api.yml
+++ b/schemas/constructs/v1beta3/connection/api.yml
@@ -321,7 +321,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ConnectionDefinition"
+              $ref: "#/components/schemas/ConnectionDefinitionPayload"
       responses:
         "201":
           description: Connection definition registered
@@ -374,7 +374,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/ConnectionDefinition"
+              $ref: "#/components/schemas/ConnectionDefinitionPayload"
       responses:
         "200":
           description: Connection definition updated
@@ -573,6 +573,129 @@ components:
             json: pageSize
           x-order: 4
           minimum: 1
+
+    ConnectionDefinitionPayload:
+      type: object
+      description: Payload for registering (creating) or updating a connection definition. Contains only client-settable fields; server-generated fields such as createdAt, updatedAt, and deletedAt are excluded.
+      required:
+        - name
+        - kind
+        - type
+        - subType
+        - status
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Existing connection definition ID for updates; omit on create.
+          x-go-name: ID
+          x-oapi-codegen-extra-tags:
+            json: "id,omitempty"
+        schemaVersion:
+          $ref: ../../v1beta2/core/api.yml#/components/schemas/VersionString
+          description: Specifies the version of the schema the definition conforms to.
+          default: connections.meshery.io/v1beta3
+          x-oapi-codegen-extra-tags:
+            json: "schemaVersion,omitempty"
+        name:
+          type: string
+          description: Connection definition name
+          minLength: 1
+          maxLength: 255
+          x-oapi-codegen-extra-tags:
+            json: "name"
+        description:
+          type: string
+          description: Human-readable description of the connection definition and its purpose.
+          maxLength: 1000
+          x-oapi-codegen-extra-tags:
+            json: "description,omitempty"
+        url:
+          type: string
+          format: uri
+          description: URL of the remote resource connections of this kind point to.
+          maxLength: 2048
+          x-oapi-codegen-extra-tags:
+            json: "url,omitempty"
+        kind:
+          type: string
+          description: Connection kind (e.g., kubernetes, prometheus, grafana)
+          maxLength: 255
+          x-oapi-codegen-extra-tags:
+            json: "kind"
+        type:
+          type: string
+          description: Connection type (platform, telemetry, collaboration)
+          maxLength: 255
+          x-oapi-codegen-extra-tags:
+            json: "type"
+        subType:
+          type: string
+          description: Connection sub-type (cloud, identity, metrics, chat, git, orchestration)
+          maxLength: 255
+          x-oapi-codegen-extra-tags:
+            json: "subType"
+        status:
+          $ref: "#/components/schemas/ConnectionStatusValue"
+          description: Initial status for connections instantiated from this definition.
+          x-go-name: Status
+          x-oapi-codegen-extra-tags:
+            json: "status"
+        modelReference:
+          $ref: ../../v1beta1/model/api.yml#/components/schemas/ModelReference
+          x-go-type: modelv1beta1.ModelReference
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/v1beta1/model
+            name: modelv1beta1
+          description: Reference to the registered model that owns this connection definition.
+          x-oapi-codegen-extra-tags:
+            json: "modelReference,omitempty"
+        metadata:
+          type: object
+          description: Kind-specific connection metadata
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "metadata"
+        credentialSchema:
+          type: object
+          description: Schema for the credential associated with connections of this kind.
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "credentialSchema"
+        connectionSchema:
+          type: object
+          description: Schema for connections of this kind.
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "connectionSchema"
+        styles:
+          $ref: ../../v1beta2/core/api.yml#/components/schemas/ComponentStyles
+          x-go-type: core.ComponentStyles
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+            name: core
+          description: Visualization styles for the connection, including svgColor and svgWhite used for UI representation.
+          x-oapi-codegen-extra-tags:
+            json: "styles,omitempty"
+        transitionMap:
+          type: object
+          description: Map describing the connection state machine. Each key is a current connection status and its value is the list of states the connection may transition to from that status.
+          additionalProperties:
+            type: array
+            items:
+              $ref: "#/components/schemas/ConnectionStateTransition"
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "transitionMap,omitempty"
 
     ConnectionPage:
       description: Represents a page of connections with meta information about connections count


### PR DESCRIPTION
**Notes for Reviewers**

This PR is part of the identifier-naming and schema-driven uniformity remediation program (section 2C), a follow-up to #1002.

The dual-schema pattern (the repo's most critical design rule) requires POST/PUT request bodies to reference a `*Payload` schema containing only client-settable fields, never the full entity schema. Two operations in `schemas/constructs/v1beta3/connection/api.yml` violated it: `registerConnectionDefinition` (POST `/api/meshmodels/connections`) and `updateConnectionDefinition` (PUT `/api/meshmodels/connections/{connectionDefinitionId}`) both referenced the `ConnectionDefinition` entity schema in their request bodies.

**What changed**

| Construct | File | Change |
| --- | --- | --- |
| connection (v1beta3) | `schemas/constructs/v1beta3/connection/api.yml` | New `ConnectionDefinitionPayload` schema in `components/schemas`: client-settable fields only (`id` optional with `json:"id,omitempty"` for upserts, `schemaVersion`, `name`, `description`, `url`, `kind`, `type`, `subType`, `status`, `modelReference`, `metadata`, `credentialSchema`, `connectionSchema`, `styles`, `transitionMap`). No `createdAt`/`updatedAt`/`deletedAt`, `owner`, `environments`, or `credentialId`. |
| connection (v1beta3) | `schemas/constructs/v1beta3/connection/api.yml` | `registerConnectionDefinition` and `updateConnectionDefinition` request bodies repointed from the `ConnectionDefinition` entity to `ConnectionDefinitionPayload`. GET responses continue to reference the full entity. |
| connection (v1beta3) | `models/v1beta3/connection/connection.go` | Regenerated via `make generate-golang`: adds the `ConnectionDefinitionPayload` struct. No existing types changed. |

**Wire and Go-source impact**

- **ADDITIVE - no wire break.** The payload is a strict subset of the fields the entity schema previously accepted, so every well-behaved client request remains valid. Any client that was sending server-generated fields (`createdAt`, `updatedAt`, `deletedAt`, `owner`, `environments`) in request bodies was already broken by contract.
- Go: purely additive - one new generated struct (`connection.ConnectionDefinitionPayload`). The hand-written `ConnectionDefinition` registry-entity type and its helper are untouched.
- Meshery Server's handlers (`server/handlers/connection_definition_handler.go`) decode POST/PUT bodies into the full `ConnectionDefinition` struct; payload-shaped bodies decode identically, so no coordinated downstream change is required. Consumers may adopt the payload type opportunistically.

**Validation**

- [x] `make generate-golang` (regenerated `models/` committed)
- [x] `make validate-schemas` (no blocking violations)
- [x] `go test ./...` (all pass)
- [x] `go run ./cmd/consumer-audit --cloud-repo ... --meshery-repo ...` (exit 0; no new findings - the two pre-existing `snake-case-param` findings in meshery-cloud `ui/api/catalog.ts` are unrelated)

TypeScript regeneration is intentionally not committed; CI regenerates it post-merge.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
