### PR TITLE
[schemas] Add canonical camelCase pageSize request param alongside deprecated pagesize (uniformity 2A)

### DIFF
--- a/models/v1beta2/key/key.go
+++ b/models/v1beta2/key/key.go
@@ -84,6 +84,9 @@ type OrgId = core.Uuid
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/models/v1beta2/keychain/keychain.go
+++ b/models/v1beta2/keychain/keychain.go
@@ -66,6 +66,9 @@ type Order = string
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/models/v1beta2/view/view.go
+++ b/models/v1beta2/view/view.go
@@ -148,6 +148,9 @@ type OrgIdQuery = string
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/models/v1beta3/environment/environment.go
+++ b/models/v1beta3/environment/environment.go
@@ -101,6 +101,9 @@ type OrgIdQuery = uuid.UUID
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/models/v1beta3/event/event.go
+++ b/models/v1beta3/event/event.go
@@ -170,8 +170,14 @@ type Order = string
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
+
+// PagesizeLegacy defines model for pagesizeLegacy.
+type PagesizeLegacy = string
 
 // Search defines model for search.
 type Search = string

--- a/models/v1beta3/token/token.go
+++ b/models/v1beta3/token/token.go
@@ -72,6 +72,9 @@ type OwnerQuery = core.Uuid
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/models/v1beta3/workspace/workspace.go
+++ b/models/v1beta3/workspace/workspace.go
@@ -268,6 +268,9 @@ type OrgIdQuery = uuid.UUID
 // CorePage defines model for page.
 type CorePage = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/schemas/constructs/v1beta2/key/api.yml
+++ b/schemas/constructs/v1beta2/key/api.yml
@@ -32,6 +32,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/orgId"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
       responses:
         "200":
@@ -55,6 +56,7 @@ paths:
       operationId: getKeys
       parameters:
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
@@ -169,8 +171,15 @@ components:
         $ref: ../../v1alpha1/core/api.yml#/components/schemas/uuid
     page:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/page
+    pageSize:
+      $ref: ../core/api.yml#/components/parameters/pageSize
     pagesize:
-      $ref: ../../v1alpha1/core/api.yml#/components/parameters/pagesize
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     order:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/order
     search:

--- a/schemas/constructs/v1beta2/keychain/api.yml
+++ b/schemas/constructs/v1beta2/keychain/api.yml
@@ -28,6 +28,7 @@ paths:
       operationId: getKeychains
       parameters:
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
@@ -195,6 +196,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/keychainId"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
@@ -242,8 +244,15 @@ components:
         $ref: ../../v1alpha1/core/api.yml#/components/schemas/uuid
     page:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/page
+    pageSize:
+      $ref: ../core/api.yml#/components/parameters/pageSize
     pagesize:
-      $ref: ../../v1alpha1/core/api.yml#/components/parameters/pagesize
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     order:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/order
     search:

--- a/schemas/constructs/v1beta2/view/api.yml
+++ b/schemas/constructs/v1beta2/view/api.yml
@@ -52,8 +52,15 @@ components:
       $ref: "../../v1alpha1/core/api.yml#/components/parameters/order"
     page:
       $ref: "../../v1alpha1/core/api.yml#/components/parameters/page"
+    pageSize:
+      $ref: "../core/api.yml#/components/parameters/pageSize"
     pagesize:
-      $ref: "../../v1alpha1/core/api.yml#/components/parameters/pagesize"
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     orgIdQuery:
       name: orgId
       in: query
@@ -358,6 +365,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - name: filter
           in: query

--- a/schemas/constructs/v1beta3/academy/api.yml
+++ b/schemas/constructs/v1beta3/academy/api.yml
@@ -177,10 +177,18 @@ paths:
           enum:
           - asc
           - desc
-      - name: pagesize
+      - name: pageSize
         in: query
         description: Number of results per page
         required: false
+        schema:
+          type: integer
+          minimum: 1
+      - name: pagesize
+        in: query
+        description: Number of results per page. Deprecated alias of pageSize.
+        required: false
+        deprecated: true
         schema:
           type: integer
       - name: page
@@ -621,10 +629,18 @@ paths:
       summary: Get academy registrations
       description: Returns a list of academy registrations with user, curricula, and pagination details.
       parameters:
-      - name: pagesize
+      - name: pageSize
         in: query
         required: false
         description: Number of results per page
+        schema:
+          type: integer
+          minimum: 1
+      - name: pagesize
+        in: query
+        required: false
+        description: Number of results per page. Deprecated alias of pageSize.
+        deprecated: true
         schema:
           type: integer
       - name: page

--- a/schemas/constructs/v1beta3/environment/api.yml
+++ b/schemas/constructs/v1beta3/environment/api.yml
@@ -47,8 +47,15 @@ components:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/order
     page:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/page
+    pageSize:
+      $ref: ../../v1beta2/core/api.yml#/components/parameters/pageSize
     pagesize:
-      $ref: ../../v1alpha1/core/api.yml#/components/parameters/pagesize
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     orgIdQuery:
       name: orgId
       in: query
@@ -230,6 +237,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/orgIdQuery"
       responses:
@@ -326,6 +334,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - name: filter
           in: query

--- a/schemas/constructs/v1beta3/event/api.yml
+++ b/schemas/constructs/v1beta3/event/api.yml
@@ -152,7 +152,8 @@ paths:
       parameters:
       - $ref: '#/components/parameters/workspaceId'
       - $ref: '#/components/parameters/page'
-      - $ref: '#/components/parameters/pagesize'
+      - $ref: '#/components/parameters/pageSize'
+      - $ref: '#/components/parameters/pagesizeLegacy'
       - $ref: '#/components/parameters/search'
       - $ref: '#/components/parameters/order'
       responses:
@@ -261,7 +262,8 @@ paths:
       summary: Get event types
       parameters:
       - $ref: '#/components/parameters/page'
-      - $ref: '#/components/parameters/pagesize'
+      - $ref: '#/components/parameters/pageSize'
+      - $ref: '#/components/parameters/pagesizeLegacy'
       responses:
         '200':
           description: Event types
@@ -305,8 +307,17 @@ components:
       required: true
     page:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/page
+    pageSize:
+      $ref: ../../v1beta2/core/api.yml#/components/parameters/pageSize
     pagesize:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/pagesize
+    pagesizeLegacy:
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     search:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/search
     order:

--- a/schemas/constructs/v1beta3/token/api.yml
+++ b/schemas/constructs/v1beta3/token/api.yml
@@ -35,6 +35,7 @@ paths:
       parameters:
       - $ref: '#/components/parameters/isOauth'
       - $ref: '#/components/parameters/page'
+      - $ref: '#/components/parameters/pageSize'
       - $ref: '#/components/parameters/pagesize'
       - $ref: '#/components/parameters/search'
       - $ref: '#/components/parameters/order'
@@ -192,8 +193,15 @@ components:
         maxLength: 500
     page:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/page
+    pageSize:
+      $ref: ../../v1beta2/core/api.yml#/components/parameters/pageSize
     pagesize:
-      $ref: ../../v1beta2/core/api.yml#/components/parameters/pagesize
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     search:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/search
     order:

--- a/schemas/constructs/v1beta3/workspace/api.yml
+++ b/schemas/constructs/v1beta3/workspace/api.yml
@@ -41,6 +41,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/filter"
       responses:
@@ -164,6 +165,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/filter"
       responses:
@@ -243,6 +245,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/filter"
       responses:
@@ -323,6 +326,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/filter"
       responses:
@@ -405,6 +409,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/filter"
       responses:
@@ -537,8 +542,15 @@ components:
       $ref: "../../v1beta1/core/api.yml#/components/parameters/order"
     page:
       $ref: "../../v1beta1/core/api.yml#/components/parameters/page"
+    pageSize:
+      $ref: "../../v1beta2/core/api.yml#/components/parameters/pageSize"
     pagesize:
-      $ref: "../../v1beta1/core/api.yml#/components/parameters/pagesize"
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     filter:
       name: filter
       in: query


### PR DESCRIPTION
**Notes for Reviewers**

This PR is part of the identifier-naming and schema-driven uniformity remediation program (plan section 2A, "additive-safe request-param fixes"), a follow-up to #1002 (released as v1.3.20).

**What this change does**

Each operation below authored a lowercase `pagesize` query parameter while its own response envelope already publishes camelCase `pageSize` - i.e. the resource was already internally mixed. This PR adds the canonical `pageSize` query parameter (`integer`, `minimum: 1`) to those operations and keeps the legacy `pagesize` parameter accepted as a deprecated alias (`deprecated: true`).

**This change is ADDITIVE - no wire break.** No parameter is removed or renamed; existing clients sending `pagesize` remain valid. Go-source impact is additive only: each affected construct package gains a `type PageSize = int` alias (and `models/v1beta3/event` gains `type PagesizeLegacy = string`); no existing generated identifiers change.

| Construct / file | Operation(s) | What changed |
| --- | --- | --- |
| `v1beta3/academy/api.yml` | `getAcademyCurricula`, `getAcademyAdminRegistrations` | Added inline `pageSize` (integer, `minimum: 1`); inline `pagesize` kept, marked `deprecated: true` |
| `v1beta3/environment/api.yml` | `getEnvironments`, `getEnvironmentConnections` | Added local `pageSize` component pointing at the canonical `v1beta2/core` `pageSize`; local `pagesize` alias inlined and marked deprecated; both params on the ops |
| `v1beta3/event/api.yml` | `getEventsOfWorkspace`, `getEventTypes` | Added local `pageSize` component (canonical core ref) plus a `pagesizeLegacy` deprecated component; only these two ops repointed |
| `v1beta2/key/api.yml` | `getUserKeys`, `getKeys` | Added `pageSize` component (canonical core ref); `pagesize` inlined, deprecated; both on the ops |
| `v1beta2/keychain/api.yml` | `getKeychains`, `getKeysOfKeychain` | Same pattern; `minimum: 1` comes from the canonical core component |
| `v1beta3/token/api.yml` | `getUserTokens` | Same pattern |
| `v1beta2/view/api.yml` | `getViews` | Same pattern |
| `v1beta3/workspace/api.yml` | `getWorkspaces`, `getTeamsOfWorkspace`, `getEnvironmentsOfWorkspace`, `getDesignsOfWorkspace`, `getViewsOfWorkspace` | Same pattern; all five list ops gained `pageSize` |

**Intentionally untouched:** `getEvents`, `getEventSummaryByUser`, and `getMeshModelModels` canonically keep lowercase `pagesize` by design. In `v1beta3/event/api.yml` the shared `pagesize` component they reference is left as-is; the deprecated flag was applied via a separate `pagesizeLegacy` component so their definitions are unaffected. Shared legacy `pagesize` components in the core specs are also untouched, since other constructs still reference them.

**Validation**

- `make generate-golang` - regenerated `models/` committed (additive aliases only)
- `make validate-schemas` - no blocking violations
- `go test ./...` - pass
- `go run ./cmd/consumer-audit` against local meshery-cloud and meshery clones - exit 0, no blocking schema-audit violations; the two pre-existing `user_id` TypeScript findings in meshery-cloud are unrelated to this change

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
