### PR TITLE
[schemas] Correct x-go-name initialisms in v1beta3 environment/workspace and verify InvitationsPage regeneration (uniformity 2B)

### DIFF
--- a/models/v1beta2/key/key.go
+++ b/models/v1beta2/key/key.go
@@ -84,6 +84,9 @@ type OrgId = core.Uuid
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/models/v1beta2/keychain/keychain.go
+++ b/models/v1beta2/keychain/keychain.go
@@ -66,6 +66,9 @@ type Order = string
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/models/v1beta2/view/view.go
+++ b/models/v1beta2/view/view.go
@@ -148,6 +148,9 @@ type OrgIdQuery = string
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/models/v1beta3/environment/environment.go
+++ b/models/v1beta3/environment/environment.go
@@ -101,6 +101,9 @@ type OrgIdQuery = uuid.UUID
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/models/v1beta3/environment/environment.go
+++ b/models/v1beta3/environment/environment.go
@@ -85,8 +85,8 @@ type EnvironmentPayload struct {
 	Description core.Text `json:"description,omitempty" yaml:"description,omitempty"`
 	Name        core.Text `json:"name" yaml:"name"`
 
-	// OrgId Select an organization in which you want to create this new environment. Keep in mind that the organization cannot be changed after creation.
-	OrgId uuid.UUID `json:"organizationId" yaml:"organizationId"`
+	// OrgID Select an organization in which you want to create this new environment. Keep in mind that the organization cannot be changed after creation.
+	OrgID uuid.UUID `json:"organizationId" yaml:"organizationId"`
 }
 
 // EnvironmentId defines model for environmentId.

--- a/models/v1beta3/event/event.go
+++ b/models/v1beta3/event/event.go
@@ -170,8 +170,14 @@ type Order = string
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
+
+// PagesizeLegacy defines model for pagesizeLegacy.
+type PagesizeLegacy = string
 
 // Search defines model for search.
 type Search = string

--- a/models/v1beta3/token/token.go
+++ b/models/v1beta3/token/token.go
@@ -72,6 +72,9 @@ type OwnerQuery = core.Uuid
 // Page defines model for page.
 type Page = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/models/v1beta3/workspace/workspace.go
+++ b/models/v1beta3/workspace/workspace.go
@@ -268,6 +268,9 @@ type OrgIdQuery = uuid.UUID
 // CorePage defines model for page.
 type CorePage = string
 
+// PageSize defines model for pageSize.
+type PageSize = int
+
 // Pagesize defines model for pagesize.
 type Pagesize = string
 

--- a/models/v1beta3/workspace/workspace.go
+++ b/models/v1beta3/workspace/workspace.go
@@ -33,7 +33,7 @@ type AvailableWorkspace struct {
 	OrgName string `db:"org_name" json:"orgName,omitempty" yaml:"orgName,omitempty"`
 
 	// OrganizationId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	OrganizationId *core.Uuid `db:"organization_id" json:"organizationId,omitempty" yaml:"organizationId,omitempty"`
+	OrganizationID *core.Uuid `db:"organization_id" json:"organizationId,omitempty" yaml:"organizationId,omitempty"`
 
 	// Owner Display name of the workspace owner.
 	Owner *string `db:"owner" json:"owner,omitempty" yaml:"owner,omitempty"`
@@ -45,7 +45,7 @@ type AvailableWorkspace struct {
 	OwnerEmail *openapi_types.Email `db:"owner_email" json:"ownerEmail,omitempty" yaml:"ownerEmail,omitempty"`
 
 	// OwnerId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	OwnerId *core.Uuid `db:"owner_id" json:"ownerId,omitempty" yaml:"ownerId,omitempty"`
+	OwnerID *core.Uuid `db:"owner_id" json:"ownerId,omitempty" yaml:"ownerId,omitempty"`
 
 	// UpdatedAt Timestamp when the resource was updated.
 	UpdatedAt core.UpdatedAt `db:"updated_at" json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`

--- a/schemas/constructs/v1beta2/key/api.yml
+++ b/schemas/constructs/v1beta2/key/api.yml
@@ -32,6 +32,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/orgId"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
       responses:
         "200":
@@ -55,6 +56,7 @@ paths:
       operationId: getKeys
       parameters:
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
@@ -169,8 +171,15 @@ components:
         $ref: ../../v1alpha1/core/api.yml#/components/schemas/uuid
     page:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/page
+    pageSize:
+      $ref: ../core/api.yml#/components/parameters/pageSize
     pagesize:
-      $ref: ../../v1alpha1/core/api.yml#/components/parameters/pagesize
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     order:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/order
     search:

--- a/schemas/constructs/v1beta2/keychain/api.yml
+++ b/schemas/constructs/v1beta2/keychain/api.yml
@@ -28,6 +28,7 @@ paths:
       operationId: getKeychains
       parameters:
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
@@ -195,6 +196,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/keychainId"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
@@ -242,8 +244,15 @@ components:
         $ref: ../../v1alpha1/core/api.yml#/components/schemas/uuid
     page:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/page
+    pageSize:
+      $ref: ../core/api.yml#/components/parameters/pageSize
     pagesize:
-      $ref: ../../v1alpha1/core/api.yml#/components/parameters/pagesize
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     order:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/order
     search:

--- a/schemas/constructs/v1beta2/view/api.yml
+++ b/schemas/constructs/v1beta2/view/api.yml
@@ -52,8 +52,15 @@ components:
       $ref: "../../v1alpha1/core/api.yml#/components/parameters/order"
     page:
       $ref: "../../v1alpha1/core/api.yml#/components/parameters/page"
+    pageSize:
+      $ref: "../core/api.yml#/components/parameters/pageSize"
     pagesize:
-      $ref: "../../v1alpha1/core/api.yml#/components/parameters/pagesize"
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     orgIdQuery:
       name: orgId
       in: query
@@ -358,6 +365,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - name: filter
           in: query

--- a/schemas/constructs/v1beta3/academy/api.yml
+++ b/schemas/constructs/v1beta3/academy/api.yml
@@ -177,10 +177,18 @@ paths:
           enum:
           - asc
           - desc
-      - name: pagesize
+      - name: pageSize
         in: query
         description: Number of results per page
         required: false
+        schema:
+          type: integer
+          minimum: 1
+      - name: pagesize
+        in: query
+        description: Number of results per page. Deprecated alias of pageSize.
+        required: false
+        deprecated: true
         schema:
           type: integer
       - name: page
@@ -621,10 +629,18 @@ paths:
       summary: Get academy registrations
       description: Returns a list of academy registrations with user, curricula, and pagination details.
       parameters:
-      - name: pagesize
+      - name: pageSize
         in: query
         required: false
         description: Number of results per page
+        schema:
+          type: integer
+          minimum: 1
+      - name: pagesize
+        in: query
+        required: false
+        description: Number of results per page. Deprecated alias of pageSize.
+        deprecated: true
         schema:
           type: integer
       - name: page

--- a/schemas/constructs/v1beta3/environment/api.yml
+++ b/schemas/constructs/v1beta3/environment/api.yml
@@ -47,8 +47,15 @@ components:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/order
     page:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/page
+    pageSize:
+      $ref: ../../v1beta2/core/api.yml#/components/parameters/pageSize
     pagesize:
-      $ref: ../../v1alpha1/core/api.yml#/components/parameters/pagesize
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     orgIdQuery:
       name: orgId
       in: query
@@ -230,6 +237,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/orgIdQuery"
       responses:
@@ -326,6 +334,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - name: filter
           in: query

--- a/schemas/constructs/v1beta3/environment/api.yml
+++ b/schemas/constructs/v1beta3/environment/api.yml
@@ -133,7 +133,7 @@ components:
           type: string
           description: Select an organization in which you want to create this new environment. Keep in mind that the organization cannot be changed after creation.
           x-go-type-skip-optional-pointer: true
-          x-go-name: OrgId
+          x-go-name: OrgID
           x-oapi-codegen-extra-tags:
             json: organizationId
           maxLength: 500

--- a/schemas/constructs/v1beta3/event/api.yml
+++ b/schemas/constructs/v1beta3/event/api.yml
@@ -152,7 +152,8 @@ paths:
       parameters:
       - $ref: '#/components/parameters/workspaceId'
       - $ref: '#/components/parameters/page'
-      - $ref: '#/components/parameters/pagesize'
+      - $ref: '#/components/parameters/pageSize'
+      - $ref: '#/components/parameters/pagesizeLegacy'
       - $ref: '#/components/parameters/search'
       - $ref: '#/components/parameters/order'
       responses:
@@ -261,7 +262,8 @@ paths:
       summary: Get event types
       parameters:
       - $ref: '#/components/parameters/page'
-      - $ref: '#/components/parameters/pagesize'
+      - $ref: '#/components/parameters/pageSize'
+      - $ref: '#/components/parameters/pagesizeLegacy'
       responses:
         '200':
           description: Event types
@@ -305,8 +307,17 @@ components:
       required: true
     page:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/page
+    pageSize:
+      $ref: ../../v1beta2/core/api.yml#/components/parameters/pageSize
     pagesize:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/pagesize
+    pagesizeLegacy:
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     search:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/search
     order:

--- a/schemas/constructs/v1beta3/token/api.yml
+++ b/schemas/constructs/v1beta3/token/api.yml
@@ -35,6 +35,7 @@ paths:
       parameters:
       - $ref: '#/components/parameters/isOauth'
       - $ref: '#/components/parameters/page'
+      - $ref: '#/components/parameters/pageSize'
       - $ref: '#/components/parameters/pagesize'
       - $ref: '#/components/parameters/search'
       - $ref: '#/components/parameters/order'
@@ -192,8 +193,15 @@ components:
         maxLength: 500
     page:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/page
+    pageSize:
+      $ref: ../../v1beta2/core/api.yml#/components/parameters/pageSize
     pagesize:
-      $ref: ../../v1beta2/core/api.yml#/components/parameters/pagesize
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     search:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/search
     order:

--- a/schemas/constructs/v1beta3/workspace/api.yml
+++ b/schemas/constructs/v1beta3/workspace/api.yml
@@ -610,7 +610,7 @@ components:
         ownerId:
           $ref: "../../v1beta1/core/api.yml#/components/schemas/uuid"
           description: User ID of the workspace owner.
-          x-go-name: OwnerId
+          x-go-name: OwnerID
           x-oapi-codegen-extra-tags:
             db: owner_id
             json: "ownerId,omitempty"
@@ -641,7 +641,7 @@ components:
         organizationId:
           $ref: "../../v1beta1/core/api.yml#/components/schemas/uuid"
           description: Organization to which this workspace belongs.
-          x-go-name: OrganizationId
+          x-go-name: OrganizationID
           x-go-type-skip-optional-pointer: true
           x-oapi-codegen-extra-tags:
             db: organization_id

--- a/schemas/constructs/v1beta3/workspace/api.yml
+++ b/schemas/constructs/v1beta3/workspace/api.yml
@@ -41,6 +41,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/filter"
       responses:
@@ -164,6 +165,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/filter"
       responses:
@@ -243,6 +245,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/filter"
       responses:
@@ -323,6 +326,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/filter"
       responses:
@@ -405,6 +409,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/filter"
       responses:
@@ -537,8 +542,15 @@ components:
       $ref: "../../v1beta1/core/api.yml#/components/parameters/order"
     page:
       $ref: "../../v1beta1/core/api.yml#/components/parameters/page"
+    pageSize:
+      $ref: "../../v1beta2/core/api.yml#/components/parameters/pageSize"
     pagesize:
-      $ref: "../../v1beta1/core/api.yml#/components/parameters/pagesize"
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     filter:
       name: filter
       in: query


### PR DESCRIPTION
**Notes for Reviewers**

Part of the identifier-naming and schema-driven uniformity remediation program, follow-up to #1002 (released as v1.3.20). Implements plan section 2B: Go-model x-go-name initialism fixes and stale-generation verification.

**Stacked on the section-2A PR - merge that first:** #1004 (branch `fix/uniformity-2a-pagesize-request-params`). Both branches regenerate the same `models/` Go files, so this PR's diff includes 2A's commit until it merges.

## What changed

| Construct | File | Change |
| --- | --- | --- |
| environment (v1beta3) | `schemas/constructs/v1beta3/environment/api.yml` | `EnvironmentPayload.organizationId` `x-go-name: OrgId` -> `OrgID` (entity already uses `OrganizationID`) |
| workspace (v1beta3) | `schemas/constructs/v1beta3/workspace/api.yml` | `AvailableWorkspace.ownerId` `x-go-name: OwnerId` -> `OwnerID` |
| workspace (v1beta3) | `schemas/constructs/v1beta3/workspace/api.yml` | `AvailableWorkspace.organizationId` `x-go-name: OrganizationId` -> `OrganizationID` (siblings `WorkspaceID`/`TeamID` already correct) |
| environment, workspace (v1beta3) | `models/v1beta3/environment/environment.go`, `models/v1beta3/workspace/workspace.go` | Regenerated via `make generate-golang` |

**Wire contract is UNCHANGED.** JSON tags (`organizationId`, `ownerId`) and db tags are identical before and after; only the generated Go field identifiers change to follow the Go initialism convention (`ID`, not `Id`). This is a Go-source-breaking, wire-compatible change.

**InvitationsPage stale-generation item (plan 2B.4):** `models/v1beta3/invitation/invitation.go` was previously stale (emitted `Data` + `Total` with `json:"total"` instead of the spec's `page`/`pageSize`/`totalCount`/`data`). The master artifact self-commit automation already regenerated it before this branch point, so no diff appears here. Verified post-regeneration: `InvitationsPage` has `Page`, `PageSize`, `TotalCount`, `Data`, and the phantom `Total` field is gone.

## Downstream impact

These renames break Go source in consumers once they bump the schemas dependency. Grep of local clones of meshery/meshery and layer5io/meshery-cloud:

`AvailableWorkspace.OrganizationId` / `AvailableWorkspace.OwnerId` (meshery/meshery, 3 hits):

- `server/models/workspace_persister.go:115` - composite literal key `OrganizationId:` -> `OrganizationID:`
- `server/models/workspace_persister.go:116` - composite literal key `OwnerId:` -> `OwnerID:`
- `mesheryctl/internal/cli/root/workspaces/list.go:98` - read `workspace.OrganizationId.String()` -> `OrganizationID`

`EnvironmentPayload.OrgId` (v1beta3): no hits in either repo. meshery/meshery consumes the v1beta1 environment package (whose `OrgId` is untouched by this PR); its sole v1beta3 environment importer does not reference the field. meshery-cloud defines a local `EnvironmentPayload` with `OrganizationID`.

`InvitationsPage.Total` (layer5io/meshery-cloud, 8 hits - break lands on dep bump because master models now emit `TotalCount`):

- `server/handlers/invitations/handlers.go:96` - `Total: 0`
- `server/handlers/invitations/dao.go:106` - `invitations.Total = len(data)` (adjacent comment at dao.go:102-103 already anticipates the rename)
- `server/handlers/invitations/handlers_test.go:248`
- `server/handlers/invitations/handlers_test.go:269`
- `server/handlers/invitations/handlers_test.go:290`
- `server/handlers/invitations/service_test.go:193`
- `server/handlers/invitations/service_test.go:292`
- `server/handlers/invitations/service_test.go:433`

meshery-cloud does not consume the schemas `AvailableWorkspace` type (it has a local struct of the same name), so the workspace renames do not affect it.

## Validation

- `make generate-golang` - clean, committed
- `make validate-schemas` - no blocking violations
- `go test ./...` - pass
- `go run ./cmd/consumer-audit --cloud-repo ... --meshery-repo ...` - 0 blocking schema-audit violations (2 pre-existing advisory TypeScript findings in meshery-cloud, unrelated to this change)
- TypeScript regeneration intentionally not committed (CI regenerates post-merge)

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
