### PR TITLE
fix(team,credential): recase pagination envelopes to camelCase pageSize/totalCount (section 2F)

### DIFF
--- a/models/v1beta2/credential/credential.go
+++ b/models/v1beta2/credential/credential.go
@@ -42,13 +42,13 @@ type CredentialPage struct {
 	Credentials []Credential `json:"credentials" yaml:"credentials"`
 
 	// TotalCount Total number of credentials across all pages.
-	TotalCount int `json:"total_count" yaml:"total_count"`
+	TotalCount int `json:"totalCount" yaml:"totalCount"`
 
 	// Page Current page number (zero-based).
 	Page int `json:"page" yaml:"page"`
 
 	// PageSize Number of credentials per page.
-	PageSize int `json:"page_size" yaml:"page_size"`
+	PageSize int `json:"pageSize" yaml:"pageSize"`
 }
 
 // CredentialPayload Payload for creating or updating a credential.
@@ -80,6 +80,9 @@ type Order = string
 
 // Page defines model for page.
 type Page = string
+
+// PageSize defines model for pageSize.
+type PageSize = int
 
 // Pagesize defines model for pagesize.
 type Pagesize = string

--- a/models/v1beta2/team/team.go
+++ b/models/v1beta2/team/team.go
@@ -49,10 +49,10 @@ type TeamMembersPage struct {
 	Page *int `json:"page,omitempty" yaml:"page,omitempty"`
 
 	// PageSize Number of items per page.
-	PageSize *int `json:"page_size,omitempty" yaml:"page_size,omitempty"`
+	PageSize *int `json:"pageSize,omitempty" yaml:"pageSize,omitempty"`
 
 	// TotalCount Total number of items available.
-	TotalCount *int `json:"total_count,omitempty" yaml:"total_count,omitempty"`
+	TotalCount *int `json:"totalCount,omitempty" yaml:"totalCount,omitempty"`
 }
 
 // TeamPage Paginated list of teams
@@ -61,13 +61,13 @@ type TeamPage struct {
 	Page *int `json:"page,omitempty" yaml:"page,omitempty"`
 
 	// PageSize Number of items per page.
-	PageSize *int `json:"page_size,omitempty" yaml:"page_size,omitempty"`
+	PageSize *int `json:"pageSize,omitempty" yaml:"pageSize,omitempty"`
 
 	// Teams The teams of the teampage.
 	Teams []Team `json:"teams,omitempty" yaml:"teams,omitempty"`
 
 	// TotalCount Total number of items available.
-	TotalCount *int `json:"total_count,omitempty" yaml:"total_count,omitempty"`
+	TotalCount *int `json:"totalCount,omitempty" yaml:"totalCount,omitempty"`
 }
 
 // TeamPayload Payload for creating a new team
@@ -113,10 +113,10 @@ type UsersTeamsMappingPage struct {
 	Page *int `json:"page,omitempty" yaml:"page,omitempty"`
 
 	// PageSize Number of items per page.
-	PageSize *int `json:"page_size,omitempty" yaml:"page_size,omitempty"`
+	PageSize *int `json:"pageSize,omitempty" yaml:"pageSize,omitempty"`
 
 	// TotalCount Total number of items available.
-	TotalCount *int `json:"total_count,omitempty" yaml:"total_count,omitempty"`
+	TotalCount *int `json:"totalCount,omitempty" yaml:"totalCount,omitempty"`
 
 	// UsersTeamsMapping The user-team mappings on the current page.
 	UsersTeamsMapping []UsersTeamsMapping `json:"usersTeamsMapping,omitempty" yaml:"usersTeamsMapping,omitempty"`
@@ -130,6 +130,9 @@ type OrgId = core.OrganizationId
 
 // Page defines model for page.
 type Page = string
+
+// PageSize defines model for pageSize.
+type PageSize = int
 
 // Pagesize defines model for pagesize.
 type Pagesize = string

--- a/schemas/constructs/v1beta2/credential/api.yml
+++ b/schemas/constructs/v1beta2/credential/api.yml
@@ -36,6 +36,7 @@ paths:
       description: Retrieves all credentials belonging to the authenticated user.
       parameters:
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
@@ -183,8 +184,15 @@ components:
         $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
     page:
       $ref: "../../v1alpha1/core/api.yml#/components/parameters/page"
+    pageSize:
+      $ref: "../core/api.yml#/components/parameters/pageSize"
     pagesize:
-      $ref: "../../v1alpha1/core/api.yml#/components/parameters/pagesize"
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
     search:
       $ref: "../../v1alpha1/core/api.yml#/components/parameters/search"
     order:
@@ -316,9 +324,9 @@ components:
       description: A paginated list of credentials.
       required:
         - credentials
-        - total_count
+        - totalCount
         - page
-        - page_size
+        - pageSize
       properties:
         credentials:
           type: array
@@ -327,7 +335,7 @@ components:
             x-go-type: Credential
           x-order: 1
           description: The credentials returned on the current page.
-        total_count:
+        totalCount:
           type: integer
           description: Total number of credentials across all pages.
           x-order: 2
@@ -337,7 +345,7 @@ components:
           description: Current page number (zero-based).
           x-order: 3
           minimum: 0
-        page_size:
+        pageSize:
           type: integer
           description: Number of credentials per page.
           x-order: 4

--- a/schemas/constructs/v1beta2/team/api.yml
+++ b/schemas/constructs/v1beta2/team/api.yml
@@ -66,8 +66,15 @@ components:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/order
     page:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/page
+    pageSize:
+      $ref: ../core/api.yml#/components/parameters/pageSize
     pagesize:
-      $ref: ../../v1alpha1/core/api.yml#/components/parameters/pagesize
+      name: pagesize
+      in: query
+      description: Get responses by pagesize. Deprecated alias of pageSize.
+      deprecated: true
+      schema:
+        type: string
 
   securitySchemes:
     jwt:
@@ -118,11 +125,11 @@ components:
           type: integer
           description: Current page number of the result set.
           minimum: 0
-        page_size:
+        pageSize:
           type: integer
           description: Number of items per page.
           minimum: 1
-        total_count:
+        totalCount:
           type: integer
           description: Total number of items available.
           minimum: 0
@@ -194,11 +201,11 @@ components:
           type: integer
           description: Current page number of the result set.
           minimum: 0
-        page_size:
+        pageSize:
           type: integer
           description: Number of items per page.
           minimum: 1
-        total_count:
+        totalCount:
           type: integer
           description: Total number of items available.
           minimum: 0
@@ -239,11 +246,11 @@ components:
           type: integer
           description: Current page number of the result set.
           minimum: 0
-        page_size:
+        pageSize:
           type: integer
           description: Number of items per page.
           minimum: 1
-        total_count:
+        totalCount:
           type: integer
           description: Total number of items available.
           minimum: 0
@@ -283,6 +290,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
       responses:
         "200":
@@ -412,6 +420,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
       responses:
         "200":
@@ -492,6 +501,7 @@ paths:
         - $ref: "#/components/parameters/search"
         - $ref: "#/components/parameters/order"
         - $ref: "#/components/parameters/page"
+        - $ref: "#/components/parameters/pageSize"
         - $ref: "#/components/parameters/pagesize"
       responses:
         "200":


### PR DESCRIPTION
## Description

Section 2F of the cross-repo identifier-uniformity remediation program (follows #1003/#1004/#1005, released as v1.3.21). Recases four v1beta2 pagination response envelopes from `page_size`/`total_count` to `pageSize`/`totalCount`, and adds the canonical `pageSize` request parameter alongside the now-deprecated legacy `pagesize` on the operations that serve them - the same request-param pattern established in #1004.

### Envelopes recased

| Envelope | File | Operation(s) serving it |
|---|---|---|
| `TeamPage` | `schemas/constructs/v1beta2/team/api.yml` | `getTeams` |
| `UsersTeamsMappingPage` | `schemas/constructs/v1beta2/team/api.yml` | `getTeamUsers` |
| `TeamMembersPage` | `schemas/constructs/v1beta2/team/api.yml` | `listUsersNotInTeam` |
| `CredentialPage` | `schemas/constructs/v1beta2/credential/api.yml` | `getUserCredentials` |

Every other property is untouched. Generated Go field names (`PageSize`, `TotalCount`) are identical before and after - the `models/` diff shows only `json`/`yaml` tag changes for these types, plus the `PageSize = int` parameter type alias that #1004 introduced for other constructs.

### Why recase-in-place is correct here

These four envelopes are served exclusively by meshery-cloud endpoints, and cloud's production handlers serve hand-rolled structs that already emit camelCase (`totalCount`/`pageSize`). Verified in meshery-cloud:

- `server/models/model_teams_page.go` - `PageSize int \`json:"pageSize"\``, `TotalCount int \`json:"totalCount"\``
- `server/models/credentials.go:23-24` - `PageSize int \`json:"pageSize"\``, `TotalCount int \`json:"totalCount"\``
- `server/models/roles.go` - same camelCase tags on every page struct

The schema's snake_case therefore documents a wire that production has never served for these endpoints. This recase aligns the contract with reality; it is the schema catching up, not a wire change.

### Active silent bug this fixes

meshery/meshery aliases the generated type (`server/models/credentials.go:7`: `type CredentialsPage = credential.CredentialPage`), and its `RemoteProvider.GetUserCredentials` (`server/models/remote_provider.go:5088`) unmarshals cloud's camelCase responses into the snake_case-tagged type. The result is zero-value `TotalCount`/`PageSize` today - the same defect family as the original Teams-count regression. After this recase and a meshery dependency bump, that unmarshal works.

### Rationale per the remediation plan

Per the remediation plan (meshery-cloud `docs/plans/schemas-cloud-identifier-uniformity-remediation.md`), this is the section-2F coordinated flip, executed as recase-in-place because the schema-documented wire was never served by the sole server implementation (meshery-cloud). A version bump would be pure ceremony for a contract nobody could have successfully consumed.

## Downstream coordination

- **(a) meshery DefaultLocalProvider (standalone mode):** `server/models/default_local_provider.go:1572,1598` serves `CredentialsPage` directly, so its wire output keys flip when meshery bumps the schemas dependency. Meshery UI reads of the credential page counts must flip in the same meshery bump PR. A read-only grep of `meshery/ui` found **no** reads of credential-page `total_count`/`page_size`: all credential consumers read only the `credentials` array (`ui/components/MesheryCredentialComponent.tsx:290,419`, `ui/components/connections/meshSync/Stepper/StepperContent.tsx:351`, `ui/components/connections/wizard/useConnectionWizard.tsx:141`), and the generic pagination transform already dual-reads both casings (`ui/rtk-query/transforms.ts:64-65`). No meshery UI change is strictly required, but the bump PR should re-verify.
- **(b) Generated TS clients:** `cloudApi`/`mesheryApi` generated TypeScript types flip `total_count` -> `totalCount` on regeneration. meshery-cloud UI already dual-reads (`totalCount ?? total_count`) via its hotfix PR layer5io/meshery-cloud#5619, so it is forward-compatible; the dual-reads collapse in the Wave-3 cloud consume PR.
- **(c) x-internal scope:** `getTeams` and `getUserCredentials` list `meshery` in `x-internal`. meshery Go does not import `team.TeamPage`/`TeamMembersPage`/`UsersTeamsMappingPage` (verified by grep of `meshery/server` and `mesheryctl` - zero hits), and the credential consumption path is covered by (a) and (b) above.

## Gates

- `make generate-golang` - pass; `models/` diff limited to json/yaml tag flips for the four envelope types plus the `PageSize` param alias
- `make validate-schemas` - pass, no blocking violations
- `go test ./...` - pass
- `go run ./cmd/consumer-audit --cloud-repo ... --meshery-repo ...` - 0 blocking schema-audit violations; the two TypeScript findings (`ui/api/catalog.ts:251,267` `user_id` params) are pre-existing and unrelated to this change

No TypeScript output is committed in this PR; generated artifacts are produced by automation on master.
