### PR TITLE
[schemas] Correct db tags to live owner column across DB-backed constructs

### DIFF
--- a/models/v1beta1/academy/academy.go
+++ b/models/v1beta1/academy/academy.go
@@ -198,7 +198,7 @@ type AcademyRegistration struct {
 	UpdatedAt core.Time         `db:"updated_at" json:"updated_at" yaml:"updated_at"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId core.Uuid `db:"user_id" json:"user_id" yaml:"user_id"`
+	UserId core.Uuid `db:"owner" json:"user_id" yaml:"user_id"`
 }
 
 // AcademyRegistrationStatus Status of the user's course registration
@@ -574,7 +574,7 @@ type TestSubmission struct {
 	UpdatedAt *time.Time `db:"updated_at" json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId core.Uuid `db:"user_id" json:"user_id" yaml:"user_id"`
+	UserId core.Uuid `db:"owner" json:"user_id" yaml:"user_id"`
 }
 
 // TestSubmissionStatus defines model for TestSubmissionStatus.

--- a/models/v1beta1/connection/connection.go
+++ b/models/v1beta1/connection/connection.go
@@ -60,7 +60,7 @@ type Connection struct {
 	Status ConnectionStatus `db:"status" json:"status" yaml:"status"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserID    *core.Uuid `db:"user_id" json:"user_id,omitempty" yaml:"user_id"`
+	UserID    *core.Uuid `db:"owner" json:"user_id,omitempty" yaml:"user_id"`
 	CreatedAt core.Time  `db:"created_at" json:"created_at,omitempty" yaml:"created_at"`
 	UpdatedAt core.Time  `db:"updated_at" json:"updated_at,omitempty" yaml:"updated_at"`
 

--- a/models/v1beta1/credential/credential.go
+++ b/models/v1beta1/credential/credential.go
@@ -17,7 +17,7 @@ type Credential struct {
 	Name string `db:"name" json:"name" yaml:"name"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId *core.Uuid `db:"user_id" json:"user_id,omitempty" yaml:"user_id,omitempty"`
+	UserId *core.Uuid `db:"owner" json:"user_id,omitempty" yaml:"user_id,omitempty"`
 
 	// Type Credential type (e.g. token, basic, AWS).
 	Type string `db:"type" json:"type" yaml:"type"`

--- a/models/v1beta1/schedule/schedule.go
+++ b/models/v1beta1/schedule/schedule.go
@@ -16,7 +16,7 @@ type Schedule struct {
 	Name string `db:"name" json:"name" yaml:"name"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId core.Uuid `db:"user_id" json:"user_id" yaml:"user_id"`
+	UserId core.Uuid `db:"owner" json:"user_id" yaml:"user_id"`
 
 	// CronExpression Cron expression defining the schedule's recurrence (e.g. "0 0 * * *" for daily at midnight).
 	CronExpression string `db:"cron_expression" json:"cron_expression" yaml:"cron_expression"`

--- a/models/v1beta1/team/team.go
+++ b/models/v1beta1/team/team.go
@@ -84,7 +84,7 @@ type TeamsUsersMapping struct {
 	UpdatedAt core.UpdatedAt `db:"updated_at" json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
 
 	// UserId user's email or username
-	UserId core.UserId `db:"user_id" json:"user_id,omitempty" yaml:"user_id,omitempty"`
+	UserId core.UserId `db:"owner" json:"user_id,omitempty" yaml:"user_id,omitempty"`
 }
 
 // TeamsUsersMappingPage Paginated list of team-user mappings

--- a/models/v1beta1/token/token.go
+++ b/models/v1beta1/token/token.go
@@ -27,7 +27,7 @@ type UserToken struct {
 	ID *core.Uuid `db:"id" json:"id,omitempty" yaml:"id,omitempty"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId *core.Uuid `db:"user_id" json:"user_id,omitempty" yaml:"user_id,omitempty"`
+	UserId *core.Uuid `db:"owner" json:"user_id,omitempty" yaml:"user_id,omitempty"`
 
 	// Provider Authentication provider associated with the token.
 	Provider *string `db:"provider" json:"provider,omitempty" yaml:"provider,omitempty"`

--- a/models/v1beta1/view/view.go
+++ b/models/v1beta1/view/view.go
@@ -55,7 +55,7 @@ type MesheryView struct {
 	Metadata core.Map `db:"metadata" json:"metadata,omitempty" yaml:"metadata"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserID    core.Uuid `db:"user_id" json:"user_id" yaml:"user_id"`
+	UserID    core.Uuid `db:"owner" json:"user_id" yaml:"user_id"`
 	CreatedAt core.Time `db:"created_at" json:"created_at" yaml:"created_at"`
 	UpdatedAt core.Time `db:"updated_at" json:"updated_at" yaml:"updated_at"`
 
@@ -101,7 +101,7 @@ type MesheryViewWithLocation struct {
 	UpdatedAt core.UpdatedAt `db:"updated_at" json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserID *core.Uuid `db:"user_id" json:"user_id,omitempty" yaml:"user_id,omitempty"`
+	UserID *core.Uuid `db:"owner" json:"user_id,omitempty" yaml:"user_id,omitempty"`
 
 	// Visibility Visibility level of the view.
 	Visibility string `db:"visibility" json:"visibility,omitempty" yaml:"visibility,omitempty"`

--- a/models/v1beta2/academy/academy.go
+++ b/models/v1beta2/academy/academy.go
@@ -202,7 +202,7 @@ type AcademyRegistration struct {
 	UpdatedAt core.Time         `db:"updated_at" json:"updated_at" yaml:"updated_at"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId core.Uuid `db:"user_id" json:"user_id" yaml:"user_id"`
+	UserId core.Uuid `db:"owner" json:"user_id" yaml:"user_id"`
 }
 
 // AcademyRegistrationStatus Status of the user's course registration
@@ -708,7 +708,7 @@ type TestSubmission struct {
 	UpdatedAt *time.Time `db:"updated_at" json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId core.Uuid `db:"user_id" json:"user_id" yaml:"user_id"`
+	UserId core.Uuid `db:"owner" json:"user_id" yaml:"user_id"`
 }
 
 // TestSubmissionStatus defines model for TestSubmissionStatus.

--- a/models/v1beta2/connection/connection.go
+++ b/models/v1beta2/connection/connection.go
@@ -62,7 +62,7 @@ type Connection struct {
 	Status ConnectionStatus `db:"status" json:"status" yaml:"status"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserID    *core.Uuid `db:"user_id" json:"user_id,omitempty" yaml:"user_id"`
+	UserID    *core.Uuid `db:"owner" json:"user_id,omitempty" yaml:"user_id"`
 	CreatedAt core.Time  `db:"created_at" json:"created_at,omitempty" yaml:"created_at"`
 	UpdatedAt core.Time  `db:"updated_at" json:"updated_at,omitempty" yaml:"updated_at"`
 

--- a/models/v1beta2/credential/credential.go
+++ b/models/v1beta2/credential/credential.go
@@ -18,7 +18,7 @@ type Credential struct {
 	Name string `db:"name" json:"name" yaml:"name"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId core.Uuid `db:"user_id" json:"userId" yaml:"userId"`
+	UserId core.Uuid `db:"owner" json:"userId" yaml:"userId"`
 
 	// Type Credential type (e.g. token, basic, AWS).
 	Type string `db:"type" json:"type" yaml:"type"`

--- a/models/v1beta2/schedule/schedule.go
+++ b/models/v1beta2/schedule/schedule.go
@@ -16,7 +16,7 @@ type Schedule struct {
 	Name string `db:"name" json:"name" yaml:"name"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId core.Uuid `db:"user_id" json:"userId" yaml:"userId"`
+	UserId core.Uuid `db:"owner" json:"userId" yaml:"userId"`
 
 	// CronExpression Cron expression defining the schedule's recurrence (e.g. "0 0 * * *" for daily at midnight).
 	CronExpression string `db:"cron_expression" json:"cronExpression" yaml:"cronExpression"`

--- a/models/v1beta2/team/team.go
+++ b/models/v1beta2/team/team.go
@@ -104,7 +104,7 @@ type UsersTeamsMapping struct {
 	UpdatedAt core.Time  `db:"updated_at" json:"updatedAt" yaml:"updatedAt,omitempty"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId *core.Uuid `db:"user_id" json:"userId" yaml:"userId,omitempty"`
+	UserId *core.Uuid `db:"owner" json:"userId" yaml:"userId,omitempty"`
 }
 
 // UsersTeamsMappingPage Paginated list of user-team mappings

--- a/models/v1beta2/token/token.go
+++ b/models/v1beta2/token/token.go
@@ -28,7 +28,7 @@ type UserToken struct {
 	ID core.Uuid `db:"id" json:"id" yaml:"id"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserId core.Uuid `db:"user_id" json:"user_id" yaml:"user_id"`
+	UserId core.Uuid `db:"owner" json:"user_id" yaml:"user_id"`
 
 	// Provider Authentication provider associated with the token.
 	Provider string `db:"provider" json:"provider" yaml:"provider"`

--- a/models/v1beta2/view/view.go
+++ b/models/v1beta2/view/view.go
@@ -57,7 +57,7 @@ type MesheryView struct {
 	Metadata core.Map `db:"metadata" json:"metadata" yaml:"metadata"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserID core.Uuid `db:"user_id" json:"userId" yaml:"userId"`
+	UserID core.Uuid `db:"owner" json:"userId" yaml:"userId"`
 
 	// CreatedAt Timestamp when the view was created.
 	CreatedAt time.Time `db:"created_at" json:"createdAt" yaml:"createdAt"`
@@ -112,7 +112,7 @@ type MesheryViewWithLocation struct {
 	UpdatedAt time.Time `db:"updated_at" json:"updatedAt" yaml:"updatedAt"`
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
-	UserID *core.Uuid `db:"user_id" json:"userId,omitempty" yaml:"userId,omitempty"`
+	UserID *core.Uuid `db:"owner" json:"userId,omitempty" yaml:"userId,omitempty"`
 
 	// Visibility Visibility level of the view.
 	Visibility string `db:"visibility" json:"visibility,omitempty" yaml:"visibility,omitempty"`

--- a/models/v1beta3/design/design.go
+++ b/models/v1beta3/design/design.go
@@ -187,7 +187,7 @@ type MesheryPattern struct {
 
 	// User Represents a user
 	User   *userV1beta.User `db:"-" json:"user,omitempty" yaml:"user,omitempty"`
-	UserId core.Id    `db:"user_id" json:"userId,omitempty" yaml:"userId,omitempty"`
+	UserId core.Id    `db:"owner" json:"userId,omitempty" yaml:"userId,omitempty"`
 
 	// ViewCount Server-aggregated count of views on this design in the catalog. Present on list/catalog responses; server-managed and ignored on writes.
 	ViewCount *int `db:"view_count" json:"viewCount,omitempty" yaml:"viewCount,omitempty"`

--- a/schemas/constructs/v1beta1/academy/api.yml
+++ b/schemas/constructs/v1beta1/academy/api.yml
@@ -1274,7 +1274,7 @@ components:
           description: ID of the user (foreign key to User)
 
           x-oapi-codegen-extra-tags:
-            db: "user_id"
+            db: "owner"
 
         status:
           $ref: "#/components/schemas/AcademyRegistrationStatus"
@@ -1763,7 +1763,7 @@ components:
         user_id:
           $ref: "../core/api.yml#/components/schemas/uuid"
           x-oapi-codegen-extra-tags:
-            db: "user_id"
+            db: "owner"
 
         created_at:
           description: When the submission was created or started

--- a/schemas/constructs/v1beta1/connection/connection.yaml
+++ b/schemas/constructs/v1beta1/connection/connection.yaml
@@ -86,7 +86,7 @@ properties:
   user_id:
     x-go-name: UserID
     x-oapi-codegen-extra-tags:
-      db: user_id
+      db: owner
       yaml: user_id
     x-order: 9
     $ref: ../core/api.yml#/components/schemas/uuid

--- a/schemas/constructs/v1beta1/credential/api.yml
+++ b/schemas/constructs/v1beta1/credential/api.yml
@@ -220,7 +220,7 @@ components:
           description: UUID of the user who owns this credential.
           x-order: 3
           x-oapi-codegen-extra-tags:
-            db: "user_id"
+            db: "owner"
         type:
           type: string
           description: Credential type (e.g. token, basic, AWS).

--- a/schemas/constructs/v1beta1/schedule/api.yml
+++ b/schemas/constructs/v1beta1/schedule/api.yml
@@ -185,7 +185,7 @@ components:
           description: UUID of the user who owns this schedule.
           x-order: 3
           x-oapi-codegen-extra-tags:
-            db: "user_id"
+            db: "owner"
         cron_expression:
           type: string
           description: >

--- a/schemas/constructs/v1beta1/team/api.yml
+++ b/schemas/constructs/v1beta1/team/api.yml
@@ -128,7 +128,7 @@ components:
         user_id:
           $ref: ../core/api.yml#/components/schemas/user_id
           x-oapi-codegen-extra-tags:
-            db: user_id
+            db: owner
         created_at:
           $ref: ../core/api.yml#/components/schemas/created_at
         updated_at:

--- a/schemas/constructs/v1beta1/token/api.yml
+++ b/schemas/constructs/v1beta1/token/api.yml
@@ -238,7 +238,7 @@ components:
           description: UUID of the user who owns the token.
           x-order: 2
           x-oapi-codegen-extra-tags:
-            db: "user_id"
+            db: "owner"
         provider:
           type: string
           description: Authentication provider associated with the token.

--- a/schemas/constructs/v1beta1/view/api.yml
+++ b/schemas/constructs/v1beta1/view/api.yml
@@ -126,7 +126,7 @@ components:
           x-go-name: UserID
           x-go-type-skip-optional-pointer: true
           x-oapi-codegen-extra-tags:
-            db: user_id
+            db: owner
             json: "user_id,omitempty"
         workspace_name:
           type: string

--- a/schemas/constructs/v1beta1/view/view.yaml
+++ b/schemas/constructs/v1beta1/view/view.yaml
@@ -79,7 +79,7 @@ properties:
     x-go-type-skip-optional-pointer: true
     x-order: 6
     x-oapi-codegen-extra-tags:
-      db: user_id
+      db: owner
       yaml: user_id
   created_at:
     $ref: ../core/api.yml#/components/schemas/Time

--- a/schemas/constructs/v1beta2/academy/api.yml
+++ b/schemas/constructs/v1beta2/academy/api.yml
@@ -1150,7 +1150,7 @@ components:
           $ref: ../core/api.yml#/components/schemas/Uuid
           description: ID of the user (foreign key to User)
           x-oapi-codegen-extra-tags:
-            db: user_id
+            db: owner
         status:
           $ref: '#/components/schemas/AcademyRegistrationStatus'
           x-go-type: AcademyRegistrationStatus
@@ -1710,7 +1710,7 @@ components:
         user_id:
           $ref: ../core/api.yml#/components/schemas/Uuid
           x-oapi-codegen-extra-tags:
-            db: user_id
+            db: owner
         created_at:
           description: When the submission was created or started
           type: string

--- a/schemas/constructs/v1beta2/connection/connection.yaml
+++ b/schemas/constructs/v1beta2/connection/connection.yaml
@@ -91,7 +91,7 @@ properties:
   user_id:
     x-go-name: UserID
     x-oapi-codegen-extra-tags:
-      db: user_id
+      db: owner
       yaml: user_id
     x-order: 9
     $ref: ../core/api.yml#/components/schemas/Uuid

--- a/schemas/constructs/v1beta2/credential/api.yml
+++ b/schemas/constructs/v1beta2/credential/api.yml
@@ -232,7 +232,7 @@ components:
           description: UUID of the user who owns this credential.
           x-order: 3
           x-oapi-codegen-extra-tags:
-            db: "user_id"
+            db: "owner"
         type:
           type: string
           description: Credential type (e.g. token, basic, AWS).

--- a/schemas/constructs/v1beta2/schedule/api.yml
+++ b/schemas/constructs/v1beta2/schedule/api.yml
@@ -188,7 +188,7 @@ components:
           description: UUID of the user who owns this schedule.
           x-order: 3
           x-oapi-codegen-extra-tags:
-            db: "user_id"
+            db: "owner"
             json: userId
         cronExpression:
           type: string

--- a/schemas/constructs/v1beta2/team/api.yml
+++ b/schemas/constructs/v1beta2/team/api.yml
@@ -162,7 +162,7 @@ components:
           $ref: ../../v1alpha1/core/api.yml#/components/schemas/uuid
           description: User ID
           x-oapi-codegen-extra-tags:
-            db: user_id
+            db: owner
             json: userId
         roleId:
           $ref: ../../v1alpha1/core/api.yml#/components/schemas/uuid

--- a/schemas/constructs/v1beta2/token/token.yaml
+++ b/schemas/constructs/v1beta2/token/token.yaml
@@ -13,7 +13,7 @@ properties:
     description: UUID of the user who owns the token.
     x-order: 2
     x-oapi-codegen-extra-tags:
-      db: user_id
+      db: owner
   provider:
     type: string
     description: Authentication provider associated with the token.

--- a/schemas/constructs/v1beta2/view/api.yml
+++ b/schemas/constructs/v1beta2/view/api.yml
@@ -139,7 +139,7 @@ components:
           x-go-name: UserID
           x-go-type-skip-optional-pointer: true
           x-oapi-codegen-extra-tags:
-            db: user_id
+            db: owner
             json: "userId,omitempty"
         workspaceName:
           type: string

--- a/schemas/constructs/v1beta2/view/view.yaml
+++ b/schemas/constructs/v1beta2/view/view.yaml
@@ -79,7 +79,7 @@ properties:
     x-go-type-skip-optional-pointer: true
     x-order: 6
     x-oapi-codegen-extra-tags:
-      db: user_id
+      db: owner
       json: userId
   createdAt:
     type: string

--- a/schemas/constructs/v1beta3/design/api.yml
+++ b/schemas/constructs/v1beta3/design/api.yml
@@ -789,7 +789,7 @@ components:
           $ref: "../../v1beta2/core/api.yml#/components/schemas/Id"
           description: Owning user ID.
           x-oapi-codegen-extra-tags:
-            db: user_id
+            db: owner
         user:
           $ref: "../../v1beta2/user/api.yml#/components/schemas/User"
           description: >


### PR DESCRIPTION
**Notes for Reviewers**

This PR is the db-tag correction round of the identifier-uniformity remediation program (plan section 0 CORRECTION). The live production Postgres column for the record-owner field is `owner`, not `user_id`, across the owner-consolidated tables. Authority: `database/cloud-schema.sql` at `layer5io/meshery-cloud` master, freshly dumped from production in layer5io/meshery-cloud#5620. Every change below was individually gated on that snapshot - no batch assumptions.

Any schemas `x-oapi-codegen-extra-tags` `db:"user_id"` on a construct backed by an owner-consolidated cloud table produces silent zero-value scans in canonical-type consumers (pop/sqlx map columns via the `db` tag; `RETURNING *` and `SELECT *` scans quietly leave the field zero when the tag names a nonexistent column). This PR corrects those tags to `db:"owner"`.

**Scope guarantees**

- Wire is untouched. Every changed line in the regenerated Go models flips only `db:"user_id"` to `db:"owner"`; all `json:`/`yaml:` tags are byte-identical. No YAML property names, refs, or enum values changed.
- Generator-driven: YAML changed first, then `make generate-golang`. No generated file was hand-edited.
- Supersedes the db-mapping intent of #977, which hand-edited generated models, bundled unrelated files, and renamed wire identifiers (`userId`/`ownerId` to `owner`), violating the program casing contract (wire stays camelCase; `owner` is the DB column only). This PR is the surgical, generator-driven replacement for that intent.

**Fixed: db tag corrected `user_id` -> `owner` (19 YAML tags, 19 generated Go lines)**

| Construct (version) | Schema element | Cloud table | Confirmed live column (cloud-schema.sql) | Change |
|---|---|---|---|---|
| design (v1beta3) | `DesignSchema.userId` | `meshery_patterns` | `owner uuid NOT NULL` + column comment "User (owner) ID who created/owns this pattern" | `db: user_id` -> `db: owner` |
| token (v1beta1, v1beta2) | `UserToken.user_id` | `user_tokens` | `owner uuid` + owner column comment | `db` -> `owner` |
| credential (v1beta1, v1beta2) | `Credential.user_id` / `.userId` | `credentials` | `owner uuid NOT NULL` | `db` -> `owner` |
| schedule (v1beta1, v1beta2) | `Schedule.user_id` / `.userId` | `schedules` | `owner uuid NOT NULL` | `db` -> `owner` |
| connection (v1beta1, v1beta2) | `Connection.user_id` | `connections` | `owner uuid NOT NULL` | `db` -> `owner` |
| team (v1beta1 `TeamsUsersMapping`, v1beta2 `UsersTeamsMapping`) | `user_id` / `userId` | `users_teams_mappings` | `owner uuid NOT NULL` | `db` -> `owner` |
| view (v1beta1, v1beta2) | `MesheryView.userId`/`user_id` (entity yaml + api.yml schema) | `meshery_views` | `owner uuid NOT NULL` | `db` -> `owner` |
| academy (v1beta1, v1beta2) | `AcademyRegistration.user_id` | `academy_registrations` | `owner uuid NOT NULL` + owner column comment | `db` -> `owner` |
| academy (v1beta1, v1beta2) | `TestSubmission.user_id` | `test_submissions` | `owner uuid NOT NULL`; cloud DAO already does `INSERT INTO test_submissions (... owner ...) RETURNING *` (server/handlers/academy/dao.go:130) | `db` -> `owner` |

**Verified correct and left unchanged**

| Element | Verdict | Evidence |
|---|---|---|
| filter v1beta3 `filter.yaml` | Already `db: owner` - correct, untouched | `meshery_filters.owner` in cloud-schema.sql |
| academy v1beta3 `AcademyRegistration` / `TestSubmission` (the version cloud imports) | Already `db: owner` - correct | v1beta3/academy/api.yml:1170, 1730; cloud imports `models/v1beta3/academy` |
| academy `UserRegistration` (v1beta1:1916, v1beta2:1865, v1beta3:1882) `db: user_id` | Correct - do not change | It is a JOIN projection, not table-backed: cloud scans it from `SELECT ... users.id AS user_id ... FROM academy_registrations JOIN users ON academy_registrations.owner = users.id` (server/handlers/academy/instructor-console.go, GetCuriculaRegistrations). The tag maps to the SELECT alias. |
| user v1beta1/v1beta2 `User.user_id`/`.userId` `db: "user_id"` | Correct - do not change | `users.user_id character varying(200) NOT NULL` is the real external-identifier column, not an owner FK |
| core `UserUuid` (v1beta2) / `user_uuid` (v1beta1, v1alpha1) with `db: user_id` | Left alone | Only db-tag consumer is the event construct; there is no `events` table in cloud (only `event_trackers`). Events persist in Meshery Server's local DB via GORM, which ignores `db` tags. Not backed by an owner-consolidated cloud table. |
| `models/v1alpha2/patterns.go` `db:"user_id"` (MesheryPattern, MesheryPatternResource) | Left alone | Frozen legacy generated artifact: no source YAML exists and `build/generate-golang.js` has no v1alpha2/patterns mapping, so regeneration cannot produce it; hand-editing generated output is prohibited. Cloud uses only `v1alpha2.PatternFile` (design-file conversion), never scans these structs. Flagging for a follow-up if v1alpha2 pattern structs ever gain a DB consumer. |

**Gates (all run, all passing)**

- `make generate-golang` - regenerated; diff in `models/` is exactly 19 lines, each flipping only the `db` tag
- `make validate-schemas` - no blocking violations
- `go test ./...` - all packages pass
- `go run ./cmd/consumer-audit --cloud-repo ... --meshery-repo ...` - 0 blocking violations for both consumers (2 pre-existing advisory findings in meshery-cloud `ui/api/catalog.ts` wire params, unrelated to db tags)

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
