### PR TITLE
[organization] Add AuthBranding preferences and UsersOrganizationsMapping schemas (plan 3.2)

### DIFF
--- a/models/v1beta2/organization/organization.go
+++ b/models/v1beta2/organization/organization.go
@@ -15,6 +15,15 @@ const (
 	Delete OrgTeamActionPayloadAction = "delete"
 )
 
+// AuthBranding Optional per-organization branding overrides for the auth pages: carousel slides and FAQ entries. Stored as JSON inside organization.metadata.preferences, so no dedicated column backs it. Empty or omitted fields fall back to the platform defaults.
+type AuthBranding struct {
+	// Carousel Ordered slides rendered in the auth-page feature carousel.
+	Carousel *[]CarouselSlide `json:"carousel,omitempty" yaml:"carousel,omitempty"`
+
+	// Faqs FAQ entries rendered on the auth pages.
+	Faqs *[]FAQ `json:"faqs,omitempty" yaml:"faqs,omitempty"`
+}
+
 // AvailableOrganization Organization listing record used in list and get responses.
 type AvailableOrganization struct {
 	Country     Text         `json:"country,omitempty" yaml:"country,omitempty"`
@@ -45,8 +54,29 @@ type AvailableTeam struct {
 	UpdatedAt   Time                   `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 }
 
+// CarouselSlide A single slide in the auth-page feature carousel.
+type CarouselSlide struct {
+	// Description Slide description text.
+	Description string `json:"description" yaml:"description"`
+
+	// ImageURL URL of the slide image asset.
+	ImageURL string `json:"imageUrl" yaml:"imageUrl"`
+
+	// Title Slide title.
+	Title string `json:"title" yaml:"title"`
+}
+
 // DashboardPrefs Preferences specific to dashboard behavior.
 type DashboardPrefs map[string]interface{}
+
+// FAQ A single question/answer pair for the auth-page FAQ section.
+type FAQ struct {
+	// Answer The answer text.
+	Answer string `json:"answer" yaml:"answer"`
+
+	// Question The question text.
+	Question string `json:"question" yaml:"question"`
+}
 
 // Links Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.
 type Links struct {
@@ -187,6 +217,9 @@ type OrganizationsPage struct {
 
 // Preferences Organization-level user experience preferences.
 type Preferences struct {
+	// AuthBranding Optional per-organization branding overrides for the auth pages: carousel slides and FAQ entries. Stored as JSON inside organization.metadata.preferences, so no dedicated column backs it. Empty or omitted fields fall back to the platform defaults.
+	AuthBranding *AuthBranding `json:"authBranding,omitempty" yaml:"authBranding,omitempty"`
+
 	// Dashboard Preferences specific to dashboard behavior.
 	Dashboard DashboardPrefs `json:"dashboard" yaml:"dashboard"`
 
@@ -264,6 +297,38 @@ type Time = core.Time
 
 // UUID A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
 type UUID = core.Uuid
+
+// UsersOrganizationsMapping Junction record linking a user to an organization, optionally carrying the role the user holds in that organization. Backed by the users_organizations_mappings table, whose user foreign-key column is named owner.
+type UsersOrganizationsMapping struct {
+	CreatedAt Time                   `db:"created_at" json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+	DeletedAt NullableTime           `db:"deleted_at" json:"deletedAt,omitempty" yaml:"deletedAt,omitempty"`
+	ID        core.GeneralId `db:"id" json:"id" yaml:"id"`
+
+	// OrganizationId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	OrganizationID *UUID `db:"organization_id" json:"organizationId" yaml:"organizationId,omitempty"`
+
+	// RoleId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	RoleID    *UUID `db:"role_id" json:"roleId,omitempty" yaml:"roleId,omitempty"`
+	UpdatedAt Time  `db:"updated_at" json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	UserID *UUID `db:"owner" json:"userId" yaml:"userId,omitempty"`
+}
+
+// UsersOrganizationsMappingPage Paginated list of user-organization mappings.
+type UsersOrganizationsMappingPage struct {
+	// Data User-organization mapping entries.
+	Data *[]UsersOrganizationsMapping `json:"data,omitempty" yaml:"data,omitempty"`
+
+	// Page Zero-based page index returned in this response.
+	Page *int `json:"page,omitempty" yaml:"page,omitempty"`
+
+	// PageSize Maximum number of items returned on each page.
+	PageSize *int `json:"pageSize,omitempty" yaml:"pageSize,omitempty"`
+
+	// TotalCount Total number of items across all pages.
+	TotalCount *int `json:"totalCount,omitempty" yaml:"totalCount,omitempty"`
+}
 
 // All defines model for all.
 type All = bool

--- a/schemas/constructs/v1beta2/organization/api.yml
+++ b/schemas/constructs/v1beta2/organization/api.yml
@@ -511,6 +511,67 @@ components:
             entry pointing at https://slack.meshery.io, a "discussion forum"
             entry, or a "support desk" entry holding a phone number.
 
+    CarouselSlide:
+      type: object
+      x-internal: ["cloud"]
+      description: A single slide in the auth-page feature carousel.
+      required:
+        - imageUrl
+        - title
+        - description
+      properties:
+        imageUrl:
+          type: string
+          format: uri
+          maxLength: 2048
+          description: URL of the slide image asset.
+          x-go-name: ImageURL
+        title:
+          type: string
+          maxLength: 500
+          description: Slide title.
+        description:
+          type: string
+          maxLength: 2048
+          description: Slide description text.
+
+    FAQ:
+      type: object
+      x-internal: ["cloud"]
+      description: A single question/answer pair for the auth-page FAQ section.
+      required:
+        - question
+        - answer
+      properties:
+        question:
+          type: string
+          maxLength: 500
+          description: The question text.
+        answer:
+          type: string
+          maxLength: 5000
+          description: The answer text.
+
+    AuthBranding:
+      type: object
+      x-internal: ["cloud"]
+      description: >-
+        Optional per-organization branding overrides for the auth pages:
+        carousel slides and FAQ entries. Stored as JSON inside
+        organization.metadata.preferences, so no dedicated column backs it.
+        Empty or omitted fields fall back to the platform defaults.
+      properties:
+        carousel:
+          type: array
+          description: Ordered slides rendered in the auth-page feature carousel.
+          items:
+            $ref: "#/components/schemas/CarouselSlide"
+        faqs:
+          type: array
+          description: FAQ entries rendered on the auth pages.
+          items:
+            $ref: "#/components/schemas/FAQ"
+
     Preferences:
       type: object
       description: Organization-level user experience preferences.
@@ -524,6 +585,9 @@ components:
         dashboard:
           x-go-type: "DashboardPrefs"
           $ref: "#/components/schemas/DashboardPrefs"
+        authBranding:
+          x-go-type: "AuthBranding"
+          $ref: "#/components/schemas/AuthBranding"
         links:
           x-go-type: "Links"
           $ref: "#/components/schemas/Links"
@@ -792,3 +856,82 @@ components:
           description: Team-organization mapping entries.
           items:
             $ref: "#/components/schemas/TeamsOrganizationsMapping"
+
+    UsersOrganizationsMapping:
+      type: object
+      description: >-
+        Junction record linking a user to an organization, optionally carrying
+        the role the user holds in that organization. Backed by the
+        users_organizations_mappings table, whose user foreign-key column is
+        named owner.
+      properties:
+        id:
+          $ref: "../../v1alpha1/core/api.yml#/components/schemas/general_id"
+          description: Mapping record ID.
+        userId:
+          $ref: "#/components/schemas/UUID"
+          description: User ID for this mapping. Stored in the owner column.
+          x-go-name: UserID
+          x-oapi-codegen-extra-tags:
+            db: owner
+            json: userId
+        organizationId:
+          $ref: "#/components/schemas/UUID"
+          description: Organization ID for this mapping.
+          x-go-name: OrganizationID
+          x-oapi-codegen-extra-tags:
+            db: organization_id
+            json: organizationId
+        roleId:
+          $ref: "#/components/schemas/UUID"
+          description: >-
+            Role the user holds within the organization; omitted when no
+            explicit role is assigned.
+          x-go-name: RoleID
+          x-oapi-codegen-extra-tags:
+            db: role_id
+            json: "roleId,omitempty"
+        createdAt:
+          $ref: "#/components/schemas/Time"
+          description: Timestamp when the mapping was created.
+          x-oapi-codegen-extra-tags:
+            db: created_at
+            json: "createdAt,omitempty"
+        updatedAt:
+          $ref: "#/components/schemas/Time"
+          description: Timestamp when the mapping was last updated.
+          x-oapi-codegen-extra-tags:
+            db: updated_at
+            json: "updatedAt,omitempty"
+        deletedAt:
+          $ref: "#/components/schemas/NullableTime"
+          description: Timestamp when the mapping was soft-deleted.
+          x-oapi-codegen-extra-tags:
+            db: deleted_at
+            json: "deletedAt,omitempty"
+
+    UsersOrganizationsMappingPage:
+      type: object
+      description: Paginated list of user-organization mappings.
+      properties:
+        page:
+          type: integer
+          description: Zero-based page index returned in this response.
+          minimum: 0
+        pageSize:
+          type: integer
+          description: Maximum number of items returned on each page.
+          minimum: 1
+          x-oapi-codegen-extra-tags:
+            json: "pageSize,omitempty"
+        totalCount:
+          type: integer
+          description: Total number of items across all pages.
+          minimum: 0
+          x-oapi-codegen-extra-tags:
+            json: "totalCount,omitempty"
+        data:
+          type: array
+          description: User-organization mapping entries.
+          items:
+            $ref: "#/components/schemas/UsersOrganizationsMapping"


### PR DESCRIPTION
**Notes for Reviewers**

Plan section 3.2 ("add-to-schemas-first") of the cross-repo identifier-uniformity remediation program (`meshery-cloud:docs/plans/schemas-cloud-identifier-uniformity-remediation.md`), rows 1-2: meshery-cloud hand-rolls these wire/DB types under `server/models/**` with no canonical schema. This PR authors them in `schemas/constructs/v1beta2/organization/` so cloud can consume the generated types and retire its local copies.

**Additive only.** New component schemas plus one new optional property (`Preferences.authBranding`); no existing wire contract, endpoint, or published casing is touched.

| Schema added | Replaces cloud local type (file) | Notes |
|---|---|---|
| `AuthBranding` | `OrgAuthBranding` (`server/models/model_organization.go`, `server/models/auth_flow_response.go`) | Attached to `Preferences` as optional `authBranding`; JSONB-backed via `organization.metadata.preferences` - no db tags |
| `CarouselSlide` | `CarouselSlide` (`server/models/auth_flow_response.go`) | `imageUrl`/`title`/`description` required; `x-go-name: ImageURL` for proper Go initialism |
| `FAQ` | `FAQ` (`server/models/auth_flow_response.go`) | `question`/`answer` required |
| `UsersOrganizationsMapping` | `UsersOrganizationsMapping` (`server/models/model_users_organizations_mapping.go`) | Mirrors sibling `TeamsOrganizationsMapping`; wire `userId`/`organizationId`/`roleId` camelCase |
| `UsersOrganizationsMappingPage` | (new; cloud handlers currently return raw slices/untyped envelopes) | camelCase `page`/`pageSize`/`totalCount`/`data` |

**db-tag gate (plan section 0 CORRECTION + section 1 live-column gate):** confirmed against the refreshed `meshery-cloud:database/cloud-schema.sql` (`CREATE TABLE public.users_organizations_mappings`, line 2111): the user FK column is **`owner`** (`COMMENT ... 'User (owner) ID in this mapping'`). `userId` therefore carries `db:"owner"`. Remaining columns confirmed as declared: `organization_id`, `role_id`, `created_at`, `updated_at`, `deleted_at`, `id`.

**Gates (all pass):**
- `make generate-golang` - regenerated `models/v1beta2/organization/organization.go` (committed); generated `UserID *UUID` carries `db:"owner" json:"userId"` as gated
- `make validate-schemas` - no blocking violations
- `go test ./...` - pass
- `go run ./cmd/consumer-audit --cloud-repo ... --meshery-repo ...` - exit 0 (two pre-existing non-blocking TS findings in cloud `ui/api/catalog.ts` `user_id` query params, unrelated to this change and already tracked by the program plan)

**Follow-ups (cloud consume step, not this PR):**
- `UsersOrganizationsMapping` needs a `TableName() string { return "users_organizations_mappings" }` pop helper when cloud adopts the generated type; the sibling `TeamsOrganizationsMapping` has none in schemas either, so this belongs in a `<construct>_helper.go` follow-up (not hand-added to generated files here).
- Cloud's `RoleId` is `nulls.UUID`; generated `RoleID` is `*UUID` - the cloud consume PR adapts the DAO accordingly.
- `addUserToOrg` (201) still responds `additionalProperties: true`; typing it as `UsersOrganizationsMapping`/`...Page` is a candidate once the cloud consume PR pins the exact handler wire shape.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
