### PR TITLE
[schemas] Add EnvironmentConnectionMappingPage, K8sContext(+Page), and sendTestEmail contracts (uniformity 3.2)

### DIFF
--- a/models/v1beta1/system/system.go
+++ b/models/v1beta1/system/system.go
@@ -8,7 +8,32 @@ import (
 	"fmt"
 
 	core "github.com/meshery/schemas/models/core"
+	openapi_types "github.com/oapi-codegen/runtime/types"
 )
+
+// EmailTestRequest Request body for sending a test email through the configured SMTP provider.
+type EmailTestRequest struct {
+	// Subject Subject line for the test message. A default subject is used when omitted.
+	Subject *string `json:"subject,omitempty" yaml:"subject,omitempty"`
+
+	// To Recipient email address for the test message.
+	To openapi_types.Email `json:"to" yaml:"to"`
+}
+
+// EmailTestResponse Result of a test email send attempt.
+type EmailTestResponse struct {
+	// Message Human-readable result message.
+	Message string `json:"message" yaml:"message"`
+
+	// SentTo Recipient address the test email was sent to.
+	SentTo openapi_types.Email `json:"sentTo" yaml:"sentTo"`
+
+	// Status Outcome status of the send attempt (e.g. `success`).
+	Status string `json:"status" yaml:"status"`
+
+	// Timestamp Unix-epoch seconds, as a decimal string, when the test email was sent.
+	Timestamp string `json:"timestamp" yaml:"timestamp"`
+}
 
 // SystemDatabaseSummary Paginated summary of the Meshery server's embedded database.
 type SystemDatabaseSummary struct {

--- a/models/v1beta3/connection/connection.go
+++ b/models/v1beta3/connection/connection.go
@@ -253,6 +253,66 @@ type ConnectionsStatusPage struct {
 	TotalCount int `json:"totalCount" yaml:"totalCount"`
 }
 
+// K8sContext Kubernetes-specific authentication context projected from a kubernetes connection and its credential. Connection metadata supplies the context identity (id, name, server, version, deployment type, instance and server IDs); the credential secret supplies the auth and cluster material. This is a response projection, not a stored table row.
+type K8sContext struct {
+	// Auth Authentication material for the context (token or kubeconfig reference), sourced from the connection's credential secret.
+	Auth core.Map `json:"auth,omitempty" yaml:"auth,omitempty"`
+
+	// Cluster Cluster definition for the context (certificate authority and server details), sourced from the connection's credential secret.
+	Cluster core.Map `json:"cluster,omitempty" yaml:"cluster,omitempty"`
+
+	// ConnectionId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	ConnectionID *core.Uuid `json:"connectionId,omitempty" yaml:"connectionId,omitempty"`
+
+	// CreatedAt Timestamp when the underlying connection was created.
+	CreatedAt time.Time `json:"createdAt,omitempty" yaml:"createdAt,omitempty"`
+
+	// CreatedBy A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	CreatedBy *core.Uuid `json:"createdBy,omitempty" yaml:"createdBy,omitempty"`
+
+	// DeploymentType How Meshery is deployed relative to the cluster (e.g. in_cluster, out_of_cluster).
+	DeploymentType string `json:"deploymentType" yaml:"deploymentType"`
+
+	// ID Stable identifier of the Kubernetes context, assigned when the context is registered. Not a UUID; carried in connection metadata.
+	ID string `json:"id,omitempty" yaml:"id,omitempty"`
+
+	// KubernetesServerId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	KubernetesServerID *core.Uuid `json:"kubernetesServerId,omitempty" yaml:"kubernetesServerId,omitempty"`
+
+	// MesheryInstanceId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	MesheryInstanceID *core.Uuid `json:"mesheryInstanceId,omitempty" yaml:"mesheryInstanceId,omitempty"`
+
+	// Name Human-readable name of the Kubernetes context.
+	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	// Owner A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	Owner *core.Uuid `json:"owner,omitempty" yaml:"owner,omitempty"`
+
+	// Server API server URL of the Kubernetes cluster.
+	Server string `json:"server,omitempty" yaml:"server,omitempty"`
+
+	// UpdatedAt Timestamp when the underlying connection was last updated.
+	UpdatedAt time.Time `json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
+
+	// Version Kubernetes server version of the cluster.
+	Version string `json:"version" yaml:"version"`
+}
+
+// K8sContextPage Paginated list of Kubernetes contexts.
+type K8sContextPage struct {
+	// Contexts Kubernetes contexts in this page.
+	Contexts []K8sContext `json:"contexts" yaml:"contexts"`
+
+	// Page Zero-based page index returned in this response.
+	Page int `json:"page" yaml:"page"`
+
+	// PageSize Maximum number of items returned on each page.
+	PageSize int `json:"pageSize" yaml:"pageSize"`
+
+	// TotalCount Total number of items across all pages.
+	TotalCount int `json:"totalCount" yaml:"totalCount"`
+}
+
 // MesheryCompatibility Meshery version compatibility check
 type MesheryCompatibility struct {
 	// CheckCompatibility Whether to check compatibility

--- a/models/v1beta3/environment/environment.go
+++ b/models/v1beta3/environment/environment.go
@@ -56,6 +56,21 @@ type EnvironmentConnectionMapping struct {
 	UpdatedAt     core.Time      `db:"updated_at" json:"updatedAt" yaml:"updatedAt,omitempty"`
 }
 
+// EnvironmentConnectionMappingPage Paginated list of environment-to-connection mapping records, returned when a connection is assigned to or unassigned from an environment. Distinct from EnvironmentConnectionsPage, which lists the connections themselves rather than the junction records.
+type EnvironmentConnectionMappingPage struct {
+	// EnvironmentConnectionMapping Environment-to-connection mapping records in this page.
+	EnvironmentConnectionMapping []EnvironmentConnectionMapping `json:"environmentConnectionMapping" yaml:"environmentConnectionMapping"`
+
+	// Page Zero-based page index returned in this response.
+	Page int `json:"page" yaml:"page"`
+
+	// PageSize Maximum number of items returned on each page.
+	PageSize int `json:"pageSize" yaml:"pageSize"`
+
+	// TotalCount Total number of items across all pages.
+	TotalCount int `json:"totalCount" yaml:"totalCount"`
+}
+
 // EnvironmentConnectionsPage Paginated list of connections associated with an environment.
 type EnvironmentConnectionsPage struct {
 	// Connections The connections of the environmentconnectionspage.

--- a/schemas/constructs/v1beta1/system/api.yml
+++ b/schemas/constructs/v1beta1/system/api.yml
@@ -117,6 +117,37 @@ paths:
         "500":
           description: Encoding error while serializing the version payload.
 
+  /api/system/email/test:
+    post:
+      x-internal: ["cloud"]
+      tags:
+        - System
+      summary: Send a test email
+      description: >-
+        Sends a test email through the configured SMTP provider to verify the
+        email configuration. Restricted to provider administrators.
+      operationId: sendTestEmail
+      requestBody:
+        description: Recipient and optional subject for the test email.
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/EmailTestRequest"
+      responses:
+        "200":
+          description: Test email sent
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/EmailTestResponse"
+        "400":
+          description: Invalid request payload or malformed recipient email address.
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          description: Email configuration validation failed or the send attempt errored.
+
   /api/system/sync:
     get:
       x-internal: ["meshery"]
@@ -149,6 +180,54 @@ components:
       bearerFormat: JWT
 
   schemas:
+    EmailTestRequest:
+      type: object
+      description: Request body for sending a test email through the configured SMTP provider.
+      additionalProperties: false
+      required:
+        - to
+      properties:
+        to:
+          type: string
+          description: Recipient email address for the test message.
+          format: email
+          maxLength: 320
+        subject:
+          type: string
+          description: Subject line for the test message. A default subject is used when omitted.
+          maxLength: 998
+          x-oapi-codegen-extra-tags:
+            json: "subject,omitempty"
+
+    EmailTestResponse:
+      type: object
+      description: Result of a test email send attempt.
+      additionalProperties: false
+      required:
+        - status
+        - message
+        - timestamp
+        - sentTo
+      properties:
+        status:
+          type: string
+          description: Outcome status of the send attempt (e.g. `success`).
+          maxLength: 64
+        message:
+          type: string
+          description: Human-readable result message.
+          maxLength: 1024
+        timestamp:
+          type: string
+          description: Unix-epoch seconds, as a decimal string, when the test email was sent.
+          pattern: "^[0-9]+$"
+          maxLength: 20
+        sentTo:
+          type: string
+          description: Recipient address the test email was sent to.
+          format: email
+          maxLength: 320
+
     SystemMessageResponse:
       type: object
       description: Status message response.

--- a/schemas/constructs/v1beta3/connection/api.yml
+++ b/schemas/constructs/v1beta3/connection/api.yml
@@ -217,7 +217,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                $ref: "#/components/schemas/K8sContextPage"
         "401":
           $ref: "#/components/responses/401"
         "404":
@@ -1040,3 +1040,152 @@ components:
           description: Whether to check compatibility
           x-oapi-codegen-extra-tags:
             json: "checkCompatibility,omitempty"
+
+    K8sContext:
+      type: object
+      description: >-
+        Kubernetes-specific authentication context projected from a kubernetes
+        connection and its credential. Connection metadata supplies the context
+        identity (id, name, server, version, deployment type, instance and
+        server IDs); the credential secret supplies the auth and cluster
+        material. This is a response projection, not a stored table row.
+      properties:
+        id:
+          type: string
+          description: >-
+            Stable identifier of the Kubernetes context, assigned when the
+            context is registered. Not a UUID; carried in connection metadata.
+          x-id-format: external
+          maxLength: 255
+          x-go-name: ID
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "id,omitempty"
+        name:
+          type: string
+          description: Human-readable name of the Kubernetes context.
+          maxLength: 255
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "name,omitempty"
+        auth:
+          type: object
+          description: >-
+            Authentication material for the context (token or kubeconfig
+            reference), sourced from the connection's credential secret.
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "auth,omitempty"
+        cluster:
+          type: object
+          description: >-
+            Cluster definition for the context (certificate authority and
+            server details), sourced from the connection's credential secret.
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "cluster,omitempty"
+        server:
+          type: string
+          description: API server URL of the Kubernetes cluster.
+          maxLength: 2048
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "server,omitempty"
+        owner:
+          $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid
+          description: ID of the user who owns the underlying connection.
+          x-oapi-codegen-extra-tags:
+            json: "owner,omitempty"
+        createdBy:
+          $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid
+          description: ID of the user who registered the context.
+          x-oapi-codegen-extra-tags:
+            json: "createdBy,omitempty"
+        mesheryInstanceId:
+          $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid
+          description: ID of the Meshery instance the context is registered with.
+          x-go-name: MesheryInstanceID
+          x-oapi-codegen-extra-tags:
+            json: "mesheryInstanceId,omitempty"
+        kubernetesServerId:
+          $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid
+          description: ID of the Kubernetes server associated with the context.
+          x-go-name: KubernetesServerID
+          x-oapi-codegen-extra-tags:
+            json: "kubernetesServerId,omitempty"
+        deploymentType:
+          type: string
+          description: How Meshery is deployed relative to the cluster (e.g. in_cluster, out_of_cluster).
+          maxLength: 64
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "deploymentType"
+        version:
+          type: string
+          description: Kubernetes server version of the cluster.
+          maxLength: 64
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "version"
+        createdAt:
+          type: string
+          description: Timestamp when the underlying connection was created.
+          format: date-time
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "createdAt,omitempty"
+        updatedAt:
+          type: string
+          description: Timestamp when the underlying connection was last updated.
+          format: date-time
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "updatedAt,omitempty"
+        connectionId:
+          $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid
+          description: ID of the connection this context was projected from.
+          x-go-name: ConnectionID
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "connectionId,omitempty"
+
+    K8sContextPage:
+      type: object
+      description: Paginated list of Kubernetes contexts.
+      required:
+        - page
+        - pageSize
+        - totalCount
+        - contexts
+      properties:
+        page:
+          type: integer
+          description: Zero-based page index returned in this response.
+          minimum: 0
+          x-oapi-codegen-extra-tags:
+            json: "page"
+        pageSize:
+          type: integer
+          description: Maximum number of items returned on each page.
+          minimum: 1
+          x-oapi-codegen-extra-tags:
+            json: "pageSize"
+        totalCount:
+          type: integer
+          description: Total number of items across all pages.
+          minimum: 0
+          x-oapi-codegen-extra-tags:
+            json: "totalCount"
+        contexts:
+          type: array
+          description: Kubernetes contexts in this page.
+          items:
+            $ref: "#/components/schemas/K8sContext"
+          x-oapi-codegen-extra-tags:
+            json: "contexts"

--- a/schemas/constructs/v1beta3/environment/api.yml
+++ b/schemas/constructs/v1beta3/environment/api.yml
@@ -193,6 +193,43 @@ components:
             additionalProperties: true
           description: The connections of the environmentconnectionspage.
 
+    EnvironmentConnectionMappingPage:
+      type: object
+      description: >-
+        Paginated list of environment-to-connection mapping records, returned
+        when a connection is assigned to or unassigned from an environment.
+        Distinct from EnvironmentConnectionsPage, which lists the connections
+        themselves rather than the junction records.
+      required:
+        - page
+        - pageSize
+        - totalCount
+        - environmentConnectionMapping
+      properties:
+        page:
+          type: integer
+          description: Zero-based page index returned in this response.
+          minimum: 0
+        pageSize:
+          type: integer
+          description: Maximum number of items returned on each page.
+          minimum: 1
+          x-oapi-codegen-extra-tags:
+            json: pageSize
+        totalCount:
+          type: integer
+          description: Total number of items across all pages.
+          minimum: 0
+          x-oapi-codegen-extra-tags:
+            json: totalCount
+        environmentConnectionMapping:
+          type: array
+          description: Environment-to-connection mapping records in this page.
+          x-oapi-codegen-extra-tags:
+            json: environmentConnectionMapping
+          items:
+            $ref: "#/components/schemas/EnvironmentConnectionMapping"
+
   requestBodies:
     environmentPayload:
       description: Body for creating environment


### PR DESCRIPTION
**Notes for Reviewers**

This PR implements plan section 3.2 ("add-to-schemas-first") of the cross-repo identifier-uniformity remediation program (`meshery-cloud:docs/plans/schemas-cloud-identifier-uniformity-remediation.md`) for three constructs whose wire types are hand-rolled in meshery-cloud with no canonical schema. **Additive-only: new component schemas plus one new operation; no existing wire property, path, or published casing is touched.**

| Schema added | Location | Replaces meshery-cloud local type (file) | Notes |
|---|---|---|---|
| `EnvironmentConnectionMappingPage` | `schemas/constructs/v1beta3/environment/api.yml` | `EnvironmentConnectionMappingPage` (`server/models/model_environment_connection_mapping.go`) | Envelope served by `AddConnectionToEnvironment`/`RemoveConnectionFromEnvironment`. Per the plan, deliberately NOT a reuse of `EnvironmentConnectionsPage` - that envelope carries a `connections[]` array of connection objects; this one carries `environmentConnectionMapping[]` junction records. Items ref the existing `EnvironmentConnectionMapping` entity. |
| `K8sContext` + `K8sContextPage` | `schemas/constructs/v1beta3/connection/api.yml` | `K8sContext`, `K8sContextPage` (`server/models/k8s_context.go`) | Wire is the canonical camelCase the cloud struct already emits (`mesheryInstanceId`, `kubernetesServerId`, `deploymentType`, `connectionId`). The existing `getKubernetesContext` operation's untyped `type: object` 200 response is repointed to `K8sContextPage` (typing fix for an already-published cloud+meshery op; previously conveyed no contract). `SystemSessionSyncK8sContext` (v1beta1/system) was verified NOT equivalent: it is the Meshery Server session-sync projection (32-hex `id`, `clusterConfigured`, `clusterId`) with no `auth`/`cluster` material, no `owner`/`createdBy`, no `connectionId`/`deploymentType`/`version`. |
| `EmailTestRequest` + `EmailTestResponse` + `sendTestEmail` op | `schemas/constructs/v1beta1/system/api.yml` | `EmailTestRequest`, `EmailTestResponse` (`server/models/smtp.go`) | New `POST /api/system/email/test` operation (`x-internal: ["cloud"]`), matching the cloud route served by `SendTestEmailHandler` (admin-gated). `OrgTemplateVars`/`TemplateVars` intentionally left out of schemas - they are untagged internal template types, not wire contracts. The system construct owns `/api/system/*`; no other api.yml carried smtp/email operations. |

**db-tag gate (section 0 CORRECTION):** `K8sContext` carries **no `db:` tags by design**. The live production schema (`meshery-cloud:database/cloud-schema.sql`) has **no `k8s_contexts` table** - only legacy `move_to_connections`/`move_to_credentials` functions still reference it. Cloud's DAO never scans this type; `buildK8sContextFromConnection` (`server/handlers/connections.go`) projects it from connection metadata + credential secret via a JSON round-trip, so only the JSON tags are load-bearing. The `db:` tags on the local cloud struct are vestigial. The two new page envelopes and the email payloads are likewise not DB-scanned.

**Field-type adaptations for the cloud consume step (expected, per plan):**
- `K8sContext.Auth`/`Cluster`: `core.Map` (canonical) instead of pop `slices.Map` (same underlying `map[string]interface{}`).
- `K8sContext.ConnectionID`: `*core.Uuid` instead of local `string` (handler currently assigns `conn.ID.String()`; assigns `&conn.ID` after consume).
- `EnvironmentConnectionMappingPage.EnvironmentConnectionMapping`: `[]EnvironmentConnectionMapping` (values) instead of local `[]*EnvironmentConnectionMapping`.
- `EmailTestRequest.To`/`EmailTestResponse.SentTo`: `openapi_types.Email` instead of `string` (repo-wide pattern for `format: email`).
- Cloud's local `validate:"required,email"` tag on `EmailTestRequest.To` is expressed here as `required` + `format: email`; the handler keeps its runtime validation.

**Follow-ups (not in this PR):**
- Wiring `addConnectionToEnvironment`/`removeConnectionFromEnvironment` 201/204 responses to `EnvironmentConnectionMappingPage`: cloud actually returns 200 + this envelope, but both ops are bundled `["cloud", "meshery"]` and Meshery Server's response shape for the same path must be confirmed before changing a published dual-consumer response contract.
- No `*_helper.go` needed: none of these types require a SQL driver, `Entity` interface, or `TableName()` (none are DB-backed).
- Pre-existing unbaselined advisory (also on master, untouched here): v1alpha1 core `created_at`/`updated_at` carry a manual `yaml:` extra-tag that surfaces as an advisory on referencing schemas (e.g. `SystemSessionSyncK8sContext`); fixing it regenerates yaml tags across many models and belongs in its own PR.

**Gates (all run locally, all passing):** `make generate-golang` (regenerated Go committed; `typescript/` untouched), `make validate-schemas` (no blocking violations), `go test ./...`, `go run ./cmd/consumer-audit --cloud-repo ../meshery-cloud --meshery-repo ../meshery` (exit 0, no blocking findings).

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
