### PR TITLE
feat(user,invitation): add canonical schemas for cloud identity pages (section 3.2)

### DIFF
--- a/schemas/constructs/v1beta2/user/api.yml
+++ b/schemas/constructs/v1beta2/user/api.yml
@@ -124,6 +124,135 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
+  /api/identity/users/profile/details:
+    get:
+      x-internal: ["cloud"]
+      tags:
+        - users
+      operationId: getUserProfileOverview
+      summary: Get profile overview counts for the current user
+      description: >-
+        Returns the aggregate counts shown on the caller's profile overview:
+        the number of Kubernetes contexts and the number of designs owned by
+        the caller.
+      responses:
+        "200":
+          description: Profile overview counts for the caller
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ProfileOverview"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /api/identity/users/{userId}/profile/activity:
+    get:
+      x-internal: ["cloud"]
+      tags:
+        - users
+      operationId: getUserRecentActivities
+      summary: Get recent activity for a user's public profile
+      description: >-
+        Returns the recent-activity feed shown on a user's public profile.
+        Accessible without authentication; sensitive event categories are
+        filtered out and email addresses are redacted unless the caller is a
+        provider admin or is viewing their own profile. Pagination beyond the
+        first page requires provider-admin privileges.
+      security: []
+      parameters:
+        - $ref: "#/components/parameters/userId"
+        - name: page
+          in: query
+          description: Zero-based page index of the activity feed.
+          schema:
+            type: integer
+            minimum: 0
+        - name: pageSize
+          in: query
+          description: Number of activity entries per page.
+          schema:
+            type: integer
+            minimum: 1
+        - name: pagesize
+          in: query
+          deprecated: true
+          description: >-
+            Deprecated lowercase alias of pageSize, kept while existing clients
+            migrate to the canonical camelCase parameter.
+          schema:
+            type: integer
+            minimum: 1
+        - $ref: "#/components/parameters/order"
+        - $ref: "#/components/parameters/filter"
+      responses:
+        "200":
+          description: Recent-activity page for the requested user
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RecentActivityPage"
+        "400":
+          $ref: "#/components/responses/400"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /api/identity/users/notify/comment:
+    post:
+      x-internal: ["cloud"]
+      tags:
+        - users
+      operationId: notifyMentionUsers
+      summary: Notify users mentioned in a design comment
+      description: >-
+        Sends email notifications to the users mentioned in a design comment,
+        to the comment thread participants, and to the design owner, and
+        records a user event for the comment.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MentionNotificationPayload"
+      responses:
+        "200":
+          description: Mention notifications dispatched
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
+  /api/identity/users/anonymous:
+    post:
+      x-internal: ["cloud"]
+      tags:
+        - users
+      operationId: createAnonymousUserSession
+      summary: Create an anonymous user and issue a session token
+      description: >-
+        Mints a synthetic anonymous user account, registers the calling Meshery
+        instance as a connection, and returns an access token together with the
+        capability document for the anonymous session. Authenticated with the
+        shared anonymous-results publishing token rather than a user JWT.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "../../v1beta3/connection/api.yml#/components/schemas/ConnectionPayload"
+      responses:
+        "200":
+          description: Anonymous session issued
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AnonymousFlowResponse"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          $ref: "#/components/responses/500"
+
   /api/identity/users/self/account-deletion-eligibility:
     get:
       x-internal: ["cloud"]
@@ -270,6 +399,13 @@ components:
       schema:
         type: string
         format: uuid
+    userId:
+      name: userId
+      in: path
+      required: true
+      description: ID of the user whose recent activity is requested
+      schema:
+        $ref: "../core/api.yml#/components/schemas/Uuid"
     page:
       name: page
       in: query
@@ -920,6 +1056,204 @@ components:
           format: uri
           description: The link of the social.
       required: ["site", "link"]
+
+    ProfileOverview:
+      type: object
+      additionalProperties: false
+      description: Aggregate counts shown on the current user's profile overview.
+      required:
+        - k8sCount
+        - patternCount
+      properties:
+        k8sCount:
+          type: integer
+          minimum: 0
+          description: Number of Kubernetes contexts owned by the user.
+          x-go-name: KubernetesContexts
+        patternCount:
+          type: integer
+          minimum: 0
+          description: Number of designs owned by the user.
+          x-go-name: PatternsCount
+
+    UserActivity:
+      type: object
+      additionalProperties: false
+      description: >-
+        A single entry in a user's recent-activity feed. A narrow projection of
+        the stored event record (id, category, action, description, owner and
+        timestamps). The pre-migration meshery-cloud serialization emitted
+        additional zero-valued event fields; those disappear once the server
+        consumes this generated type.
+      properties:
+        id:
+          $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: Unique identifier of the underlying event.
+          x-go-name: ID
+          x-oapi-codegen-extra-tags:
+            db: id
+            json: id
+        category:
+          type: string
+          maxLength: 500
+          description: Resource category on which the activity occurred.
+          x-oapi-codegen-extra-tags:
+            db: category
+            json: category
+        action:
+          type: string
+          maxLength: 500
+          description: Action recorded by the activity.
+          x-oapi-codegen-extra-tags:
+            db: action
+            json: action
+        description:
+          type: string
+          maxLength: 5000
+          description: >-
+            Human-readable description of the activity. Email addresses are
+            redacted for non-privileged viewers.
+          x-oapi-codegen-extra-tags:
+            db: description
+            json: description
+        owner:
+          $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: ID of the user who performed the activity.
+          x-oapi-codegen-extra-tags:
+            db: owner
+            json: owner
+        createdAt:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the activity was recorded.
+          x-oapi-codegen-extra-tags:
+            db: created_at
+            json: createdAt
+        updatedAt:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the activity was last updated.
+          x-oapi-codegen-extra-tags:
+            db: updated_at
+            json: updatedAt
+
+    RecentActivityPage:
+      type: object
+      description: Paginated recent-activity feed for a user's public profile.
+      properties:
+        page:
+          type: integer
+          description: Current page number of the result set.
+          minimum: 0
+        pageSize:
+          type: integer
+          description: Number of items per page.
+          minimum: 1
+        totalCount:
+          type: integer
+          description: Total number of items available.
+          minimum: 0
+        activities:
+          type: array
+          items:
+            $ref: "#/components/schemas/UserActivity"
+          description: The activity entries on the current page.
+
+    MentionMessage:
+      type: object
+      additionalProperties: false
+      description: A single comment message included in a mention notification.
+      properties:
+        firstName:
+          type: string
+          maxLength: 200
+          description: First name of the comment author.
+        lastName:
+          type: string
+          maxLength: 300
+          description: Last name of the comment author.
+        avatarUrl:
+          type: string
+          format: uri
+          maxLength: 500
+          description: URL to the comment author's avatar image.
+          x-go-name: AvatarURL
+        message:
+          type: string
+          maxLength: 5000
+          description: Text of the comment message.
+        timestamp:
+          $ref: "../core/api.yml#/components/schemas/Time"
+          description: Timestamp when the comment message was written.
+        userId:
+          $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: ID of the comment author.
+          x-go-name: UserID
+
+    MentionNotificationPayload:
+      type: object
+      additionalProperties: false
+      description: >-
+        Request body for notifying users about a design comment: the users
+        mentioned in the comment, the thread participants, and the comment
+        messages to include in the notification email.
+      required:
+        - designId
+      properties:
+        mentionUsers:
+          type: array
+          items:
+            $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: IDs of the users explicitly mentioned in the comment.
+        participants:
+          type: array
+          items:
+            $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: IDs of the users participating in the comment thread.
+        designId:
+          $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: ID of the design the comment was made on.
+          x-go-name: DesignID
+        usersOptedOutOfNotifications:
+          type: array
+          items:
+            $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: IDs of the users who opted out of mention notifications.
+        messages:
+          type: array
+          items:
+            $ref: "#/components/schemas/MentionMessage"
+          description: The comment messages to include in the notification email.
+
+    AnonymousFlowResponse:
+      type: object
+      additionalProperties: false
+      description: >-
+        Response returned after minting an anonymous user session: the session
+        access token, the ID of the synthetic anonymous user, and the
+        capability document for the session.
+      required:
+        - accessToken
+        - userId
+      properties:
+        accessToken:
+          type: string
+          maxLength: 4096
+          description: JWT access token for the anonymous session.
+          x-oapi-codegen-extra-tags:
+            json: accessToken
+        capability:
+          type: object
+          additionalProperties: true
+          description: >-
+            Capability document for the anonymous session. Untyped pending the
+            provider-capabilities schema tracked separately in the
+            identifier-uniformity program.
+          x-go-name: Capabilities
+        userId:
+          $ref: "../core/api.yml#/components/schemas/Uuid"
+          description: ID of the newly minted anonymous user.
+          x-go-name: UserID
+          x-oapi-codegen-extra-tags:
+            json: userId
 
     AccountDeletionEligibility:
       type: object

--- a/schemas/constructs/v1beta3/invitation/api.yml
+++ b/schemas/constructs/v1beta3/invitation/api.yml
@@ -314,8 +314,7 @@ paths:
           content:
             application/json:
               schema:
-                type: object
-                additionalProperties: true
+                $ref: '#/components/schemas/SignupRequestNotification'
         '204':
           description: No pending signup request notifications
         '401':
@@ -392,6 +391,155 @@ components:
       type: object
       description: A signup request submitted for organization access.
       additionalProperties: true
+    SignupData:
+      type: object
+      additionalProperties: false
+      description: >-
+        A signup request record as persisted in the signup_data table. Captures
+        the requester's identity, the product form the request originated from
+        (for example playground, meshmap, docker-extension), the moderation
+        status, and the tracking task created for the request. Also embedded in
+        signup webhook and notification payloads, where only a subset of fields
+        may be populated.
+      properties:
+        id:
+          $ref: ../../v1beta2/core/api.yml#/components/schemas/Uuid
+          description: Unique identifier of the signup request.
+          x-go-name: ID
+          x-oapi-codegen-extra-tags:
+            db: id
+            json: "id,omitempty"
+        firstName:
+          type: string
+          maxLength: 200
+          description: First name of the requester.
+          x-oapi-codegen-extra-tags:
+            db: first_name
+            json: "firstName,omitempty"
+        lastName:
+          type: string
+          maxLength: 300
+          description: Last name of the requester.
+          x-oapi-codegen-extra-tags:
+            db: last_name
+            json: "lastName,omitempty"
+        email:
+          type: string
+          format: email
+          maxLength: 300
+          description: Email address of the requester.
+          x-oapi-codegen-extra-tags:
+            db: email
+            json: "email,omitempty"
+        occupation:
+          type: string
+          maxLength: 300
+          description: Occupation stated by the requester.
+          x-oapi-codegen-extra-tags:
+            db: occupation
+            json: "occupation,omitempty"
+        organization:
+          type: string
+          maxLength: 300
+          description: Organization stated by the requester.
+          x-oapi-codegen-extra-tags:
+            db: organization
+            json: "organization,omitempty"
+        role:
+          type: string
+          maxLength: 300
+          description: Role stated by the requester within their organization.
+          x-oapi-codegen-extra-tags:
+            db: role
+            json: "role,omitempty"
+        formType:
+          type: string
+          maxLength: 300
+          description: >-
+            Product form the signup request originated from. Known values
+            include playground, meshmap, docker-extension, epsma-book, content,
+            contact and event; the set is open-ended.
+          x-oapi-codegen-extra-tags:
+            db: form_type
+            json: "formType,omitempty"
+        status:
+          type: string
+          maxLength: 300
+          description: Moderation status of the signup request.
+          x-oapi-codegen-extra-tags:
+            db: status
+            json: "status,omitempty"
+        taskId:
+          type: string
+          maxLength: 300
+          description: Identifier of the tracking task created for this request in the external task system.
+          x-id-format: external
+          x-go-name: TaskID
+          x-oapi-codegen-extra-tags:
+            db: task_id
+            json: "taskId,omitempty"
+        taskLink:
+          type: string
+          format: uri
+          maxLength: 300
+          description: Link to the tracking task created for this request.
+          x-oapi-codegen-extra-tags:
+            db: task_link
+            json: "taskLink,omitempty"
+        createdAt:
+          $ref: ../../v1beta2/core/api.yml#/components/schemas/Time
+          description: Timestamp when the signup request was created.
+          x-oapi-codegen-extra-tags:
+            db: created_at
+            json: "createdAt,omitempty"
+        updatedAt:
+          $ref: ../../v1beta2/core/api.yml#/components/schemas/Time
+          description: Timestamp when the signup request was last updated.
+          x-oapi-codegen-extra-tags:
+            db: updated_at
+            json: "updatedAt,omitempty"
+    SignupRequestNotification:
+      type: object
+      additionalProperties: false
+      description: >-
+        Notification about the most recent signup request awaiting moderator
+        action, served by getSignupRequestNotification.
+      required:
+        - signupData
+        - preProcessed
+      properties:
+        signupData:
+          $ref: '#/components/schemas/SignupData'
+          description: The signup request the notification refers to.
+          x-oapi-codegen-extra-tags:
+            json: signupData
+        preProcessed:
+          type: boolean
+          description: Whether the signup request was automatically processed before moderator review.
+          x-oapi-codegen-extra-tags:
+            json: preProcessed
+    SignupWebhookPayload:
+      type: object
+      additionalProperties: false
+      description: >-
+        Outbound webhook body that Cloud POSTs to the configured signup and
+        entitlement webhooks (WEBHOOK_SIGNUP_REQUEST, WEBHOOK_KANVAS_ENTITLEMENT)
+        when a signup request is processed. Emitted by Cloud; not served by any
+        Cloud endpoint.
+      required:
+        - signupData
+        - newUser
+      properties:
+        signupData:
+          $ref: '#/components/schemas/SignupData'
+          description: The signup request that triggered the webhook.
+          x-oapi-codegen-extra-tags:
+            json: signupData
+        newUser:
+          type: boolean
+          description: Whether the requester is a newly created user.
+          x-oapi-codegen-extra-tags:
+            json: newUser
     SignupRequestsPage:
       type: object
       description: Paginated list of signup requests.


### PR DESCRIPTION
**Notes for Reviewers**

Part of the schemas-cloud identifier-uniformity remediation program, **section 3.2 (add-to-schemas-first)**: meshery-cloud hand-rolls wire/DB types under `server/models/**` that have no canonical schema; this PR authors the invitation/user identity-page rows so Cloud can consume generated types and retire the local structs.

**This change is additive only.** No existing published property is renamed, recased, or removed. The only touched existing element is the `getSignupRequestNotification` 200 response, which moves from an untyped `additionalProperties: true` placeholder (zero published properties) to the new typed `SignupRequestNotification`.

### Schemas authored

| Added schema (construct) | Cloud local type it replaces (file) | Notes |
|---|---|---|
| `SignupData` (invitation@v1beta3) | `SignupData` (`server/models/users.go`) | Typed entity, db-tagged to the confirmed `signup_data` table columns. Wire already camelCase in Cloud; carried over 1:1. |
| `SignupRequestNotification` (invitation@v1beta3) | `SignupRequestNotification` (`server/models/users.go`) | Now referenced by the `getSignupRequestNotification` 200 response (previously an untyped object). |
| `SignupWebhookPayload` (invitation@v1beta3) | `WebhookPayload` (`server/models/users.go`) | Renamed from Cloud's generic `WebhookPayload` for clarity. Outbound webhook body (`WEBHOOK_SIGNUP_REQUEST`, `WEBHOOK_KANVAS_ENTITLEMENT`); not served by any endpoint, so not referenced by an operation. |
| `ProfileOverview` + op `getUserProfileOverview` (user@v1beta2) | `ProfileOverview` (`server/models/users.go`) | GET `/api/identity/users/profile/details`. `x-go-name` matches Cloud field names (`KubernetesContexts`, `PatternsCount`) for drop-in consume. |
| `UserActivity`, `RecentActivityPage` + op `getUserRecentActivities` (user@v1beta2) | `RecentActivityPage` + the `EventTracker` projection it serves (`server/models/users.go`, `server/models/event_tracker.go`) | GET `/api/identity/users/{userId}/profile/activity` (public; `security: []`). `UserActivity` is the exact 7-column projection the DAO selects (id, category, action, description, owner, created_at, updated_at), db-tagged for direct Pop scanning. Canonical `pageSize` query param authored alongside a deprecated `pagesize` alias (the live handler and UI still send `pagesize`; Cloud should accept both on consume, mirroring its existing `QueryParam(q, "pageSize", "pagesize")` pattern). |
| `MentionMessage`, `MentionNotificationPayload` + op `notifyMentionUsers` (user@v1beta2) | `Messages`, `MentionRequestBody` (`server/models/users.go`) | POST `/api/identity/users/notify/comment`. Renames: `Messages` (misnamed plural for a single message) to `MentionMessage`; `MentionRequestBody` to `MentionNotificationPayload` per the `*Payload` request-body convention. Wire keys unchanged. |
| `AnonymousFlowResponse` + op `createAnonymousUserSession` (user@v1beta2) | `AnonymousFlowResponse` (`server/models/users.go`) | POST `/api/identity/users/anonymous`. Request body references the canonical `connection@v1beta3` `ConnectionPayload` (what the handler decodes). `capability` stays an open object pending the provider-capabilities schema (separate section 3.2 row). |

### Mappings recorded instead of authoring (near-misses; no duplicates added)

| Cloud local type (file) | Canonical mapping | Delta to reconcile at consume time |
|---|---|---|
| `UsersSummaryPage` (`server/models/users.go`) | `user.UsersPageForAdmin` | Items are already `user.User` in both; only delta is the array wire key `users` vs canonical `data`. Cloud adapts at consume (endpoint belongs to the resource-access-mapping row). |
| `UsersPage` (`server/models/roles.go`) | `user.UsersPageForAdmin` | Envelope keys identical (`page`/`pageSize`/`totalCount`/`data`). Items: `UserWithRole` vs `user.User` below. |
| `UserWithRole` (`server/models/roles.go`) | `user.User` | `user.User` already carries the role context (`roleNames`, `organizations.organizationsWithRoles`, `teams.teamsWithRoles`). Cloud extras to fold in at consume: flat `organizationWithUserRoles`/`teamsWithUserRoles` vs canonical nested objects; `prefs` (welcomeEmail/notifyRoleChange); Cloud's `username` is canonical `userId` (the DAO aliases `u.user_id as username` and `u.id as user_id`), an identifier-semantics fork this program exists to close. |
| `PublicUsersPage`/`PublicUserView` (`server/models/roles.go`) | `user.UsersPageForNonAdmin` | Same envelope; Cloud items are the narrow public projection {id, userId, username, avatarUrl} with the same `username`/`userId` semantic fork as above. `UsersPageForNonAdmin` items claim full `user.User` with a required-set wider than the public projection; relaxing that or adding a dedicated public projection is a wire-coordinated change deferred to the consume/version step. |
| `SearchableUsersPage`/`SearchableUserView` (`server/models/roles.go`) | `user.UsersPageForNonAdmin` + `email` | The `/users/search` endpoints are intentionally non-canonical this cycle (plan section 4: keep the two search branches). Not authored. |
| `TeamMembersPage`/`TeamMemberWithRole` (`server/models/roles.go`) | `team.TeamMembersPage`/`team.TeamMember` | Envelope already camelCase-identical after the section 2F flip. `team.TeamMember` is deliberately open (`additionalProperties: true`) with per-field typing tracked in meshery/schemas#832; authoring a parallel typed member here would fork that roadmap. |

### Skipped (with reasons)

- `MeshMapAcceptedWebhookPayload` (`server/models/users.go`): dead code. Declared but never referenced; `CallMeshMapAcceptedWebHook` actually sends `WebhookPayload` (now `SignupWebhookPayload`). Deletion candidate in the Cloud consume PR.
- `OrganizationWithRoles` local aggregate (`server/models/users.go:271`, `{roles[], organizations[]}`): also dead code; only its declaration exists. The planned rename (for the name collision with schemas' `user.OrganizationWithRoles`, which has a different shape) is moot; delete it in the consume PR instead of authoring `UserOrganizationsWithRolesSummary`.
- `SignupRequestsPage` (invitation@v1beta3) already exists camelCase after the v1.3.20 regen; untouched. Two published deltas remain for the consume step: its `data` items are the untyped `SignupRequest` map (repointing to typed `SignupData` is a published-property change, deferred), and Cloud's live wire key for the array is `signupData` vs canonical `data`.

### DB-gate verdicts (per plan section 0/1, against refreshed `database/cloud-schema.sql`)

- `signup_data` table confirmed: `id, email, first_name, last_name, occupation, organization, role, form_type, status, task_id, task_link, created_at, updated_at`. No owner/user_id column exists on this table; `SignupData` db tags match these columns exactly.
- `UserActivity` db tags target the recent-activity DAO projection over the events store (`id, category, action, description, owner, created_at, updated_at`), matching the columns/aliases the DAO selects; the user column there is `owner`, consistent with the section 0 correction.
- No other schema in this PR is DB-scanned.

### Known pre-existing defect this converges on

- `server/models/roles.go` carries a `db:"created_at"` mismap on `UpdatedAt` (in `UserWithRole`, `TeamMemberWithRole`, and `TimeStamp`), so served `updatedAt` values are actually `created_at`. It self-corrects when Cloud adopts the schema-generated types (canonical tags map `updatedAt` to `updated_at`).

### Follow-ups for the Cloud consume PR

- `invitation_helper.go`: `SignupData` needs `TableName() string { return "signup_data" }` (Pop scans it directly) and the `signup_request` event-category constant. Helper files are manual by convention; not hand-added to generated output here.
- Cloud handler for `getUserRecentActivities` should accept both `pageSize` and the deprecated `pagesize` while the UI migrates.
- Generated Go/TS artifacts are intentionally not committed; the `generate-artifacts-from-schemas` workflow self-commits them on master (matches PR #1006/#1007 precedent).

### Gates (all run locally, all passing)

- `make generate-golang` - clean; only `models/v1beta2/user/user.go` and `models/v1beta3/invitation/invitation.go` change (new types only)
- `make validate-schemas` - no blocking violations
- `go test ./...` - all packages pass
- `go run ./cmd/consumer-audit --cloud-repo ../meshery-cloud --meshery-repo ../meshery` - 0 blocking violations; the two `ui/api/catalog.ts` snake-case findings and the one Cloud-only endpoint note are pre-existing on master (verified against a clean master run)

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
