### PR TITLE
[model] Fix MeshModelModelsPage.models to reference ModelDefinition, not the Model stub

### DIFF
--- a/models/v1beta1/model/model.go
+++ b/models/v1beta1/model/model.go
@@ -86,7 +86,7 @@ type ImportRequestUploadType string
 // MeshModelModelsPage defines model for MeshModelModelsPage.
 type MeshModelModelsPage struct {
 	// Models The models matching the list-endpoint query.
-	Models *[]Model `json:"models,omitempty" yaml:"models,omitempty"`
+	Models *[]ModelDefinition `json:"models,omitempty" yaml:"models,omitempty"`
 
 	// Page Current page number of the result set.
 	Page *int `json:"page,omitempty" yaml:"page,omitempty"`

--- a/models/v1beta2/model/model.go
+++ b/models/v1beta2/model/model.go
@@ -93,7 +93,7 @@ type ImportRequestUploadType string
 // MeshModelModelsPage Page of mesh models matching the list-endpoint query.
 type MeshModelModelsPage struct {
 	// Models The models matching the list-endpoint query.
-	Models *[]Model `json:"models,omitempty" yaml:"models,omitempty"`
+	Models *[]ModelDefinition `json:"models,omitempty" yaml:"models,omitempty"`
 
 	// Page Current page number of the result set.
 	Page *int `json:"page,omitempty" yaml:"page,omitempty"`

--- a/schemas/constructs/v1beta1/model/api.yml
+++ b/schemas/constructs/v1beta1/model/api.yml
@@ -282,5 +282,5 @@ components:
         models:
           type: array
           items:
-            $ref: "#/components/schemas/Model"
+            $ref: "#/components/schemas/ModelDefinition"
           description: The models matching the list-endpoint query.

--- a/schemas/constructs/v1beta2/model/api.yml
+++ b/schemas/constructs/v1beta2/model/api.yml
@@ -294,7 +294,7 @@ components:
         models:
           type: array
           items:
-            $ref: "#/components/schemas/Model"
+            $ref: "#/components/schemas/ModelDefinition"
           description: The models matching the list-endpoint query.
 
     MesheryModelImportFormPayload:


### PR DESCRIPTION
**Notes for Reviewers**

Part of the identifier-naming / schema-driven uniformity remediation program (follow-up surfaced while bumping meshery-cloud to a recent schemas release).

- **Symptom** - meshery-cloud's Docker UI build fails: `Property 'displayName' does not exist on type '{ version: string; }'` in the catalog components that read `useGetMeshModelModelsQuery().data.models[].displayName`.
- **Root cause** - `MeshModelModelsPage.models[]` (the `getMeshModelModels` response, GET `/api/integrations/meshmodels/models`) references the minimal `Model` schema, which only carries `{ version }`. The endpoint actually returns full registry models, so the generated TypeScript response type was wrong; any consumer bumping to a schemas version that carries this shape loses `displayName`/`name`/etc. (An older published schemas version happened to reference the full model, which is why cloud built before its `ui/package.json` bump.)
- **Fix** - point `MeshModelModelsPage.models[].items` at `ModelDefinition` (the full model defined in `model.yaml` - `displayName`, `name`, `version`, ...) in both v1beta1 and v1beta2. The singular `ModelReference.model` field keeps the minimal `Model` stub, which is correct for a by-version reference.
- **Watch for** - the change widens the wire response type (strictly more fields), so it is backward-compatible; `Model.version` is still present on `ModelDefinition`. No Go consumer reads the schemas `MeshModelModelsPage` type (both meshery and meshery-cloud use local structs - verified), so there is no Go-source break.

**Gates (all pass)**
- `make generate-golang` - diff is exactly `Models *[]Model` -> `Models *[]ModelDefinition` in models/v1beta1/model and models/v1beta2/model
- `make validate-schemas` - no blocking violations
- `go test ./...` - all pass
- `go run ./cmd/consumer-audit --cloud-repo ../meshery-cloud --meshery-repo ../meshery` - 0 blocking (2 pre-existing advisory catalog.ts `user_id` param findings, unrelated)

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
