### PR TITLE
[System/Connections] Controller status (SSE+REST), connection actions, and diagnostics endpoints

### DIFF
--- a/models/v1beta1/system/system.go
+++ b/models/v1beta1/system/system.go
@@ -11,6 +11,102 @@ import (
 	openapi_types "github.com/oapi-codegen/runtime/types"
 )
 
+// Defines values for ControllerDiagnosticController.
+const (
+	ControllerDiagnosticControllerBROKER   ControllerDiagnosticController = "BROKER"
+	ControllerDiagnosticControllerMESHSYNC ControllerDiagnosticController = "MESHSYNC"
+	ControllerDiagnosticControllerOPERATOR ControllerDiagnosticController = "OPERATOR"
+)
+
+// Defines values for ControllerDiagnosticSeverity.
+const (
+	Error   ControllerDiagnosticSeverity = "error"
+	Info    ControllerDiagnosticSeverity = "info"
+	Warning ControllerDiagnosticSeverity = "warning"
+)
+
+// Defines values for ControllerStatusController.
+const (
+	ControllerStatusControllerBROKER   ControllerStatusController = "BROKER"
+	ControllerStatusControllerMESHSYNC ControllerStatusController = "MESHSYNC"
+	ControllerStatusControllerOPERATOR ControllerStatusController = "OPERATOR"
+)
+
+// ConnectionDiagnostics Diagnostics for a kubernetes connection's Meshery controllers, for rendering a "Diagnostics" section in the connection detail view.
+type ConnectionDiagnostics struct {
+	// ConnectionId The kubernetes connection ID these diagnostics belong to.
+	ConnectionId string `json:"connectionId" yaml:"connectionId"`
+
+	// Diagnostics The diagnostics detected for this connection (possibly empty).
+	Diagnostics []ControllerDiagnostic `json:"diagnostics" yaml:"diagnostics"`
+
+	// Healthy True when no warning/error diagnostics were detected (informational diagnostics do not affect health).
+	Healthy bool `json:"healthy" yaml:"healthy"`
+}
+
+// ControllerDiagnostic A single human-actionable diagnostic about a kubernetes connection's Meshery controllers, with an explanation and remediation steps.
+type ControllerDiagnostic struct {
+	// Code Stable machine-readable code for this diagnostic (e.g. `broker_unreachable`), for the UI to key on.
+	Code string `json:"code" yaml:"code"`
+
+	// Controller The controller this diagnostic concerns, when applicable.
+	Controller *ControllerDiagnosticController `json:"controller,omitempty" yaml:"controller,omitempty"`
+
+	// Description A fuller explanation of what is wrong and why.
+	Description *string `json:"description,omitempty" yaml:"description,omitempty"`
+
+	// Endpoint A relevant endpoint for the diagnostic, when applicable (e.g. the broker's published address the user needs to make reachable).
+	Endpoint *string `json:"endpoint,omitempty" yaml:"endpoint,omitempty"`
+
+	// Remediation Ordered, concrete steps the user can take to resolve the issue.
+	Remediation *[]string `json:"remediation,omitempty" yaml:"remediation,omitempty"`
+
+	// Severity How serious the diagnostic is.
+	Severity ControllerDiagnosticSeverity `json:"severity" yaml:"severity"`
+
+	// Summary Short, human-readable title for the diagnostic.
+	Summary string `json:"summary" yaml:"summary"`
+}
+
+// ControllerDiagnosticController The controller this diagnostic concerns, when applicable.
+type ControllerDiagnosticController string
+
+// ControllerDiagnosticSeverity How serious the diagnostic is.
+type ControllerDiagnosticSeverity string
+
+// ControllerInfo Detailed status of a named Meshery controller (MeshSync or Broker) for a kubernetes connection.
+type ControllerInfo struct {
+	// ConnectionId The kubernetes connection ID this status belongs to.
+	ConnectionId string `json:"connectionId" yaml:"connectionId"`
+
+	// Name Controller name (e.g. MeshSync, MesheryBroker).
+	Name string `json:"name" yaml:"name"`
+
+	// Status Current controller status. May be composed, e.g. "Connected <endpoint>".
+	Status string `json:"status" yaml:"status"`
+
+	// Version Deployed controller version, when known.
+	Version string `json:"version" yaml:"version"`
+}
+
+// ControllerStatus Status of a single Meshery controller (operator, MeshSync, or broker) for a kubernetes connection. Element type of the controller-status SSE stream and the operator status response.
+type ControllerStatus struct {
+	// ConnectionId The kubernetes connection ID this status belongs to.
+	ConnectionId string `json:"connectionId" yaml:"connectionId"`
+
+	// Controller The controller this status describes.
+	Controller ControllerStatusController `json:"controller" yaml:"controller"`
+
+	// Status Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKOWN).
+	Status string `json:"status" yaml:"status"`
+
+	// Version Deployed controller version, when known.
+	Version string `json:"version" yaml:"version"`
+}
+
+// ControllerStatusController The controller this status describes.
+type ControllerStatusController string
+
 // EmailTestRequest Request body for sending a test email through the configured SMTP provider.
 type EmailTestRequest struct {
 	// Subject Subject line for the test message. A default subject is used when omitted.

--- a/models/v1beta3/connection/connection.go
+++ b/models/v1beta3/connection/connection.go
@@ -24,6 +24,17 @@ const (
 	ConnectionStatusRegistered   ConnectionStatus = "registered"
 )
 
+// Defines values for ConnectionActionRequestAction.
+const (
+	SetMeshsyncMode ConnectionActionRequestAction = "setMeshsyncMode"
+)
+
+// Defines values for ConnectionActionRequestMode.
+const (
+	Embedded ConnectionActionRequestMode = "embedded"
+	Operator ConnectionActionRequestMode = "operator"
+)
+
 // Defines values for ConnectionStatusValue.
 const (
 	ConnectionStatusValueConnected    ConnectionStatusValue = "connected"
@@ -100,6 +111,21 @@ type Connection struct {
 
 // ConnectionStatus Connection Status
 type ConnectionStatus string
+
+// ConnectionActionRequest A side-effecting operation to perform on a connection via POST /api/integrations/connections/{connectionId}/actions. The `action` field selects the operation; operation-specific fields carry its parameters. Unlike PUT (which updates resource fields), the server owns any resulting metadata merge and cluster-side effects.
+type ConnectionActionRequest struct {
+	// Action The operation to perform on the connection.
+	Action ConnectionActionRequestAction `json:"action" yaml:"action"`
+
+	// Mode Target MeshSync deployment mode. Required when `action` is `setMeshsyncMode`; the server redeploys MeshSync (operator vs embedded) for the connection's cluster.
+	Mode *ConnectionActionRequestMode `json:"mode,omitempty" yaml:"mode,omitempty"`
+}
+
+// ConnectionActionRequestAction The operation to perform on the connection.
+type ConnectionActionRequestAction string
+
+// ConnectionActionRequestMode Target MeshSync deployment mode. Required when `action` is `setMeshsyncMode`; the server redeploys MeshSync (operator vs embedded) for the connection's cluster.
+type ConnectionActionRequestMode string
 
 // ConnectionDefinition A connection definition is an uninitialized connection, authored per-model (in a model's `connections/` folder) and registered into the registry alongside components and relationships. It conforms to the connection schema; the dynamic, kind-specific shape is carried in `metadata`. The `model` association scopes the definition to its owning model.
 // type ConnectionDefinition — defined in manual helper file

--- a/schemas/constructs/v1beta1/system/api.yml
+++ b/schemas/constructs/v1beta1/system/api.yml
@@ -168,6 +168,138 @@ paths:
         "500":
           description: Marshal error while serializing the session sync payload.
 
+  /api/system/controllers/operator/status:
+    get:
+      x-internal: ["meshery"]
+      tags:
+        - System
+      summary: Get the Meshery Operator status for a connection
+      description: >-
+        Returns the current status of the Meshery Operator controller for the
+        given kubernetes connection. Replaces the getOperatorStatus GraphQL
+        query.
+      operationId: getOperatorControllerStatus
+      parameters:
+        - name: connectionId
+          in: query
+          description: The kubernetes connection ID whose operator status is requested.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Operator controller status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerStatus"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          description: Internal server error while resolving controller status.
+
+  /api/system/controllers/meshsync/status:
+    get:
+      x-internal: ["meshery"]
+      tags:
+        - System
+      summary: Get the MeshSync controller status for a connection
+      description: >-
+        Returns the current status of the MeshSync controller for the given
+        kubernetes connection. Replaces the getMeshsyncStatus GraphQL query.
+      operationId: getMeshsyncControllerStatus
+      parameters:
+        - name: connectionId
+          in: query
+          description: The kubernetes connection ID whose MeshSync status is requested.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: MeshSync controller status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerInfo"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          description: Internal server error while resolving controller status.
+
+  /api/system/controllers/broker/status:
+    get:
+      x-internal: ["meshery"]
+      tags:
+        - System
+      summary: Get the Meshery Broker (NATS) controller status for a connection
+      description: >-
+        Returns the current status of the Meshery Broker (NATS) controller for
+        the given kubernetes connection. Replaces the getNatsStatus GraphQL
+        query.
+      operationId: getBrokerControllerStatus
+      parameters:
+        - name: connectionId
+          in: query
+          description: The kubernetes connection ID whose broker status is requested.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Broker controller status
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ControllerInfo"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          description: Internal server error while resolving controller status.
+
+  /api/system/controllers/status/subscribe:
+    get:
+      x-internal: ["meshery"]
+      tags:
+        - System
+      summary: Stream Meshery controller status over Server-Sent Events
+      description: >-
+        Server-Sent Events (SSE) stream of controller status (operator,
+        MeshSync, broker) for the requested kubernetes connections. Replaces the
+        subscribeMesheryControllersStatus GraphQL subscription. The server emits
+        the full status array as an unnamed SSE event (`data: <json>` followed
+        by a blank line) on subscribe and again whenever any controller's status
+        changes; a comment keepalive is sent periodically. Consume with a native
+        EventSource, not a buffered JSON client.
+      operationId: subscribeControllersStatus
+      parameters:
+        - name: connectionIds
+          in: query
+          description: >-
+            Kubernetes connection IDs to watch. Repeatable
+            (connectionIds=<id>&connectionIds=<id>).
+          required: false
+          schema:
+            type: array
+            items:
+              type: string
+              format: uuid
+      responses:
+        "200":
+          description: An open text/event-stream of controller status snapshots.
+          content:
+            text/event-stream:
+              schema:
+                type: string
+                description: >-
+                  SSE frames. Each `data:` line is a JSON array of
+                  ControllerStatus items.
+        "401":
+          $ref: "#/components/responses/401"
+
 components:
   responses:
     401:
@@ -240,6 +372,72 @@ components:
           description: Human-readable status message.
           minLength: 1
           maxLength: 1024
+
+    ControllerStatus:
+      type: object
+      description: >-
+        Status of a single Meshery controller (operator, MeshSync, or broker)
+        for a kubernetes connection. Element type of the controller-status SSE
+        stream and the operator status response.
+      additionalProperties: false
+      required:
+        - connectionId
+        - controller
+        - status
+        - version
+      properties:
+        connectionId:
+          type: string
+          description: The kubernetes connection ID this status belongs to.
+          maxLength: 255
+        controller:
+          type: string
+          description: The controller this status describes.
+          enum:
+            - OPERATOR
+            - MESHSYNC
+            - BROKER
+        status:
+          type: string
+          description: >-
+            Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING,
+            CONNECTED, UNKOWN).
+          maxLength: 255
+        version:
+          type: string
+          description: Deployed controller version, when known.
+          maxLength: 255
+
+    ControllerInfo:
+      type: object
+      description: >-
+        Detailed status of a named Meshery controller (MeshSync or Broker) for a
+        kubernetes connection.
+      additionalProperties: false
+      required:
+        - name
+        - version
+        - status
+        - connectionId
+      properties:
+        name:
+          type: string
+          description: Controller name (e.g. MeshSync, MesheryBroker).
+          maxLength: 255
+        version:
+          type: string
+          description: Deployed controller version, when known.
+          maxLength: 255
+        status:
+          type: string
+          description: >-
+            Current controller status. May be composed, e.g. "Connected
+            <endpoint>".
+          maxLength: 1024
+        connectionId:
+          type: string
+          description: The kubernetes connection ID this status belongs to.
+          maxLength: 255
 
     SystemDatabaseTable:
       type: object

--- a/schemas/constructs/v1beta1/system/api.yml
+++ b/schemas/constructs/v1beta1/system/api.yml
@@ -260,6 +260,41 @@ paths:
         "500":
           description: Internal server error while resolving controller status.
 
+  /api/system/controllers/diagnostics:
+    get:
+      x-internal: ["meshery"]
+      tags:
+        - System
+      summary: Get controller diagnostics and remediation for a connection
+      description: >-
+        Returns human-actionable diagnostics for a kubernetes connection's
+        Meshery controllers (operator, MeshSync, broker), derived from their
+        current status and Meshery's live broker connection. Each diagnostic
+        carries a severity, a summary, an explanation, and concrete remediation
+        steps so the UI can render a "Diagnostics" section in the connection
+        detail view. An empty diagnostics list (with healthy=true) means no
+        problems were detected.
+      operationId: getControllerDiagnostics
+      parameters:
+        - name: connectionId
+          in: query
+          description: The kubernetes connection ID whose diagnostics are requested.
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Connection controller diagnostics
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectionDiagnostics"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          description: Internal server error while resolving controller diagnostics.
+
   /api/system/controllers/status/subscribe:
     get:
       x-internal: ["meshery"]
@@ -438,6 +473,92 @@ components:
           type: string
           description: The kubernetes connection ID this status belongs to.
           maxLength: 255
+
+    ControllerDiagnostic:
+      type: object
+      description: >-
+        A single human-actionable diagnostic about a kubernetes connection's
+        Meshery controllers, with an explanation and remediation steps.
+      additionalProperties: false
+      required:
+        - severity
+        - code
+        - summary
+      properties:
+        severity:
+          type: string
+          description: How serious the diagnostic is.
+          enum:
+            - info
+            - warning
+            - error
+        controller:
+          type: string
+          description: The controller this diagnostic concerns, when applicable.
+          enum:
+            - OPERATOR
+            - MESHSYNC
+            - BROKER
+          x-oapi-codegen-extra-tags:
+            json: "controller,omitempty"
+        code:
+          type: string
+          description: >-
+            Stable machine-readable code for this diagnostic (e.g.
+            `broker_unreachable`), for the UI to key on.
+          maxLength: 128
+        summary:
+          type: string
+          description: Short, human-readable title for the diagnostic.
+          maxLength: 255
+        description:
+          type: string
+          description: A fuller explanation of what is wrong and why.
+          maxLength: 2048
+          x-oapi-codegen-extra-tags:
+            json: "description,omitempty"
+        remediation:
+          type: array
+          description: Ordered, concrete steps the user can take to resolve the issue.
+          items:
+            type: string
+            maxLength: 1024
+          x-oapi-codegen-extra-tags:
+            json: "remediation,omitempty"
+        endpoint:
+          type: string
+          description: >-
+            A relevant endpoint for the diagnostic, when applicable (e.g. the
+            broker's published address the user needs to make reachable).
+          maxLength: 512
+          x-oapi-codegen-extra-tags:
+            json: "endpoint,omitempty"
+
+    ConnectionDiagnostics:
+      type: object
+      description: >-
+        Diagnostics for a kubernetes connection's Meshery controllers, for
+        rendering a "Diagnostics" section in the connection detail view.
+      additionalProperties: false
+      required:
+        - connectionId
+        - healthy
+        - diagnostics
+      properties:
+        connectionId:
+          type: string
+          description: The kubernetes connection ID these diagnostics belong to.
+          maxLength: 255
+        healthy:
+          type: boolean
+          description: >-
+            True when no warning/error diagnostics were detected (informational
+            diagnostics do not affect health).
+        diagnostics:
+          type: array
+          description: The diagnostics detected for this connection (possibly empty).
+          items:
+            $ref: "#/components/schemas/ControllerDiagnostic"
 
     SystemDatabaseTable:
       type: object

--- a/schemas/constructs/v1beta1/system/api.yml
+++ b/schemas/constructs/v1beta1/system/api.yml
@@ -422,9 +422,8 @@ components:
         - version
       properties:
         connectionId:
-          type: string
+          $ref: ../../v1alpha1/core/api.yml#/components/schemas/uuid
           description: The kubernetes connection ID this status belongs to.
-          maxLength: 255
         controller:
           type: string
           description: The controller this status describes.
@@ -436,7 +435,7 @@ components:
           type: string
           description: >-
             Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING,
-            CONNECTED, UNKOWN).
+            CONNECTED, UNKNOWN).
           maxLength: 255
         version:
           type: string
@@ -470,9 +469,8 @@ components:
             <endpoint>".
           maxLength: 1024
         connectionId:
-          type: string
+          $ref: ../../v1alpha1/core/api.yml#/components/schemas/uuid
           description: The kubernetes connection ID this status belongs to.
-          maxLength: 255
 
     ControllerDiagnostic:
       type: object
@@ -546,9 +544,8 @@ components:
         - diagnostics
       properties:
         connectionId:
-          type: string
+          $ref: ../../v1alpha1/core/api.yml#/components/schemas/uuid
           description: The kubernetes connection ID these diagnostics belong to.
-          maxLength: 255
         healthy:
           type: boolean
           description: >-

--- a/schemas/constructs/v1beta3/connection/api.yml
+++ b/schemas/constructs/v1beta3/connection/api.yml
@@ -181,6 +181,44 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
+  /api/integrations/connections/{connectionId}/actions:
+    post:
+      x-internal: ["meshery"]
+      tags:
+        - Connections
+      operationId: performConnectionAction
+      summary: Perform an action on a connection
+      description: >-
+        Perform a side-effecting operation on a connection (as opposed to a
+        field update via PUT). The action is selected by the `action`
+        discriminator in the request body. Currently supports switching the
+        MeshSync deployment mode for a kubernetes connection, which redeploys
+        MeshSync (operator vs embedded) for the connection's cluster; the server
+        owns the connection metadata merge so callers only send the intent.
+      parameters:
+        - $ref: "#/components/parameters/connectionId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionActionRequest"
+      responses:
+        "200":
+          description: The updated connection after the action was applied.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Connection"
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
   /api/integrations/connections/meshery/{mesheryServerId}:
     delete:
       x-internal: ["cloud", "meshery"]
@@ -776,6 +814,37 @@ components:
           x-oapi-codegen-extra-tags:
             json: "description,omitempty"
           x-order: 2
+
+    ConnectionActionRequest:
+      type: object
+      description: >-
+        A side-effecting operation to perform on a connection via
+        POST /api/integrations/connections/{connectionId}/actions. The `action`
+        field selects the operation; operation-specific fields carry its
+        parameters. Unlike PUT (which updates resource fields), the server owns
+        any resulting metadata merge and cluster-side effects.
+      additionalProperties: false
+      required:
+        - action
+      properties:
+        action:
+          type: string
+          description: The operation to perform on the connection.
+          enum:
+            - setMeshsyncMode
+          x-oapi-codegen-extra-tags:
+            json: "action"
+        mode:
+          type: string
+          description: >-
+            Target MeshSync deployment mode. Required when `action` is
+            `setMeshsyncMode`; the server redeploys MeshSync (operator vs
+            embedded) for the connection's cluster.
+          enum:
+            - operator
+            - embedded
+          x-oapi-codegen-extra-tags:
+            json: "mode,omitempty"
 
     ConnectionPayload:
       type: object

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -53,6 +53,57 @@ const injectedRtkApi = api
         query: () => ({ url: `/api/system/sync` }),
         providesTags: ["System_API_System"],
       }),
+      getOperatorControllerStatus: build.query<
+        GetOperatorControllerStatusApiResponse,
+        GetOperatorControllerStatusApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/system/controllers/operator/status`,
+          params: {
+            connectionId: queryArg?.connectionId,
+          },
+        }),
+        providesTags: ["System_API_System"],
+      }),
+      getMeshsyncControllerStatus: build.query<
+        GetMeshsyncControllerStatusApiResponse,
+        GetMeshsyncControllerStatusApiArg
+      >({
+        query: (queryArg) => ({
+          url: `/api/system/controllers/meshsync/status`,
+          params: {
+            connectionId: queryArg?.connectionId,
+          },
+        }),
+        providesTags: ["System_API_System"],
+      }),
+      getBrokerControllerStatus: build.query<GetBrokerControllerStatusApiResponse, GetBrokerControllerStatusApiArg>({
+        query: (queryArg) => ({
+          url: `/api/system/controllers/broker/status`,
+          params: {
+            connectionId: queryArg?.connectionId,
+          },
+        }),
+        providesTags: ["System_API_System"],
+      }),
+      getControllerDiagnostics: build.query<GetControllerDiagnosticsApiResponse, GetControllerDiagnosticsApiArg>({
+        query: (queryArg) => ({
+          url: `/api/system/controllers/diagnostics`,
+          params: {
+            connectionId: queryArg?.connectionId,
+          },
+        }),
+        providesTags: ["System_API_System"],
+      }),
+      subscribeControllersStatus: build.query<SubscribeControllersStatusApiResponse, SubscribeControllersStatusApiArg>({
+        query: (queryArg) => ({
+          url: `/api/system/controllers/status/subscribe`,
+          params: {
+            connectionIds: queryArg?.connectionIds,
+          },
+        }),
+        providesTags: ["System_API_System"],
+      }),
       getUserCredentials: build.query<GetUserCredentialsApiResponse, GetUserCredentialsApiArg>({
         query: (queryArg) => ({
           url: `/api/integrations/credentials`,
@@ -322,6 +373,14 @@ const injectedRtkApi = api
       }),
       deleteConnection: build.mutation<DeleteConnectionApiResponse, DeleteConnectionApiArg>({
         query: (queryArg) => ({ url: `/api/integrations/connections/${queryArg.connectionId}`, method: "DELETE" }),
+        invalidatesTags: ["Connection_API_Connections"],
+      }),
+      performConnectionAction: build.mutation<PerformConnectionActionApiResponse, PerformConnectionActionApiArg>({
+        query: (queryArg) => ({
+          url: `/api/integrations/connections/${queryArg.connectionId}/actions`,
+          method: "POST",
+          body: queryArg.body,
+        }),
         invalidatesTags: ["Connection_API_Connections"],
       }),
       deleteMesheryConnection: build.mutation<DeleteMesheryConnectionApiResponse, DeleteMesheryConnectionApiArg>({
@@ -2750,6 +2809,80 @@ export type GetSystemSyncApiResponse = /** status 200 Session sync payload */ {
   [key: string]: any;
 };
 export type GetSystemSyncApiArg = void;
+export type GetOperatorControllerStatusApiResponse = /** status 200 Operator controller status */ {
+  /** The kubernetes connection ID this status belongs to. */
+  connectionId: string;
+  /** The controller this status describes. */
+  controller: "OPERATOR" | "MESHSYNC" | "BROKER";
+  /** Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKOWN). */
+  status: string;
+  /** Deployed controller version, when known. */
+  version: string;
+};
+export type GetOperatorControllerStatusApiArg = {
+  /** The kubernetes connection ID whose operator status is requested. */
+  connectionId: string;
+};
+export type GetMeshsyncControllerStatusApiResponse = /** status 200 MeshSync controller status */ {
+  /** Controller name (e.g. MeshSync, MesheryBroker). */
+  name: string;
+  /** Deployed controller version, when known. */
+  version: string;
+  /** Current controller status. May be composed, e.g. "Connected <endpoint>". */
+  status: string;
+  /** The kubernetes connection ID this status belongs to. */
+  connectionId: string;
+};
+export type GetMeshsyncControllerStatusApiArg = {
+  /** The kubernetes connection ID whose MeshSync status is requested. */
+  connectionId: string;
+};
+export type GetBrokerControllerStatusApiResponse = /** status 200 Broker controller status */ {
+  /** Controller name (e.g. MeshSync, MesheryBroker). */
+  name: string;
+  /** Deployed controller version, when known. */
+  version: string;
+  /** Current controller status. May be composed, e.g. "Connected <endpoint>". */
+  status: string;
+  /** The kubernetes connection ID this status belongs to. */
+  connectionId: string;
+};
+export type GetBrokerControllerStatusApiArg = {
+  /** The kubernetes connection ID whose broker status is requested. */
+  connectionId: string;
+};
+export type GetControllerDiagnosticsApiResponse = /** status 200 Connection controller diagnostics */ {
+  /** The kubernetes connection ID these diagnostics belong to. */
+  connectionId: string;
+  /** True when no warning/error diagnostics were detected (informational diagnostics do not affect health). */
+  healthy: boolean;
+  /** The diagnostics detected for this connection (possibly empty). */
+  diagnostics: {
+    /** How serious the diagnostic is. */
+    severity: "info" | "warning" | "error";
+    /** The controller this diagnostic concerns, when applicable. */
+    controller?: "OPERATOR" | "MESHSYNC" | "BROKER";
+    /** Stable machine-readable code for this diagnostic (e.g. `broker_unreachable`), for the UI to key on. */
+    code: string;
+    /** Short, human-readable title for the diagnostic. */
+    summary: string;
+    /** A fuller explanation of what is wrong and why. */
+    description?: string;
+    /** Ordered, concrete steps the user can take to resolve the issue. */
+    remediation?: string[];
+    /** A relevant endpoint for the diagnostic, when applicable (e.g. the broker's published address the user needs to make reachable). */
+    endpoint?: string;
+  }[];
+};
+export type GetControllerDiagnosticsApiArg = {
+  /** The kubernetes connection ID whose diagnostics are requested. */
+  connectionId: string;
+};
+export type SubscribeControllersStatusApiResponse = unknown;
+export type SubscribeControllersStatusApiArg = {
+  /** Kubernetes connection IDs to watch. Repeatable (connectionIds=<id>&connectionIds=<id>). */
+  connectionIds?: string[];
+};
 export type GetUserCredentialsApiResponse = /** status 200 Credentials response */ {
   /** The credentials returned on the current page. */
   credentials: {
@@ -6290,6 +6423,282 @@ export type DeleteConnectionApiArg = {
   /** Connection ID */
   connectionId: string;
 };
+export type PerformConnectionActionApiResponse =
+  /** status 200 The updated connection after the action was applied. */ {
+    /** Connection ID */
+    id: string;
+    /** Connection Name */
+    name: string;
+    /** Human-readable description of the connection and its purpose. */
+    description?: string;
+    /** URL of the remote resource this connection points to (e.g. the Helm repository URL, the Kubernetes API server endpoint, the Grafana instance URL). */
+    url?: string;
+    /** Associated Credential ID */
+    credentialId?: string;
+    /** Connection Type (platform, telemetry, collaboration) */
+    type: string;
+    /** Connection Subtype (cloud, identity, metrics, chat, git, orchestration) */
+    subType: string;
+    /** Connection Kind (meshery, kubernetes, prometheus, grafana, gke, aws, azure, slack, github) */
+    kind: string;
+    /** Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models */
+    modelReference?: {
+      /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
+      id: string;
+      /** The unique name for the model within the scope of a registrant. */
+      name: string;
+      /** Version of the model definition. */
+      version: string;
+      /** Human-readable name for the model. */
+      displayName: string;
+      /** Registrant-defined data associated with the model. Properties pertain to the software being managed (e.g. Kubernetes v1.31). */
+      model: {
+        /** Version of the model as defined by the registrant. */
+        version: string;
+      };
+      registrant: {
+        /** Kind of the registrant. */
+        kind: string;
+      };
+    };
+    /** Additional connection metadata */
+    metadata?: object;
+    /** Schema for the credential Associated with the connection */
+    credentialSchema?: object;
+    /** Schema for the connection */
+    connectionSchema?: object;
+    /** Visualization styles for the connection, including svgColor and svgWhite used for UI representation. */
+    styles?: {
+      /** Primary color of the component used for UI representation. */
+      primaryColor: string;
+      /** Secondary color of the entity used for UI representation. */
+      secondaryColor?: string;
+      /** White SVG of the entity used for UI representation on dark background. */
+      svgWhite: string;
+      /** Colored SVG of the entity used for UI representation on light background. */
+      svgColor: string;
+      /** Complete SVG of the entity used for UI representation, often inclusive of background. */
+      svgComplete: string;
+      /** The color of the element's label. Colours may be specified by name (e.g. red), hex (e.g. */
+      color?: string;
+      /** The opacity of the label text, including its outline. */
+      textOpacity?: number;
+      /** A comma-separated list of font names to use on the label text. */
+      fontFamily?: string;
+      /** The size of the label text. */
+      fontSize?: string;
+      /** A CSS font style to be applied to the label text. */
+      fontStyle?: string;
+      /** A CSS font weight to be applied to the label text. */
+      fontWeight?: string;
+      /** A transformation to apply to the label text */
+      textTransform?: "none" | "uppercase" | "lowercase";
+      /** The opacity of the element, ranging from 0 to 1. Note that the opacity of a compound node parent affects the effective opacity of its children. */
+      opacity?: number;
+      /** An integer value that affects the relative draw order of elements. In general, an element with a higher z-index will be drawn on top of an element with a lower z-index. Note that edges are under nodes despite z-index. */
+      zIndex?: number;
+      /** The text to display for an element's label. Can give a path, e.g. data(id) will label with the elements id */
+      label?: string;
+      /** The animation to apply to the element. example ripple,bounce,etc */
+      animation?: object;
+      [key: string]: any;
+    } & {
+      /** The shape of the node's body. Note that each shape fits within the specified width and height, and so you may have to adjust width and height if you desire an equilateral shape (i.e. width !== height for several equilateral shapes) */
+      shape:
+        | "ellipse"
+        | "triangle"
+        | "round-triangle"
+        | "rectangle"
+        | "round-rectangle"
+        | "bottom-round-rectangle"
+        | "cut-rectangle"
+        | "barrel"
+        | "rhomboid"
+        | "diamond"
+        | "round-diamond"
+        | "pentagon"
+        | "round-pentagon"
+        | "hexagon"
+        | "round-hexagon"
+        | "concave-hexagon"
+        | "heptagon"
+        | "round-heptagon"
+        | "octagon"
+        | "round-octagon"
+        | "star"
+        | "tag"
+        | "round-tag"
+        | "vee"
+        | "polygon";
+      /** The position of the node. If the position is set, the node is drawn at that position in the given dimensions. If the position is not set, the node is drawn at a random position. */
+      position?: {
+        /** The x-coordinate of the node. */
+        x: number;
+        /** The y-coordinate of the node. */
+        y: number;
+      };
+      /** The text to display for an element's body. Can give a path, e.g. data(id) will label with the elements id */
+      bodyText?: string;
+      /** How to wrap the text in the node. Can be 'none', 'wrap', or 'ellipsis'. */
+      bodyTextWrap?: "none" | "wrap" | "ellipsis";
+      /** The maximum width for wrapping text in the node. */
+      bodyTextMaxWidth?: string;
+      /** The opacity of the node's body text, including its outline. */
+      bodyTextOpacity?: number;
+      /** The colour of the node's body text background. Colours may be specified by name (e.g. red), hex (e.g. */
+      bodyTextBackgroundColor?: string;
+      /** The size of the node's body text. */
+      bodyTextFontSize?: number;
+      /** The colour of the node's body text. Colours may be specified by name (e.g. red), hex (e.g. */
+      bodyTextColor?: string;
+      /** A CSS font weight to be applied to the node's body text. */
+      bodyTextFontWeight?: string;
+      /** A CSS horizontal alignment to be applied to the node's body text. */
+      bodyTextHorizontalAlign?: string;
+      /** A CSS text decoration to be applied to the node's body text. */
+      bodyTextDecoration?: string;
+      /** A CSS vertical alignment to be applied to the node's body text. */
+      bodyTextVerticalAlign?: string;
+      /** The width of the node's body or the width of an edge's line. */
+      width?: number;
+      /** The height of the node's body */
+      height?: number;
+      /** The URL that points to the image to show in the node. */
+      backgroundImage?: string;
+      /** The colour of the node's body. Colours may be specified by name (e.g. red), hex (e.g. */
+      backgroundColor?: string;
+      /** Blackens the node's body for values from 0 to 1; whitens the node's body for values from 0 to -1. */
+      backgroundBlacken?: number;
+      /** The opacity level of the node's background colour */
+      backgroundOpacity?: number;
+      /** The x position of the background image, measured in percent (e.g. 50%) or pixels (e.g. 10px) */
+      backgroundPositionX?: string;
+      /** The y position of the background image, measured in percent (e.g. 50%) or pixels (e.g. 10px) */
+      backgroundPositionY?: string;
+      /** The x offset of the background image, measured in percent (e.g. 50%) or pixels (e.g. 10px) */
+      backgroundOffsetX?: string;
+      /** The y offset of the background image, measured in percent (e.g. 50%) or pixels (e.g. 10px) */
+      backgroundOffsetY?: string;
+      /** How the background image is fit to the node. Can be 'none', 'contain', or 'cover'. */
+      backgroundFit?: "none" | "contain" | "cover";
+      /** How the background image is clipped to the node. Can be 'none', 'node', or 'node-border'. */
+      backgroundClip?: "none" | "node" | "node-border";
+      /** How the background image's width is determined. Can be 'none', 'inner', or 'outer'. */
+      backgroundWidthRelativeTo?: "none" | "inner" | "outer";
+      /** How the background image's height is determined. Can be 'none', 'inner', or 'outer'. */
+      backgroundHeightRelativeTo?: "none" | "inner" | "outer";
+      /** The size of the node's border. */
+      borderWidth?: number;
+      /** The style of the node's border */
+      borderStyle?: "solid" | "dotted" | "dashed" | "double";
+      /** The colour of the node's border. Colours may be specified by name (e.g. red), hex (e.g. */
+      borderColor?: string;
+      /** The opacity of the node's border */
+      borderOpacity?: number;
+      /** The amount of padding around all sides of the node. */
+      padding?: number;
+      /** The horizontal alignment of a node's label */
+      textHalign?: "left" | "center" | "right";
+      /** The vertical alignment of a node's label */
+      textValign?: "top" | "center" | "bottom";
+      /** Whether to use the ghost effect, a semitransparent duplicate of the element drawn at an offset. */
+      ghost?: "yes" | "no";
+      /** The colour of the indicator shown when the background is grabbed by the user. Selector needs to be *core*. Colours may be specified by name (e.g. red), hex (e.g. */
+      activeBgColor?: string;
+      /** The opacity of the active background indicator. Selector needs to be *core*. */
+      activeBgOpacity?: string;
+      /** The opacity of the active background indicator. Selector needs to be *core*. */
+      activeBgSize?: string;
+      /** The background colour of the selection box used for drag selection. Selector needs to be *core*. Colours may be specified by name (e.g. red), hex (e.g. */
+      selectionBoxColor?: string;
+      /** The size of the border on the selection box. Selector needs to be *core* */
+      selectionBoxBorderWidth?: number;
+      /** The opacity of the selection box. Selector needs to be *core* */
+      selectionBoxOpacity?: number;
+      /** The colour of the area outside the viewport texture when initOptions.textureOnViewport === true. Selector needs to be *core*. Colours may be specified by name (e.g. red), hex (e.g. */
+      outsideTextureBgColor?: string;
+      /** The opacity of the area outside the viewport texture. Selector needs to be *core* */
+      outsideTextureBgOpacity?: number;
+      /** An array (or a space-separated string) of numbers ranging on [-1, 1], representing alternating x and y values (i.e. x1 y1 x2 y2, x3 y3 ...). This represents the points in the polygon for the node's shape. The bounding box of the node is given by (-1, -1), (1, -1), (1, 1), (-1, 1). The node's position is the origin (0, 0 ) */
+      shapePolygonPoints?: string;
+      /** The colour of the background of the component menu. Colours may be specified by name (e.g. red), hex (e.g. */
+      menuBackgroundColor?: string;
+      /** The opacity of the background of the component menu. */
+      menuBackgroundOpacity?: number;
+      /** The colour of the text or icons in the component menu. Colours may be specified by name (e.g. red), hex (e.g. */
+      menuForgroundColor?: string;
+    };
+    /** Connection Status */
+    status:
+      | "discovered"
+      | "registered"
+      | "connected"
+      | "ignored"
+      | "maintenance"
+      | "disconnected"
+      | "deleted"
+      | "not found";
+    /** Map describing the connection state machine. Each key is a current connection status and its value is the list of states the connection may transition to from that status, along with a description of each transition. */
+    transitionMap?: {
+      [key: string]: {
+        /** Connection Status Value */
+        nextState:
+          | "discovered"
+          | "registered"
+          | "connected"
+          | "ignored"
+          | "maintenance"
+          | "disconnected"
+          | "deleted"
+          | "not found";
+        /** Human-readable explanation of when or why this transition occurs. */
+        description?: string;
+      }[];
+    };
+    /** User ID who owns this connection */
+    owner?: string;
+    /** Timestamp when the connection was created. */
+    createdAt?: string;
+    /** Timestamp when the connection was last updated. */
+    updatedAt?: string;
+    /** Timestamp when the connection was soft-deleted, if applicable. */
+    deletedAt?: string;
+    /** Associated environments for this connection */
+    environments?: {
+      /** ID */
+      id: string;
+      /** Specifies the version of the schema to which the environment conforms. */
+      schemaVersion: string;
+      /** Environment name */
+      name: string;
+      /** Environment description */
+      description: string;
+      /** Environment organization ID */
+      organizationId: string;
+      /** Environment owner */
+      owner?: string;
+      /** Timestamp when the environment was created. */
+      createdAt?: string;
+      /** Additional metadata associated with the environment. */
+      metadata?: object;
+      /** Timestamp when the environment was last updated. */
+      updatedAt?: string;
+      /** Timestamp when the environment was soft deleted. Null while the environment remains active. */
+      deletedAt?: string | null;
+    }[];
+    /** Specifies the version of the schema used for the definition. */
+    schemaVersion: string;
+  };
+export type PerformConnectionActionApiArg = {
+  /** Connection ID */
+  connectionId: string;
+  body: {
+    /** The operation to perform on the connection. */
+    action: "setMeshsyncMode";
+    /** Target MeshSync deployment mode. Required when `action` is `setMeshsyncMode`; the server redeploys MeshSync (operator vs embedded) for the connection's cluster. */
+    mode?: "operator" | "embedded";
+  };
+};
 export type DeleteMesheryConnectionApiResponse = unknown;
 export type DeleteMesheryConnectionApiArg = {
   /** Meshery server ID */
@@ -8968,6 +9377,11 @@ export const {
   useResetSystemDatabaseMutation,
   useGetSystemVersionQuery,
   useGetSystemSyncQuery,
+  useGetOperatorControllerStatusQuery,
+  useGetMeshsyncControllerStatusQuery,
+  useGetBrokerControllerStatusQuery,
+  useGetControllerDiagnosticsQuery,
+  useSubscribeControllersStatusQuery,
   useGetUserCredentialsQuery,
   useSaveUserCredentialMutation,
   useUpdateUserCredentialMutation,
@@ -9004,6 +9418,7 @@ export const {
   useGetConnectionByIdQuery,
   useUpdateConnectionMutation,
   useDeleteConnectionMutation,
+  usePerformConnectionActionMutation,
   useDeleteMesheryConnectionMutation,
   useGetKubernetesContextQuery,
   useAddConnectionToEnvironmentMutation,


### PR DESCRIPTION
## Description

Adds the API surface for the Meshery **Kubernetes connection / controller** work (migrating connection & controller status off GraphQL subscriptions onto SSE + REST). Three additive, `x-internal: ["meshery"]` changes to `constructs/v1beta1/system/api.yml` and `constructs/v1beta3/connection/api.yml`, with regenerated Go models and the RTK client.

### Endpoints

- **Controller status** (replaces the GraphQL controller-status subscription/queries):
  - `GET /api/system/controllers/status/subscribe` — SSE stream of `ControllerStatus[]`.
  - `GET /api/system/controllers/{operator,meshsync,broker}/status` — one-shot status.
- **Connection actions**:
  - `POST /api/integrations/connections/{connectionId}/actions` — a side-effecting action envelope (`ConnectionActionRequest`), first action `setMeshsyncMode` (operator/embedded).
- **Controller diagnostics**:
  - `GET /api/system/controllers/diagnostics` — per-connection `ConnectionDiagnostics` (a `healthy` flag + `ControllerDiagnostic[]` with severity, code, summary, description, remediation steps, endpoint) for the connection-detail Diagnostics view.

### Schemas added

`ControllerStatus`, `ControllerInfo`, `ConnectionActionRequest`, `ControllerDiagnostic`, `ConnectionDiagnostics`.

### Generated

Regenerated the Go models (`models/v1beta1/system`, `models/v1beta3/connection`) and the RTK client (`typescript/rtk/meshery.ts`) so consumers get the new `getControllerDiagnostics` / `subscribeControllersStatus` / `performConnectionAction` hooks and types. `make validate-schemas` and `make consumer-audit` pass. The full TypeScript `typescript/generated/**` and `dist/**` artifacts are intentionally left to the repo's automated build/generate step (regenerating them locally produced unrelated formatting churn across the tree).

## Consumers

Consumed by meshery/meshery (`connections-sse` branch): the SSE controller-status client, the REST status/diagnostics hooks, the `/actions` mutation, and the connection-detail Diagnostics section.
