### PR TITLE
[Docs] Repoint remaining dangling identifier-naming citations

### DIFF
--- a/cmd/phase0-consumer-graph/main.go
+++ b/cmd/phase0-consumer-graph/main.go
@@ -2,7 +2,7 @@
 // graph across the downstream repos and produces the Phase 0 Agent 0.D
 // baseline (validation/baseline/consumer-graph.json) used by Phase 3 per-
 // resource sequencing in the identifier-naming migration
-// (docs/identifier-naming-migration.md §6, §9).
+// (see docs/schema-tooling.md).
 //
 // Two kinds of imports are attributed:
 //

--- a/cmd/phase0-field-count/main.go
+++ b/cmd/phase0-field-count/main.go
@@ -19,7 +19,7 @@
 //
 // The report is the input to Phase 1 rule authoring and Phase 3 sequencing in
 // the identifier-naming migration
-// (docs/identifier-naming-migration.md §6).
+// (see docs/schema-tooling.md).
 package main
 
 import (

--- a/cmd/phase0-tag-divergence/main.go
+++ b/cmd/phase0-tag-divergence/main.go
@@ -2,7 +2,7 @@
 // meshery-cloud server/models directories and produces the Phase 0 Agent 0.B
 // tag-divergence baseline (validation/baseline/tag-divergence.json) used by
 // the identifier-naming migration
-// (docs/identifier-naming-migration.md §6).
+// (see docs/schema-tooling.md).
 //
 // Each scanned field is evaluated against three criteria from Agent 0.B's
 // charter:

--- a/schemas/constructs/v1beta2/design/api.yml
+++ b/schemas/constructs/v1beta2/design/api.yml
@@ -8,8 +8,8 @@ info:
     Phase 3 identifier-naming migration (camelCase-on-the-wire contract). All
     JSON tags and query/path parameters were snake_case in v1beta2; the
     replacement v1beta3 schema publishes them as canonical camelCase. v1beta2
-    remains served for one release cycle after all downstream consumers
-    migrate, then is retired per docs/identifier-naming-migration.md §9.1 row 5.
+    remains served indefinitely for consumers that pin it, per the Phase 4.A
+    non-deletion policy in docs/schema-tooling.md.
   version: v1beta2
   x-deprecated: true
   x-superseded-by: v1beta3/design

--- a/specs/casing-rules.md
+++ b/specs/casing-rules.md
@@ -1,6 +1,16 @@
-# Meshery Schemas Casing Rules — Definitive Reference
+# Meshery Schemas Casing Rules - Superseded Pre-Migration Reference
 
-This document is the single authoritative source for casing decisions across the Meshery schema ecosystem. It governs OpenAPI schema definitions, Go code generation (oapi-codegen), TypeScript type generation (openapi-typescript), and the two primary downstream ORM consumers: **GORM** (meshery/meshery) and **Buffalo Pop** (layer5io/meshery-cloud).
+> **SUPERSEDED.** This document describes the pre-migration casing
+> contract, under which DB-backed fields published snake_case on the
+> wire. The identifier-naming migration replaced that contract; the
+> current authority is [`docs/casing-rules.md`](../docs/casing-rules.md)
+> (wire is camelCase everywhere; snake_case lives only in the `db:`
+> tag). The rule descriptions below (Rules 6, 32, 33) no longer match
+> the validator: Rule 32 is a retired stub, Rule 33 now flags
+> `page_size`/`total_count` as legacy, and Rule 6 is unconditional
+> camelCase. Retained for historical context only.
+
+This document was the authoritative source for casing decisions across the Meshery schema ecosystem prior to the identifier-naming migration. It governed OpenAPI schema definitions, Go code generation (oapi-codegen), TypeScript type generation (openapi-typescript), and the two primary downstream ORM consumers: **GORM** (meshery/meshery) and **Buffalo Pop** (layer5io/meshery-cloud).
 
 ## The Core Principle
 

--- a/validation/casing.go
+++ b/validation/casing.go
@@ -10,8 +10,8 @@ import (
 //
 // Phase 4.D — `knownLowercaseSuffixViolations` retired.
 //
-// Phase 3 migrated all 22 resources in the §9.1 inventory of
-// docs/identifier-naming-migration.md to canonical camelCase wire form,
+// Phase 3 migrated all 22 resources in the migration inventory to
+// canonical camelCase wire form (see docs/schema-tooling.md),
 // and Phase 4.A administratively closed with every legacy directory
 // carrying `info.x-deprecated: true`. The audit walker
 // (validation/audit.go::walkValidatedConstructSpecs) skips deprecated
@@ -64,14 +64,14 @@ var (
 // above). The empty map is retained so `HasLowercaseSuffix` keeps its
 // public signature — callers inside `GetCamelCaseIssues` still
 // type-check and simply never append a lowercase-suffix issue. See
-// docs/identifier-naming-migration.md §10 Agent 4.D.
+// docs/schema-tooling.md.
 var knownLowercaseSuffixViolations = map[string]bool{}
 
 // dbMirroredFields enumerates known snake_case property names that originated
 // as DB column mirrors in pre-canonical-contract schemas.
 //
-// Under the canonical identifier-naming contract (see docs/casing-rules.md
-// and docs/identifier-naming-migration.md), wire tags are
+// Under the canonical identifier-naming contract (see
+// docs/casing-rules.md), wire tags are
 // camelCase regardless of DB backing — so these names are no longer treated
 // as an exception to Rule 6. They surface as Rule 6 violations and are
 // routed through the same `--style-debt` severity path as every other
@@ -187,8 +187,8 @@ type CasingIssue struct {
 // OpenAPI query/header parameter name, or any similar camelCase-expected
 // token) for casing violations.
 //
-// Under the canonical identifier-naming contract (docs/casing-rules.md,
-// docs/identifier-naming-migration.md §1), wire names are
+// Under the canonical identifier-naming contract
+// (docs/casing-rules.md), wire names are
 // camelCase regardless of DB backing — the snake_case DB column name lives
 // only in `x-oapi-codegen-extra-tags.db`, not on the wire. Accordingly this
 // checker is unconditional: there is no DB-mirroring exception. The

--- a/validation/casing_test.go
+++ b/validation/casing_test.go
@@ -114,8 +114,8 @@ func TestToCamelCase(t *testing.T) {
 
 func TestGetCamelCaseIssues(t *testing.T) {
 	// Under the canonical identifier-naming contract, GetCamelCaseIssues
-	// is unconditional: DB-mirrored names no longer get a pass. See Rule 6
-	// inversion in Phase 1.B of docs/identifier-naming-migration.md.
+	// is unconditional: DB-mirrored names no longer get a pass. See
+	// docs/casing-rules.md.
 	tests := []struct {
 		name           string
 		wantIssueCount int

--- a/validation/rules_design.go
+++ b/validation/rules_design.go
@@ -311,8 +311,7 @@ func checkRule25(filePath string, doc *openapi3.T, opts AuditOptions) []Violatio
 		// Accept any canonical page-size parameter name: the snake/lowercase
 		// variants are retained for legacy compatibility inside existing API
 		// versions, while newly authored / canonical-casing API versions use
-		// "pageSize". See docs/identifier-naming-migration.md §9 and
-		// docs/casing-rules.md.
+		// "pageSize". See docs/casing-rules.md.
 		if !paramNames["pagesize"] && !paramNames["page_size"] && !paramNames["pageSize"] {
 			missing = append(missing, "pageSize")
 		}

--- a/validation/rules_entity.go
+++ b/validation/rules_entity.go
@@ -277,8 +277,8 @@ func checkRule6ForEntity(filePath string, entity *entitySchema, opts AuditOption
 // match their snake_case `db:` tag exactly; under the new contract the
 // wire property name is camelCase and the snake_case DB column name lives
 // only in `x-oapi-codegen-extra-tags.db`, so propName != col is the
-// expected shape for DB-backed fields. See Phase 1.B in
-// docs/identifier-naming-migration.md. The function is retained as a
+// expected shape for DB-backed fields. See
+// docs/casing-rules.md. The function is retained as a
 // retired stub so historical audit-pipeline callers can be resolved at
 // compile time; it returns no violations.
 func checkRule32ForEntity(_ string, _ *entitySchema, _ AuditOptions) []Violation {

--- a/validation/rules_parity.go
+++ b/validation/rules_parity.go
@@ -259,8 +259,7 @@ func reportParityViolations(acc *parityAccumulator, opts AuditOptions) []Violati
 						`Partial parity across sibling list endpoints is the drift `+
 						`class that dropped the workspaces-orgId query in production. `+
 						`Either add the ref here, or remove it from the sibling for `+
-						`consistency. See docs/casing-rules.md and `+
-						`docs/identifier-naming-migration.md §9.4.`,
+						`consistency. See docs/casing-rules.md.`,
 					e.path, opID, version),
 				Severity:   *sev,
 				RuleNumber: 46,

--- a/validation/rules_property.go
+++ b/validation/rules_property.go
@@ -13,7 +13,7 @@ import (
 //
 // The pre-canonical rule required DB-backed property names to match their
 // snake_case `db:` tag exactly. Under the new contract (see
-// docs/identifier-naming-migration.md §1 and docs/casing-rules.md),
+// docs/casing-rules.md),
 // the wire property name is camelCase and the snake_case DB
 // column name lives only in `x-oapi-codegen-extra-tags.db` — so a
 // property whose name differs from its `db:` tag is the *expected* shape
@@ -29,7 +29,7 @@ func checkRule32ForAPI(_ string, _ *openapi3.T, _ AuditOptions) []Violation {
 // --- Rule 33: Pagination envelopes use canonical camelCase ---
 //
 // Under the canonical identifier-naming contract (see
-// docs/identifier-naming-migration.md §1 and docs/casing-rules.md),
+// docs/casing-rules.md),
 // pagination envelope properties are camelCase on the wire:
 // page, pageSize, totalCount. The legacy snake_case forms (page_size,
 // total_count) are still accepted inside existing API versions for
@@ -63,12 +63,12 @@ func checkRule33(filePath string, doc *openapi3.T, _ AuditOptions) []Violation {
 		}
 		if hasPageSizeSnake {
 			out = append(out, Violation{File: filePath,
-				Message:  fmt.Sprintf(`Schema %q — pagination envelopes should use "pageSize" (canonical camelCase), not "page_size". (migrate at the resource's next API-version bump per docs/identifier-naming-migration.md §9)`, name),
+				Message:  fmt.Sprintf(`Schema %q - pagination envelopes should use "pageSize" (canonical camelCase), not "page_size". (migrate at the resource's next API-version bump per docs/casing-rules.md)`, name),
 				Severity: SeverityAdvisory, RuleNumber: 33})
 		}
 		if hasTotalCountSnake {
 			out = append(out, Violation{File: filePath,
-				Message:  fmt.Sprintf(`Schema %q — pagination envelopes should use "totalCount" (canonical camelCase), not "total_count". (migrate at the resource's next API-version bump per docs/identifier-naming-migration.md §9)`, name),
+				Message:  fmt.Sprintf(`Schema %q - pagination envelopes should use "totalCount" (canonical camelCase), not "total_count". (migrate at the resource's next API-version bump per docs/casing-rules.md)`, name),
 				Severity: SeverityAdvisory, RuleNumber: 33})
 		}
 	}

--- a/validation/rules_property_test.go
+++ b/validation/rules_property_test.go
@@ -438,7 +438,7 @@ func TestFingerprintSchema_IdenticalSchemasProduceSameFingerprint(t *testing.T) 
 
 // ---------------------------------------------------------------------------
 // Rule 6 (inverted): unconditional camelCase — no DB-mirroring exception.
-// See docs/identifier-naming-migration.md Phase 1.B.
+// See docs/casing-rules.md.
 // ---------------------------------------------------------------------------
 
 // TestCheckRule6ForAPI_DBBackedSnakeFails is the first charter acceptance


### PR DESCRIPTION
**Notes for Reviewers**

Follow-up to #1019. That PR repointed the dangling identifier-naming citations in `docs/identifier-naming-contributor-guide.md` and `validation/rules_naming.go`; this PR sweeps the remaining files that still cite `docs/identifier-naming-migration.md` (deleted from the tree when the migration closed). All changes are comments and violation-message strings only - no logic changes.

**What changed**

- Policy citations (canonical casing contract, recase-at-next-version-bump) now point at `docs/casing-rules.md`, which states the same policy: the Rule 32 retirement stubs (`validation/rules_property.go`, `validation/rules_entity.go`), the Rule 33 pagination messages, the Rule 25 comment (`validation/rules_design.go`), the Rule 46 message (`validation/rules_parity.go`), both contract comments in `validation/casing.go`, and two test-file comments.
- Migration-status and baseline-tooling citations now point at `docs/schema-tooling.md`: the three `cmd/phase0-*` package docs and the Phase 3 / Phase 4.D history comments in `validation/casing.go`.
- `schemas/constructs/v1beta2/design/api.yml` gets a factual correction, not just a repoint: its `info.description` claimed v1beta2 "is retired per §9.1 row 5" of the deleted plan, but that retirement schedule was overridden by the Phase 4.A non-deletion policy. The sentence now states the actual policy (retained indefinitely for consumers that pin it) and cites `docs/schema-tooling.md`.
- The two Rule 33 message strings also drop their em-dash characters.

**Reviewer notes**

- Advisory-baseline safety was verified before changing the Rule 33/46 message strings: the baseline entries embedding the old text belong to deprecated specs the audit walker skips (dead entries), Rule 46 currently fires nowhere, and the only two live Rule 33 hits were already unbaselined. The advisory count is 316 before and after this change.
- `CHANGELOG.md` still cites the deleted doc in three historical entries; those are intentionally left untouched.
- Verified locally: `go build ./...`, `go test ./validation/...` (pass), `make validate-schemas` (no blocking violations).

**Out-of-scope fix (flagged for reviewers)**

- `specs/casing-rules.md` is now marked as a superseded pre-migration reference (commit eebeffe3). The repo carried two contradictory casing-rules.md files: `docs/casing-rules.md` states the current camelCase-on-the-wire contract and matches the live validator, while `specs/casing-rules.md` (titled "Definitive Reference") still described the retired pre-migration contract (snake_case wire names for DB-backed fields, Rule 32 blocking, Rule 33 requiring `page_size`/`total_count`). The contradiction had practical cost: an automated reviewer on this PR read the stale spec as authoritative and flagged the `docs/casing-rules.md` citations as broken links. Content is retained for historical context, consistent with the repo's deprecate-with-pointer convention.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

