### PR TITLE
preserve docs_href in site data regeneration

### DIFF
--- a/build/generate-site-data.js
+++ b/build/generate-site-data.js
@@ -182,11 +182,19 @@ function loadExistingDocsHrefs(outputPath) {
   }
   try {
     const existing = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+
+    if (!Array.isArray(existing)) {
+      throw new Error("Invalid configuration: existing docs hrefs must be an array.");
+    }
+
     return Object.fromEntries(
-      existing.filter((e) => e.docs_href).map((e) => [e.construct, e.docs_href])
+      existing
+        .filter((e) => e && typeof e === "object" && e.construct && e.docs_href)
+        .map((e) => [e.construct, e.docs_href])
     );
-  } catch {
-    return {};
+  } catch (error) {
+
+    throw new Error("Failed to load existing docs hrefs: " + error.message);
   }
 }
 

--- a/build/generate-site-data.js
+++ b/build/generate-site-data.js
@@ -176,13 +176,34 @@ function resolveConstructClassification(repoRoot, version, construct) {
   };
 }
 
-function buildSiteData(repoRoot, constructs) {
-  return constructs.map(({ construct, version }) => ({
-    construct,
-    version,
-    href: resolveSchemaHref(repoRoot, version, construct),
-    ...resolveConstructClassification(repoRoot, version, construct),
-  }));
+function loadExistingDocsHrefs(outputPath) {
+  if (!fs.existsSync(outputPath)) {
+    return {};
+  }
+  try {
+    const existing = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    return Object.fromEntries(
+      existing.filter((e) => e.docs_href).map((e) => [e.construct, e.docs_href])
+    );
+  } catch {
+    return {};
+  }
+}
+
+function buildSiteData(repoRoot, constructs, docsHrefs = {}) {
+  return constructs.map(({ construct, version }) => {
+    const entry = {
+      construct,
+      version,
+      href: resolveSchemaHref(repoRoot, version, construct),
+    };
+
+    if (docsHrefs[construct]) {
+      entry.docs_href = docsHrefs[construct];
+    }
+
+    return { ...entry, ...resolveConstructClassification(repoRoot, version, construct) };
+  });
 }
 
 function writeSiteData(outputPath, siteData) {
@@ -194,7 +215,8 @@ function main(argv = process.argv.slice(2)) {
   const repoRoot = paths.getProjectRoot();
   const outputPath = resolveOutputPath(argv, repoRoot);
   const constructs = loadLatestConstructs(repoRoot);
-  const siteData = buildSiteData(repoRoot, constructs);
+  const docsHrefs = loadExistingDocsHrefs(outputPath);
+  const siteData = buildSiteData(repoRoot, constructs, docsHrefs);
 
   writeSiteData(outputPath, siteData);
   process.stdout.write(`Wrote ${path.relative(repoRoot, outputPath)}\n`);
@@ -208,6 +230,7 @@ module.exports = {
   DEFAULT_OUTPUT_RELATIVE_PATH,
   buildSiteData,
   collectXInternalTags,
+  loadExistingDocsHrefs,
   loadLatestConstructs,
   main,
   parseLatestConstructs,

--- a/site/_data/latest_schema_versions.json
+++ b/site/_data/latest_schema_versions.json
@@ -38,6 +38,7 @@
     "construct": "component",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/component/component.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/components",
     "core": false,
     "extension": false
   },
@@ -45,6 +46,7 @@
     "construct": "connection",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/connection/connection.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/connections",
     "core": true,
     "extension": true
   },
@@ -66,6 +68,7 @@
     "construct": "credential",
     "version": "v1beta2",
     "href": "/schemas/constructs/v1beta2/credential/api.yml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/credentials",
     "core": true,
     "extension": true
   },
@@ -73,6 +76,7 @@
     "construct": "design",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/design/design.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/designs",
     "core": true,
     "extension": true
   },
@@ -80,6 +84,7 @@
     "construct": "environment",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/environment/environment.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/environments",
     "core": true,
     "extension": true
   },
@@ -136,6 +141,7 @@
     "construct": "model",
     "version": "v1beta2",
     "href": "/schemas/constructs/v1beta2/model/model.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/models",
     "core": true,
     "extension": true
   },
@@ -143,6 +149,7 @@
     "construct": "organization",
     "version": "v1beta2",
     "href": "/schemas/constructs/v1beta2/organization/organization.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/organizations",
     "core": true,
     "extension": true
   },
@@ -171,6 +178,7 @@
     "construct": "relationship",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/relationship/relationship.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/relationships",
     "core": false,
     "extension": false
   },
@@ -248,6 +256,7 @@
     "construct": "workspace",
     "version": "v1beta3",
     "href": "/schemas/constructs/v1beta3/workspace/workspace.yaml",
+    "docs_href": "https://docs.meshery.io/concepts/logical/workspaces",
     "core": true,
     "extension": true
   }

--- a/site/index.html
+++ b/site/index.html
@@ -326,7 +326,7 @@ permalink: /
           <tbody role="rowgroup">
             {% for schema in site.data.latest_schema_versions %}
             <tr role="row">
-              <th scope="row" role="rowheader">{% if schema.docs_href != blank %}<a href="{{ schema.docs_href }}" target="_blank" rel="noopener noreferrer">{{ schema.construct }}</a>{% else %}{{ schema.construct }}{% endif %}</th>
+              <th scope="row" role="rowheader">{% if schema.docs_href %}<a href="{{ schema.docs_href }}" target="_blank" rel="noopener noreferrer">{{ schema.construct }}</a>{% else %}{{ schema.construct }}{% endif %}</th>
               <td role="cell" data-label="Latest schema"><a href="https://github.com/meshery/schemas/blob/master{{ schema.href }}" target="_blank" rel="noopener noreferrer">{{ schema.version }}</a></td>
               <td role="cell" class="classification" data-label="Core">
                 {% if schema.core %}<span class="yes" aria-hidden="true">✓</span><span class="sr-only">Core</span>{% else %}<span class="no" aria-hidden="true">·</span><span class="sr-only">Not Core</span>{% endif %}

--- a/tests/generate-site-data.test.js
+++ b/tests/generate-site-data.test.js
@@ -8,6 +8,7 @@ const {
   DEFAULT_OUTPUT_RELATIVE_PATH,
   buildSiteData,
   collectXInternalTags,
+  loadExistingDocsHrefs,
   parseLatestConstructs,
   resolveConstructClassification,
   resolveOutputPath,
@@ -222,6 +223,113 @@ test("buildSiteData returns Jekyll-friendly schema rows", () => {
         extension: false,
       },
     ]);
+  });
+});
+
+test("loadExistingDocsHrefs returns empty object when file does not exist", () => {
+  assert.deepEqual(loadExistingDocsHrefs("/nonexistent/path.json"), {});
+});
+
+test("loadExistingDocsHrefs extracts docs_href entries keyed by construct", () => {
+  const existing = [
+    { construct: "component", version: "v1beta3", href: "/schemas/constructs/v1beta3/component/component.yaml", docs_href: "https://docs.meshery.io/concepts/logical/components", core: false, extension: false },
+    { construct: "connection", version: "v1beta3", href: "/schemas/constructs/v1beta3/connection/connection.yaml", docs_href: "https://docs.meshery.io/concepts/logical/connections", core: true, extension: true },
+    { construct: "academy",   version: "v1beta3", href: "/schemas/constructs/v1beta3/academy/academy.yaml", core: false, extension: true },
+  ];
+
+  withTempRepo({ "data.json": JSON.stringify(existing) }, (tempDir) => {
+    assert.deepEqual(loadExistingDocsHrefs(path.join(tempDir, "data.json")), {
+      component: "https://docs.meshery.io/concepts/logical/components",
+      connection: "https://docs.meshery.io/concepts/logical/connections",
+    });
+  });
+});
+
+test("loadExistingDocsHrefs throws when file contains invalid JSON", () => {
+  withTempRepo({ "data.json": "not valid json" }, (tempDir) => {
+    assert.throws(
+      () => loadExistingDocsHrefs(path.join(tempDir, "data.json")),
+      /Failed to load existing docs hrefs/,
+    );
+  });
+});
+
+test("loadExistingDocsHrefs throws when file contains a non-array", () => {
+  withTempRepo({ "data.json": JSON.stringify({ construct: "component" }) }, (tempDir) => {
+    assert.throws(
+      () => loadExistingDocsHrefs(path.join(tempDir, "data.json")),
+      /Failed to load existing docs hrefs/,
+    );
+  });
+});
+
+test("buildSiteData includes docs_href when provided", () => {
+  withTempRepo({
+    "schemas/constructs/v1/component/component.yaml": "",
+    "schemas/constructs/v1/component/api.yml": API_CLOUD_ONLY,
+  }, (tempRepoRoot) => {
+    const siteData = buildSiteData(
+      tempRepoRoot,
+      [{ construct: "component", version: "v1" }],
+      { component: "https://docs.meshery.io/concepts/logical/components" }
+    );
+
+    assert.deepEqual(siteData, [
+      {
+        construct: "component",
+        version: "v1",
+        href: "/schemas/constructs/v1/component/component.yaml",
+        docs_href: "https://docs.meshery.io/concepts/logical/components",
+        core: false,
+        extension: true,
+      },
+    ]);
+  });
+});
+
+test("buildSiteData omits docs_href when not in map", () => {
+  withTempRepo({
+    "schemas/constructs/v1/academy/academy.yaml": "",
+    "schemas/constructs/v1/academy/api.yml": API_NO_OPERATIONS,
+  }, (tempRepoRoot) => {
+    const siteData = buildSiteData(
+      tempRepoRoot,
+      [{ construct: "academy", version: "v1" }],
+      {}
+    );
+
+    assert.equal("docs_href" in siteData[0], false);
+  });
+});
+
+test("docs_href values survive a full regeneration cycle", () => {
+  withTempRepo({
+    "schemas/constructs/v1/component/component.yaml": "",
+    "schemas/constructs/v1/component/api.yml": API_CLOUD_ONLY,
+    "schemas/constructs/v1/academy/academy.yaml": "",
+    "schemas/constructs/v1/academy/api.yml": API_NO_OPERATIONS,
+  }, (tempRepoRoot) => {
+    const outputPath = path.join(tempRepoRoot, "data.json");
+
+    // Simulate the committed file with docs_href on component only
+    const initial = [
+      { construct: "component", version: "v1", href: "/schemas/constructs/v1/component/component.yaml", docs_href: "https://docs.meshery.io/concepts/logical/components", core: false, extension: true },
+      { construct: "academy",   version: "v1", href: "/schemas/constructs/v1/academy/academy.yaml", core: false, extension: false },
+    ];
+    fs.writeFileSync(outputPath, JSON.stringify(initial));
+
+    // Simulate what CI does: read existing docs_href, regenerate, write
+    const docsHrefs = loadExistingDocsHrefs(outputPath);
+    const regenerated = buildSiteData(
+      tempRepoRoot,
+      [{ construct: "component", version: "v1" }, { construct: "academy", version: "v1" }],
+      docsHrefs
+    );
+    writeSiteData(outputPath, regenerated);
+
+    const result = JSON.parse(fs.readFileSync(outputPath, "utf8"));
+    assert.equal(result.find((e) => e.construct === "component").docs_href, "https://docs.meshery.io/concepts/logical/components");
+    assert.equal("docs_href" in result.find((e) => e.construct === "academy"), false);
   });
 });
 


### PR DESCRIPTION
**Notes for Reviewers**

`build/generate-site-data.js` regenerates `site/_data/latest_schema_versions.json` from scratch on every CI run, dropping any field not derived from schema files. `docs_href` links added in PR #966 were silently stripped by the `Generate Artifacts from schemas` auto-commit immediately after that PR merged.

**Changes:**
- `build/generate-site-data.js` — added `loadExistingDocsHrefs()` which reads `docs_href` values from the existing JSON before regenerating, so they are carried forward into the new output
- `site/_data/latest_schema_versions.json` — restored the 9 `docs_href` entries that were stripped by CI

This PR fixes #1047

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
