### PR TITLE
fix(invitation): allow null emails and expiresAt in v1beta3

### DIFF
--- a/schemas/constructs/v1beta3/invitation/invitation.yaml
+++ b/schemas/constructs/v1beta3/invitation/invitation.yaml
@@ -52,11 +52,13 @@ properties:
     maxLength: 5000
   emails:
     type: array
+    nullable: true
     description: Email addresses or patterns for which the invitation is valid. Null
       means the invitation is valid for any email address.
     x-go-type: pq.StringArray
     x-go-type-import:
       path: github.com/lib/pq
+    x-go-type-skip-optional-pointer: true
     items:
       type: string
       pattern: ^([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-z]{2,}|@[a-zA-Z0-9.-]+\.[a-z]{2,})$
@@ -73,6 +75,7 @@ properties:
   expiresAt:
     type: string
     format: date-time
+    nullable: true
     description: Timestamp when the invitation expires, if applicable. Null or empty
       means the invitation does not expire.
     x-oapi-codegen-extra-tags:


### PR DESCRIPTION
## Description

The v1beta3 `Invitation` schema declares `emails` (array) and `expiresAt` (date-time) **without** `nullable`, yet the API and DB treat `null` as a first-class value - each field's own description says so:

- `emails`: *"Null means the invitation is valid for any email address."*
- `expiresAt`: *"Null or empty means the invitation does not expire."*

Consumers that validate an existing invitation against this schema - notably the Meshery Cloud **Edit Invitation** RJSF form - reject a `null` that the server itself produced:

> Please fix the highlighted fields: `.emails must be array`

This PR marks both properties `nullable: true` so the JSON Schema matches the documented contract.

## Change

- `schemas/constructs/v1beta3/invitation/invitation.yaml`: `emails` and `expiresAt` → `nullable: true`.
- `emails` additionally gets `x-go-type-skip-optional-pointer: true` so the generated Go type stays `pq.StringArray` (already nil-able) rather than becoming a redundant `*pq.StringArray` pointer. `expiresAt` is already `*time.Time`. **Net Go model diff is zero** - no downstream Go breakage.

Only the source YAML is committed here; generated Go/TS/dist artifacts are regenerated and auto-committed by the `Generate Artifacts from schemas` workflow on merge.

## Verification

- `make validate-schemas` → no blocking violations.
- `make bundle-openapi && make generate-golang` → `models/v1beta3/invitation/invitation.go` unchanged (0 diff).
- Built the dist locally and confirmed RJSF/AJV (`@rjsf/validator-ajv8`) now accepts `emails: null` / `expiresAt: null` while still rejecting genuinely malformed values.

## Related

- Fixes the schema-contract half of layer5io/meshery-cloud#5712.
- The Meshery Cloud UI fix (PR linked below) works against the current published `@meshery/schemas` and picks up this contract correction on the next dependency bump.
