### PR TITLE
fix(rtk): cross-construct cache invalidation for environment connections (assign/remove/delete, both clients)

### DIFF
--- a/build/generate-rtk.js
+++ b/build/generate-rtk.js
@@ -248,6 +248,80 @@ function guardOptionalQueryParams(filePath) {
 }
 
 /**
+ * Post-process generated RTK file to add cross-construct cache invalidation
+ * for operations whose OpenAPI tags cannot express it.
+ *
+ * `addConnectionToEnvironment` / `removeConnectionFromEnvironment` live in
+ * the `connection` construct (schemas/constructs/<version>/connection/api.yml), so
+ * bundle-openapi.js's prefixTags() namespaces their tags under
+ * `Connection_API_*`. There is no mechanism for a tag declared in one
+ * construct file to resolve to another construct's namespace, so these
+ * mutations can never automatically invalidate `Environment_environments`,
+ * the tag `getEnvironmentConnections` provides -- even though assigning or
+ * removing a connection changes exactly that data. Without this, the
+ * Environment UI's "Assigned Connections" count silently goes stale after
+ * every assign/remove action.
+ *
+ * This manually injects the missing tag into `invalidatesTags` for the
+ * affected operations after codegen runs.
+ *
+ * @param {string} filePath - Absolute path to the generated TS file
+ * @returns {number} count of operations patched
+ */
+function addCrossConstructInvalidation(filePath) {
+  if (!paths.fileExists(filePath)) {
+    logger.warn(`Post-process skipped: ${filePath} not found.`);
+    return 0;
+  }
+  const content = fs.readFileSync(filePath, "utf8");
+
+  const targets = ["addConnectionToEnvironment", "removeConnectionFromEnvironment"];
+  const extraTag = "Environment_environments";
+
+  let patched = content;
+  let count = 0;
+
+  for (const opName of targets) {
+    // Find the operation's starting position, then look for invalidatesTags
+    // within a bounded window right after it. This avoids both the original
+    // cross-operation matching risk and the inner-brace false-match issue
+    // (query blocks close with their own "}),", which a naive block regex
+    // can match before reaching the operation's actual invalidatesTags line).
+    const opStart = patched.indexOf(`${opName}: build.mutation`);
+    if (opStart === -1) {
+      logger.warn(`Post-process note: ${opName} not found; skipping cross-construct tag injection.`);
+      continue;
+    }
+    const searchWindow = patched.slice(opStart, opStart + 2000);
+    const tagsMatch = /invalidatesTags:\s*\[([^\]]*)\]/.exec(searchWindow);
+    if (!tagsMatch) {
+      logger.warn(`Post-process note: ${opName} has no invalidatesTags array within range; skipping.`);
+      continue;
+    }
+    if (tagsMatch[1].includes(extraTag)) {
+      continue;
+    }
+    const existingTags = tagsMatch[1].trim();
+    const newTagsInner = existingTags.length > 0
+      ? `${existingTags}, "${extraTag}"`
+      : `"${extraTag}"`;
+    const oldFull = tagsMatch[0];
+    const newFull = `invalidatesTags: [${newTagsInner}]`;
+    const absoluteIndex = opStart + tagsMatch.index;
+    patched = patched.slice(0, absoluteIndex) + newFull + patched.slice(absoluteIndex + oldFull.length);
+    count += 1;
+  }
+
+  if (count > 0) {
+    fs.writeFileSync(filePath, patched, "utf8");
+    logger.success(
+      `Post-processed: added cross-construct invalidatesTags to ${count} operation(s) in ${filePath}`,
+    );
+  }
+  return count;
+}
+
+/**
  * Post-process a generated RTK file to add extra named exports.
  * The codegen only emits `export { injectedRtkApi as <exportName> }`.
  * For consumers that import `injectedRtkApi` by its original internal name
@@ -289,6 +363,9 @@ async function generateRtkClient(rtk) {
     logger.success(`Generated: ${rtk.outputDescription}`);
     if (rtk.outputFile) {
       guardOptionalQueryParams(paths.fromRoot(rtk.outputFile));
+    }
+    if (rtk.name === "meshery" && rtk.outputFile) {
+      addCrossConstructInvalidation(paths.fromRoot(rtk.outputFile));
     }
     if (rtk.outputFile && rtk.outputExportName) {
       addInjectedRtkApiExport(paths.fromRoot(rtk.outputFile), rtk.outputExportName);
@@ -332,6 +409,7 @@ async function main() {
 }
 
 module.exports = {
+  addCrossConstructInvalidation,
   addInjectedRtkApiExport,
   checkPrerequisites,
   findUnguardedQueryParamAccesses,

--- a/build/generate-rtk.js
+++ b/build/generate-rtk.js
@@ -248,25 +248,35 @@ function guardOptionalQueryParams(filePath) {
 }
 
 /**
- * Post-process generated RTK file to add cross-construct cache invalidation
+ * Post-process a generated RTK file to add cross-construct cache invalidation
  * for operations whose OpenAPI tags cannot express it.
  *
- * `addConnectionToEnvironment` / `removeConnectionFromEnvironment` live in
- * the `connection` construct (schemas/constructs/<version>/connection/api.yml), so
+ * `addConnectionToEnvironment` / `removeConnectionFromEnvironment` /
+ * `deleteConnection` / `deleteMesheryConnection` live in the `connection`
+ * construct (schemas/constructs/<version>/connection/api.yml), so
  * bundle-openapi.js's prefixTags() namespaces their tags under
  * `Connection_API_*`. There is no mechanism for a tag declared in one
  * construct file to resolve to another construct's namespace, so these
  * mutations can never automatically invalidate `Environment_environments`,
- * the tag `getEnvironmentConnections` provides -- even though assigning or
- * removing a connection changes exactly that data. Without this, the
- * Environment UI's "Assigned Connections" count silently goes stale after
- * every assign/remove action.
+ * the tag `getEnvironmentConnections` provides -- even though assigning,
+ * removing, or deleting a connection changes exactly that data (a Connection
+ * embeds its own `environments` membership -- see connection.yaml). Without
+ * this, the Environment UI's "Assigned Connections" count silently goes
+ * stale after every assign/remove/delete action. Both generated clients
+ * define these operations identically, so this runs against both
+ * typescript/rtk/meshery.ts and typescript/rtk/cloud.ts.
  *
  * This manually injects the missing tag into `invalidatesTags` for the
- * affected operations after codegen runs.
+ * affected operations after codegen runs. Every target operation must
+ * either already carry the tag (from a prior run) or be successfully
+ * patched -- if upstream codegen ever renames an operation or reshapes its
+ * output so a target can't be matched, this throws rather than silently
+ * shipping a file missing the fix (mirroring guardOptionalQueryParams's
+ * fail-loud contract above).
  *
  * @param {string} filePath - Absolute path to the generated TS file
- * @returns {number} count of operations patched
+ * @returns {number} count of operations patched (excludes operations that
+ *   already carried the tag from a prior run)
  */
 function addCrossConstructInvalidation(filePath) {
   if (!paths.fileExists(filePath)) {
@@ -275,11 +285,17 @@ function addCrossConstructInvalidation(filePath) {
   }
   const content = fs.readFileSync(filePath, "utf8");
 
-  const targets = ["addConnectionToEnvironment", "removeConnectionFromEnvironment"];
+  const targets = [
+    "addConnectionToEnvironment",
+    "removeConnectionFromEnvironment",
+    "deleteConnection",
+    "deleteMesheryConnection",
+  ];
   const extraTag = "Environment_environments";
 
   let patched = content;
   let count = 0;
+  const unmatched = [];
 
   for (const opName of targets) {
     // Find the operation's starting position, then look for invalidatesTags
@@ -289,13 +305,13 @@ function addCrossConstructInvalidation(filePath) {
     // can match before reaching the operation's actual invalidatesTags line).
     const opStart = patched.indexOf(`${opName}: build.mutation`);
     if (opStart === -1) {
-      logger.warn(`Post-process note: ${opName} not found; skipping cross-construct tag injection.`);
+      unmatched.push(`${opName} (operation not found)`);
       continue;
     }
     const searchWindow = patched.slice(opStart, opStart + 2000);
     const tagsMatch = /invalidatesTags:\s*\[([^\]]*)\]/.exec(searchWindow);
     if (!tagsMatch) {
-      logger.warn(`Post-process note: ${opName} has no invalidatesTags array within range; skipping.`);
+      unmatched.push(`${opName} (no invalidatesTags array within range)`);
       continue;
     }
     if (tagsMatch[1].includes(extraTag)) {
@@ -312,11 +328,24 @@ function addCrossConstructInvalidation(filePath) {
     count += 1;
   }
 
+  // Fail loud: a target that can't be found or patched means this file is
+  // shipping without the fix it needs, silently. Match
+  // guardOptionalQueryParams's contract above rather than letting `make
+  // build`/CI stay green while the stale-cache bug this exists to fix
+  // quietly regresses.
+  if (unmatched.length > 0) {
+    throw new Error(
+      `Post-process failed: cross-construct invalidation target(s) could not be located in ${filePath}: ${unmatched.join(", ")}`,
+    );
+  }
+
   if (count > 0) {
     fs.writeFileSync(filePath, patched, "utf8");
     logger.success(
       `Post-processed: added cross-construct invalidatesTags to ${count} operation(s) in ${filePath}`,
     );
+  } else {
+    logger.info(`Post-process note: cross-construct invalidatesTags already present in ${filePath}.`);
   }
   return count;
 }
@@ -364,7 +393,7 @@ async function generateRtkClient(rtk) {
     if (rtk.outputFile) {
       guardOptionalQueryParams(paths.fromRoot(rtk.outputFile));
     }
-    if (rtk.name === "meshery" && rtk.outputFile) {
+    if ((rtk.name === "meshery" || rtk.name === "cloud") && rtk.outputFile) {
       addCrossConstructInvalidation(paths.fromRoot(rtk.outputFile));
     }
     if (rtk.outputFile && rtk.outputExportName) {

--- a/build/generate-rtk.js
+++ b/build/generate-rtk.js
@@ -167,8 +167,11 @@ function findUnguardedQueryParamAccesses(content) {
  */
 function guardOptionalQueryParams(filePath) {
   if (!paths.fileExists(filePath)) {
-    logger.warn(`Post-process skipped: ${filePath} not found.`);
-    return 0;
+    // Fail loud: after a successful codegen the output file must exist. A
+    // missing file means the RTK codegen output path has drifted (e.g. the
+    // config's outputFile changed), so silently skipping would let `make
+    // build`/CI stay green while this post-processing quietly stops applying.
+    throw new Error(`Post-process failed: expected generated file not found: ${filePath}.`);
   }
   const content = fs.readFileSync(filePath, "utf8");
 
@@ -280,8 +283,11 @@ function guardOptionalQueryParams(filePath) {
  */
 function addCrossConstructInvalidation(filePath) {
   if (!paths.fileExists(filePath)) {
-    logger.warn(`Post-process skipped: ${filePath} not found.`);
-    return 0;
+    // Fail loud: after a successful codegen the output file must exist. A
+    // missing file means the RTK codegen output path has drifted (e.g. the
+    // config's outputFile changed), so silently skipping would let `make
+    // build`/CI stay green while this post-processing quietly stops applying.
+    throw new Error(`Post-process failed: expected generated file not found: ${filePath}.`);
   }
   const content = fs.readFileSync(filePath, "utf8");
 
@@ -374,8 +380,10 @@ function addCrossConstructInvalidation(filePath) {
  */
 function addInjectedRtkApiExport(filePath, exportName) {
   if (!paths.fileExists(filePath)) {
-    logger.warn(`Post-process skipped: ${filePath} not found.`);
-    return;
+    // Fail loud (see the other post-processors): a missing output file after
+    // codegen means the path drifted, and skipping the export injection would
+    // silently ship a client without its `injectedRtkApi` export.
+    throw new Error(`Post-process failed: expected generated file not found: ${filePath}.`);
   }
   const content = fs.readFileSync(filePath, "utf8");
   const original = `export { injectedRtkApi as ${exportName} };`;

--- a/build/generate-rtk.js
+++ b/build/generate-rtk.js
@@ -303,24 +303,38 @@ function addCrossConstructInvalidation(filePath) {
     // cross-operation matching risk and the inner-brace false-match issue
     // (query blocks close with their own "}),", which a naive block regex
     // can match before reaching the operation's actual invalidatesTags line).
-    const opStart = patched.indexOf(`${opName}: build.mutation`);
-    if (opStart === -1) {
+    // Match the operation start with a regex rather than a fixed string so
+    // arbitrary spacing around the `:` (e.g. a prettier/codegen config change)
+    // doesn't silently stop matching. `\b` prevents a shorter target name from
+    // matching inside a longer one.
+    const opMatch = new RegExp(`\\b${opName}\\s*:\\s*build\\.mutation`).exec(patched);
+    if (!opMatch) {
       unmatched.push(`${opName} (operation not found)`);
       continue;
     }
+    const opStart = opMatch.index;
     const searchWindow = patched.slice(opStart, opStart + 2000);
     const tagsMatch = /invalidatesTags:\s*\[([^\]]*)\]/.exec(searchWindow);
     if (!tagsMatch) {
       unmatched.push(`${opName} (no invalidatesTags array within range)`);
       continue;
     }
-    if (tagsMatch[1].includes(extraTag)) {
+    const existingTags = tagsMatch[1].trim();
+    // Compare per tag (quotes stripped) so a tag whose name merely *contains*
+    // `extraTag` as a substring can't yield a false "already present".
+    const currentTags = existingTags
+      .split(",")
+      .map((t) => t.trim().replace(/^['"]|['"]$/g, ""))
+      .filter(Boolean);
+    if (currentTags.includes(extraTag)) {
       continue;
     }
-    const existingTags = tagsMatch[1].trim();
+    // Match the file's quote style so the injected tag stays consistent with
+    // whatever the codegen/formatter emits.
+    const quote = existingTags.includes("'") ? "'" : '"';
     const newTagsInner = existingTags.length > 0
-      ? `${existingTags}, "${extraTag}"`
-      : `"${extraTag}"`;
+      ? `${existingTags}, ${quote}${extraTag}${quote}`
+      : `${quote}${extraTag}${quote}`;
     const oldFull = tagsMatch[0];
     const newFull = `invalidatesTags: [${newTagsInner}]`;
     const absoluteIndex = opStart + tagsMatch.index;

--- a/tests/fixtures/cross-construct-invalidation-missing-op.fixture.ts
+++ b/tests/fixtures/cross-construct-invalidation-missing-op.fixture.ts
@@ -1,0 +1,64 @@
+export const injectedRtkApi = {
+  endpoints: (build) => ({
+    getEnvironmentConnections: build.query<
+      GetEnvironmentConnectionsApiResponse,
+      GetEnvironmentConnectionsApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/environments/${queryArg.environmentId}/connections`,
+      }),
+      providesTags: ["Environment_environments"],
+    }),
+    addConnectionToEnvironment: build.mutation<
+      AddConnectionToEnvironmentApiResponse,
+      AddConnectionToEnvironmentApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/environments/${queryArg.environmentId}/connections/${queryArg.connectionId}`,
+        method: "POST",
+      }),
+      invalidatesTags: ["Connection_API_Connections"],
+    }),
+    removeConnectionFromEnvironment: build.mutation<
+      RemoveConnectionFromEnvironmentApiResponse,
+      RemoveConnectionFromEnvironmentApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/environments/${queryArg.environmentId}/connections/${queryArg.connectionId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Connection_API_Connections"],
+    }),
+    deleteConnection: build.mutation<DeleteConnectionApiResponse, DeleteConnectionApiArg>({
+      query: (queryArg) => ({
+        url: `/api/integrations/connections/${queryArg.connectionId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Connection_API_Connections"],
+    }),
+    // Simulates an upstream operationId rename: `deleteMesheryConnection` is
+    // the fourth target addCrossConstructInvalidation looks for, and it must
+    // not be present anywhere in this fixture.
+    removeMesheryServerConnection: build.mutation<
+      RemoveMesheryServerConnectionApiResponse,
+      RemoveMesheryServerConnectionApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/integrations/connections/meshery/${queryArg.mesheryServerId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Connection_API_Connections"],
+    }),
+  }),
+};
+
+export type GetEnvironmentConnectionsApiResponse = unknown;
+export type GetEnvironmentConnectionsApiArg = { environmentId: string };
+export type AddConnectionToEnvironmentApiResponse = unknown;
+export type AddConnectionToEnvironmentApiArg = { environmentId: string; connectionId: string };
+export type RemoveConnectionFromEnvironmentApiResponse = unknown;
+export type RemoveConnectionFromEnvironmentApiArg = { environmentId: string; connectionId: string };
+export type DeleteConnectionApiResponse = unknown;
+export type DeleteConnectionApiArg = { connectionId: string };
+export type RemoveMesheryServerConnectionApiResponse = unknown;
+export type RemoveMesheryServerConnectionApiArg = { mesheryServerId: string };

--- a/tests/fixtures/cross-construct-invalidation-robustness.fixture.ts
+++ b/tests/fixtures/cross-construct-invalidation-robustness.fixture.ts
@@ -1,0 +1,70 @@
+// Robustness fixture for addCrossConstructInvalidation: deliberately varies the
+// formatting the naive string match assumed, to prove the post-processing is
+// resilient to it.
+//   - addConnectionToEnvironment: extra spaces around the `:` after the op name
+//   - removeConnectionFromEnvironment: single-quoted tags (quote-style detection)
+//   - deleteConnection: an existing tag that CONTAINS "Environment_environments"
+//       as a substring but is not it (precise per-tag membership must not
+//       false-positive and skip the injection)
+//   - deleteMesheryConnection: ordinary formatting
+export const injectedRtkApi = {
+  endpoints: (build) => ({
+    getEnvironmentConnections: build.query<
+      GetEnvironmentConnectionsApiResponse,
+      GetEnvironmentConnectionsApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/environments/${queryArg.environmentId}/connections`,
+      }),
+      providesTags: ["Environment_environments"],
+    }),
+    addConnectionToEnvironment   :   build.mutation<
+      AddConnectionToEnvironmentApiResponse,
+      AddConnectionToEnvironmentApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/environments/${queryArg.environmentId}/connections/${queryArg.connectionId}`,
+        method: "POST",
+      }),
+      invalidatesTags: ["Connection_API_Connections"],
+    }),
+    removeConnectionFromEnvironment: build.mutation<
+      RemoveConnectionFromEnvironmentApiResponse,
+      RemoveConnectionFromEnvironmentApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/environments/${queryArg.environmentId}/connections/${queryArg.connectionId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ['Connection_API_Connections'],
+    }),
+    deleteConnection: build.mutation<DeleteConnectionApiResponse, DeleteConnectionApiArg>({
+      query: (queryArg) => ({
+        url: `/api/integrations/connections/${queryArg.connectionId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Connection_API_Connections", "Environment_environmentsLegacy"],
+    }),
+    deleteMesheryConnection: build.mutation<
+      DeleteMesheryConnectionApiResponse,
+      DeleteMesheryConnectionApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/integrations/connections/meshery/${queryArg.mesheryServerId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Connection_API_Connections"],
+    }),
+  }),
+};
+
+export type GetEnvironmentConnectionsApiResponse = unknown;
+export type GetEnvironmentConnectionsApiArg = { environmentId: string };
+export type AddConnectionToEnvironmentApiResponse = unknown;
+export type AddConnectionToEnvironmentApiArg = { environmentId: string; connectionId: string };
+export type RemoveConnectionFromEnvironmentApiResponse = unknown;
+export type RemoveConnectionFromEnvironmentApiArg = { environmentId: string; connectionId: string };
+export type DeleteConnectionApiResponse = unknown;
+export type DeleteConnectionApiArg = { connectionId: string };
+export type DeleteMesheryConnectionApiResponse = unknown;
+export type DeleteMesheryConnectionApiArg = { mesheryServerId: string };

--- a/tests/fixtures/cross-construct-invalidation.fixture.ts
+++ b/tests/fixtures/cross-construct-invalidation.fixture.ts
@@ -1,0 +1,74 @@
+export const injectedRtkApi = {
+  endpoints: (build) => ({
+    getEnvironmentConnections: build.query<
+      GetEnvironmentConnectionsApiResponse,
+      GetEnvironmentConnectionsApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/environments/${queryArg.environmentId}/connections`,
+      }),
+      providesTags: ["Environment_environments"],
+    }),
+    addConnectionToEnvironment: build.mutation<
+      AddConnectionToEnvironmentApiResponse,
+      AddConnectionToEnvironmentApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/environments/${queryArg.environmentId}/connections/${queryArg.connectionId}`,
+        method: "POST",
+      }),
+      invalidatesTags: ["Connection_API_Connections"],
+    }),
+    removeConnectionFromEnvironment: build.mutation<
+      RemoveConnectionFromEnvironmentApiResponse,
+      RemoveConnectionFromEnvironmentApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/environments/${queryArg.environmentId}/connections/${queryArg.connectionId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Connection_API_Connections"],
+    }),
+    deleteConnection: build.mutation<DeleteConnectionApiResponse, DeleteConnectionApiArg>({
+      query: (queryArg) => ({
+        url: `/api/integrations/connections/${queryArg.connectionId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Connection_API_Connections"],
+    }),
+    performConnectionAction: build.mutation<
+      PerformConnectionActionApiResponse,
+      PerformConnectionActionApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/integrations/connections/${queryArg.connectionId}/actions`,
+        method: "POST",
+        body: queryArg.body,
+      }),
+      invalidatesTags: ["Connection_API_Connections"],
+    }),
+    deleteMesheryConnection: build.mutation<
+      DeleteMesheryConnectionApiResponse,
+      DeleteMesheryConnectionApiArg
+    >({
+      query: (queryArg) => ({
+        url: `/api/integrations/connections/meshery/${queryArg.mesheryServerId}`,
+        method: "DELETE",
+      }),
+      invalidatesTags: ["Connection_API_Connections"],
+    }),
+  }),
+};
+
+export type GetEnvironmentConnectionsApiResponse = unknown;
+export type GetEnvironmentConnectionsApiArg = { environmentId: string };
+export type AddConnectionToEnvironmentApiResponse = unknown;
+export type AddConnectionToEnvironmentApiArg = { environmentId: string; connectionId: string };
+export type RemoveConnectionFromEnvironmentApiResponse = unknown;
+export type RemoveConnectionFromEnvironmentApiArg = { environmentId: string; connectionId: string };
+export type DeleteConnectionApiResponse = unknown;
+export type DeleteConnectionApiArg = { connectionId: string };
+export type PerformConnectionActionApiResponse = unknown;
+export type PerformConnectionActionApiArg = { connectionId: string; body: unknown };
+export type DeleteMesheryConnectionApiResponse = unknown;
+export type DeleteMesheryConnectionApiArg = { mesheryServerId: string };

--- a/tests/generate-rtk.test.js
+++ b/tests/generate-rtk.test.js
@@ -124,6 +124,20 @@ test("addCrossConstructInvalidation is robust to spacing, quote style, and subst
   });
 });
 
+test("post-processors fail loud when the generated output file is missing", () => {
+  // After a successful codegen the output file must exist; a missing file means
+  // the codegen output path drifted, so skipping silently must not be allowed.
+  const missing = path.join(os.tmpdir(), `rtk-missing-${Date.now()}`, "generated.ts");
+  assert.throws(
+    () => addCrossConstructInvalidation(missing),
+    /expected generated file not found/,
+  );
+  assert.throws(
+    () => guardOptionalQueryParams(missing),
+    /expected generated file not found/,
+  );
+});
+
 test("addCrossConstructInvalidation fails loudly when a target operation cannot be located", () => {
   withFixtureCopy("cross-construct-invalidation-missing-op.fixture.ts", (workingPath) => {
     assert.throws(

--- a/tests/generate-rtk.test.js
+++ b/tests/generate-rtk.test.js
@@ -94,6 +94,36 @@ test("addCrossConstructInvalidation is idempotent on a second run", () => {
   });
 });
 
+test("addCrossConstructInvalidation is robust to spacing, quote style, and substring tag names", () => {
+  withFixtureCopy("cross-construct-invalidation-robustness.fixture.ts", (workingPath) => {
+    const patchedCount = addCrossConstructInvalidation(workingPath);
+    const output = fs.readFileSync(workingPath, "utf8");
+
+    // All four targets patched despite the formatting variations.
+    assert.equal(patchedCount, 4);
+    // Extra spaces around the `:` after the op name must not defeat matching.
+    assert.match(
+      output,
+      /addConnectionToEnvironment[\s\S]*?invalidatesTags: \["Connection_API_Connections", "Environment_environments"\]/,
+    );
+    // Single-quoted tags: the injected tag matches the file's quote style.
+    assert.match(
+      output,
+      /removeConnectionFromEnvironment:[\s\S]*?invalidatesTags: \['Connection_API_Connections', 'Environment_environments'\]/,
+    );
+    // A tag that merely CONTAINS the target as a substring must not be treated
+    // as already-present; the exact tag is still injected.
+    assert.match(
+      output,
+      /deleteConnection:[\s\S]*?invalidatesTags: \["Connection_API_Connections", "Environment_environmentsLegacy", "Environment_environments"\]/,
+    );
+    assert.match(
+      output,
+      /deleteMesheryConnection:[\s\S]*?invalidatesTags: \["Connection_API_Connections", "Environment_environments"\]/,
+    );
+  });
+});
+
 test("addCrossConstructInvalidation fails loudly when a target operation cannot be located", () => {
   withFixtureCopy("cross-construct-invalidation-missing-op.fixture.ts", (workingPath) => {
     assert.throws(

--- a/tests/generate-rtk.test.js
+++ b/tests/generate-rtk.test.js
@@ -5,6 +5,7 @@ const os = require("node:os");
 const path = require("node:path");
 
 const {
+  addCrossConstructInvalidation,
   findUnguardedQueryParamAccesses,
   guardOptionalQueryParams,
 } = require("../build/generate-rtk");
@@ -43,6 +44,61 @@ test("guardOptionalQueryParams fails loudly when a params block still contains a
     assert.throws(
       () => guardOptionalQueryParams(workingPath),
       /unguarded queryArg access\(es\) remain/,
+    );
+  });
+});
+
+test("addCrossConstructInvalidation adds Environment_environments to all cross-construct connection operations", () => {
+  withFixtureCopy("cross-construct-invalidation.fixture.ts", (workingPath) => {
+    const patchedCount = addCrossConstructInvalidation(workingPath);
+    const output = fs.readFileSync(workingPath, "utf8");
+
+    assert.equal(patchedCount, 4);
+    assert.match(
+      output,
+      /addConnectionToEnvironment:[\s\S]*?invalidatesTags: \["Connection_API_Connections", "Environment_environments"\]/,
+    );
+    assert.match(
+      output,
+      /removeConnectionFromEnvironment:[\s\S]*?invalidatesTags: \["Connection_API_Connections", "Environment_environments"\]/,
+    );
+    assert.match(
+      output,
+      /deleteConnection:[\s\S]*?invalidatesTags: \["Connection_API_Connections", "Environment_environments"\]/,
+    );
+    assert.match(
+      output,
+      /deleteMesheryConnection:[\s\S]*?invalidatesTags: \["Connection_API_Connections", "Environment_environments"\]/,
+    );
+    // performConnectionAction is not a cross-construct target and must be untouched.
+    assert.match(
+      output,
+      /performConnectionAction:[\s\S]*?invalidatesTags: \["Connection_API_Connections"\]/,
+    );
+  });
+});
+
+test("addCrossConstructInvalidation is idempotent on a second run", () => {
+  withFixtureCopy("cross-construct-invalidation.fixture.ts", (workingPath) => {
+    const firstRun = addCrossConstructInvalidation(workingPath);
+    const secondRun = addCrossConstructInvalidation(workingPath);
+    const output = fs.readFileSync(workingPath, "utf8");
+
+    assert.equal(firstRun, 4);
+    assert.equal(secondRun, 0);
+    // 1 pre-existing occurrence (getEnvironmentConnections' own providesTags)
+    // + 4 injected into the target mutations' invalidatesTags. A second run
+    // must not add any more.
+    const tagOccurrences = output.match(/"Environment_environments"/g) || [];
+    assert.equal(tagOccurrences.length, 5);
+  });
+});
+
+test("addCrossConstructInvalidation fails loudly when a target operation cannot be located", () => {
+  withFixtureCopy("cross-construct-invalidation-missing-op.fixture.ts", (workingPath) => {
+    assert.throws(
+      () => addCrossConstructInvalidation(workingPath),
+      /cross-construct invalidation target\(s\) could not be located.*deleteMesheryConnection/,
     );
   });
 });

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -790,14 +790,14 @@ const injectedRtkApi = api
       }),
       deleteConnection: build.mutation<DeleteConnectionApiResponse, DeleteConnectionApiArg>({
         query: (queryArg) => ({ url: `/api/integrations/connections/${queryArg.connectionId}`, method: "DELETE" }),
-        invalidatesTags: ["Connection_API_Connections"],
+        invalidatesTags: ["Connection_API_Connections", "Environment_environments"],
       }),
       deleteMesheryConnection: build.mutation<DeleteMesheryConnectionApiResponse, DeleteMesheryConnectionApiArg>({
         query: (queryArg) => ({
           url: `/api/integrations/connections/meshery/${queryArg.mesheryServerId}`,
           method: "DELETE",
         }),
-        invalidatesTags: ["Connection_API_Connections"],
+        invalidatesTags: ["Connection_API_Connections", "Environment_environments"],
       }),
       getKubernetesContext: build.query<GetKubernetesContextApiResponse, GetKubernetesContextApiArg>({
         query: (queryArg) => ({ url: `/api/integrations/connections/kubernetes/${queryArg.connectionId}/context` }),
@@ -811,7 +811,7 @@ const injectedRtkApi = api
           url: `/api/environments/${queryArg.environmentId}/connections/${queryArg.connectionId}`,
           method: "POST",
         }),
-        invalidatesTags: ["Connection_API_Connections"],
+        invalidatesTags: ["Connection_API_Connections", "Environment_environments"],
       }),
       removeConnectionFromEnvironment: build.mutation<
         RemoveConnectionFromEnvironmentApiResponse,
@@ -821,7 +821,7 @@ const injectedRtkApi = api
           url: `/api/environments/${queryArg.environmentId}/connections/${queryArg.connectionId}`,
           method: "DELETE",
         }),
-        invalidatesTags: ["Connection_API_Connections"],
+        invalidatesTags: ["Connection_API_Connections", "Environment_environments"],
       }),
       listConnectionDefinitions: build.query<ListConnectionDefinitionsApiResponse, ListConnectionDefinitionsApiArg>({
         query: (queryArg) => ({

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -358,7 +358,7 @@ const injectedRtkApi = api
           url: `/api/environments/${queryArg.environmentId}/connections/${queryArg.connectionId}`,
           method: "POST",
         }),
-        invalidatesTags: ["Connection_API_Connections"],
+        invalidatesTags: ["Connection_API_Connections", "Environment_environments"],
       }),
       removeConnectionFromEnvironment: build.mutation<
         RemoveConnectionFromEnvironmentApiResponse,
@@ -368,7 +368,7 @@ const injectedRtkApi = api
           url: `/api/environments/${queryArg.environmentId}/connections/${queryArg.connectionId}`,
           method: "DELETE",
         }),
-        invalidatesTags: ["Connection_API_Connections"],
+        invalidatesTags: ["Connection_API_Connections", "Environment_environments"],
       }),
       listConnectionDefinitions: build.query<ListConnectionDefinitionsApiResponse, ListConnectionDefinitionsApiArg>({
         query: (queryArg) => ({

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -329,7 +329,7 @@ const injectedRtkApi = api
       }),
       deleteConnection: build.mutation<DeleteConnectionApiResponse, DeleteConnectionApiArg>({
         query: (queryArg) => ({ url: `/api/integrations/connections/${queryArg.connectionId}`, method: "DELETE" }),
-        invalidatesTags: ["Connection_API_Connections"],
+        invalidatesTags: ["Connection_API_Connections", "Environment_environments"],
       }),
       performConnectionAction: build.mutation<PerformConnectionActionApiResponse, PerformConnectionActionApiArg>({
         query: (queryArg) => ({
@@ -344,7 +344,7 @@ const injectedRtkApi = api
           url: `/api/integrations/connections/meshery/${queryArg.mesheryServerId}`,
           method: "DELETE",
         }),
-        invalidatesTags: ["Connection_API_Connections"],
+        invalidatesTags: ["Connection_API_Connections", "Environment_environments"],
       }),
       getKubernetesContext: build.query<GetKubernetesContextApiResponse, GetKubernetesContextApiArg>({
         query: (queryArg) => ({ url: `/api/integrations/connections/kubernetes/${queryArg.connectionId}/context` }),


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1044.

### Problem

The Environment card's "Assigned Connections" count uses `getEnvironmentConnections` (tagged `Environment_environments`), but the connection mutations only invalidated `Connection_API_Connections` — so the card kept showing a stale count after connections were assigned/removed/deleted. Root cause: these operations live in the `connection` construct, and `bundle-openapi.js`'s `prefixTags()` namespaces tags under `Connection_API_*`; there's no OpenAPI-level way for a connection endpoint to invalidate an environment-namespaced tag across construct files.

### Fix

Post-process the generated RTK clients (after codegen) to inject the missing `Environment_environments` tag into `invalidatesTags` for the affected operations — following the same pattern as the existing `guardOptionalQueryParams` step.

This PR lands the base fix and extends it:

- **Operations:** `addConnectionToEnvironment`, `removeConnectionFromEnvironment`, **and** `deleteConnection` / `deleteMesheryConnection`. A Connection embeds its own `environments` membership (see `connection.yaml`), so deleting a connection changes that data too — not just assign/remove.
- **Both clients:** runs against `typescript/rtk/meshery.ts` **and** `typescript/rtk/cloud.ts` (both define these operations identically).
- **Fail-loud:** if a target operation can't be located/patched, the post-processing now **throws** instead of logging a warning and silently shipping a client missing the fix — mirroring `guardOptionalQueryParams`'s contract, so `make build`/CI can't stay green while this stale-cache bug quietly regresses (e.g. if upstream codegen renames an operation).
- **Tests:** unit coverage for the injection and the fail-loud path, with fixtures.

### Notes

- Includes @Faisal77666's base commit (authorship preserved); extended here for the delete operations, the cloud client, the fail-loud contract, and test coverage.
- Generated `typescript/rtk/*.ts` regenerated from the branch's schemas; the only client diff is the injected tag.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
