### PR TITLE
docs(consumer-audit): clarify report metric labels and legend

### DIFF
--- a/.github/workflows/schema-audit.yml
+++ b/.github/workflows/schema-audit.yml
@@ -231,8 +231,6 @@ jobs:
             const lines = [];
             lines.push('## Consumer audit report');
             lines.push('');
-            lines.push('Coverage of OpenAPI operations (`schemas`) vs registered handlers in each consumer.');
-            lines.push('');
             lines.push('| Metric | schemas | meshery | cloud |');
             lines.push('|---|---|---|---|');
             lines.push(`| Total endpoints | ${totals[0]} | ${totals[1]} | ${totals[2]} |`);
@@ -242,21 +240,9 @@ jobs:
             lines.push(`| Spec without consumer handler | ${missingHandler[0]} | ${missingHandler[1]} | ${missingHandler[2]} |`);
             lines.push(`| Handler only (no spec) | ${handlerOnly[0]} | ${handlerOnly[1]} | ${handlerOnly[2]} |`);
             lines.push('');
-            lines.push('<details>');
-            lines.push('<summary>What each metric means</summary>');
-            lines.push('');
-            lines.push('| Metric | Meaning |');
-            lines.push('|---|---|');
-            lines.push('| **Total endpoints** | Endpoints discovered in that source (OpenAPI ops / registered routes). |');
-            lines.push('| **Spec applies to consumer** | Schema operations whose `x-internal` targets this consumer (eligible there). Not "how many handlers already match a schema." |');
-            lines.push('| **Spec passes validation** | Schema-defined endpoints whose construct has no blocking schema-audit violations. |');
-            lines.push('| **Spec only (no handlers)** | In schemas, but no matching handler in **any** audited consumer. |');
-            lines.push('| **Spec without consumer handler** | Spec targets this consumer, but **that** consumer has no matching route yet (may still exist elsewhere). |');
-            lines.push('| **Handler only (no spec)** | Route registered in the consumer with no matching schema operation. |');
-            lines.push('');
-            lines.push('A `-` means the metric does not apply to that column. Full per-endpoint detail (including x-internal scope breakdown) is in the artifact.');
-            lines.push('');
-            lines.push('</details>');
+            lines.push('**Note:**');
+            lines.push('Spec only (no handlers) --> no matching handler in any audited consumer.');
+            lines.push('Spec without consumer handler --> this consumer is missing it (may exist elsewhere).');
             lines.push('');
 
             if (totalTs > 0) {

--- a/.github/workflows/schema-audit.yml
+++ b/.github/workflows/schema-audit.yml
@@ -173,14 +173,15 @@ jobs:
 
             // Parse the fixed-format summary block emitted by
             // cmd/consumer-audit/main.go → printAuditReport. Rows look like:
-            //   Category                       Schema  Meshery  Cloud
-            //   Total Endpoints                179     217      282
-            //   Schema Backed                  -       70       178
-            //   Schema Completeness (TRUE)     179     -        -
-            //   Schema Only                    16      -        -
-            //   Unimplemented With Schema      -       29       17
-            //   Consumer Only                  -       172      120
-            // Columns are separated by two-or-more spaces.
+            //   Metric                              Schema  Meshery  Cloud
+            //   Total endpoints                     179     217      282
+            //   Spec applies to consumer            -       70       178
+            //   Spec passes validation              179     -        -
+            //   Spec only (no handlers)             16      -        -
+            //   Spec without consumer handler       -       29       17
+            //   Handler only (no spec)              -       172      120
+            // Columns are separated by two-or-more spaces. Labels must stay
+            // in lockstep with printAuditReport.
             const parseRow = (label) => {
               const escapedLabel = label.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
               const re = new RegExp(`^${escapedLabel}\\s{2,}(\\S+)\\s+(\\S+)\\s+(\\S+)\\s*$`, 'm');
@@ -188,12 +189,12 @@ jobs:
               return m ? [m[1], m[2], m[3]] : ['?', '?', '?'];
             };
 
-            const totals = parseRow('Total Endpoints');
-            const schemaBacked = parseRow('Schema Backed');
-            const schemaCompleteness = parseRow('Schema Completeness (TRUE)');
-            const schemaOnly = parseRow('Schema Only');
-            const unimplemented = parseRow('Unimplemented With Schema');
-            const consumerOnly = parseRow('Consumer Only');
+            const totals = parseRow('Total endpoints');
+            const specApplies = parseRow('Spec applies to consumer');
+            const specValid = parseRow('Spec passes validation');
+            const specOnly = parseRow('Spec only (no handlers)');
+            const missingHandler = parseRow('Spec without consumer handler');
+            const handlerOnly = parseRow('Handler only (no spec)');
 
             // Count TS findings by kind across all repos. The output section
             // is rendered by printTSFindings; per-finding lines look like:
@@ -230,14 +231,32 @@ jobs:
             const lines = [];
             lines.push('## Consumer audit report');
             lines.push('');
-            lines.push('| Category       | schemas | meshery | cloud |');
+            lines.push('Coverage of OpenAPI operations (`schemas`) vs registered handlers in each consumer.');
+            lines.push('');
+            lines.push('| Metric | schemas | meshery | cloud |');
             lines.push('|---|---|---|---|');
-            lines.push(`| Total Endpoints| ${totals[0]}     | ${totals[1]}     | ${totals[2]}   |`);
-            lines.push(`| Schema Backed | ${schemaBacked[0]} | ${schemaBacked[1]} | ${schemaBacked[2]} |`);
-            lines.push(`| Schema Completeness (TRUE) | ${schemaCompleteness[0]} | ${schemaCompleteness[1]} | ${schemaCompleteness[2]} |`);
-            lines.push(`| Schema Only | ${schemaOnly[0]} | ${schemaOnly[1]} | ${schemaOnly[2]} |`);
-            lines.push(`| Unimplemented With Schema | ${unimplemented[0]} | ${unimplemented[1]} | ${unimplemented[2]} |`);
-            lines.push(`| Consumer Only  | ${consumerOnly[0]}       | ${consumerOnly[1]}     | ${consumerOnly[2]}   |`);
+            lines.push(`| Total endpoints | ${totals[0]} | ${totals[1]} | ${totals[2]} |`);
+            lines.push(`| Spec applies to consumer | ${specApplies[0]} | ${specApplies[1]} | ${specApplies[2]} |`);
+            lines.push(`| Spec passes validation | ${specValid[0]} | ${specValid[1]} | ${specValid[2]} |`);
+            lines.push(`| Spec only (no handlers) | ${specOnly[0]} | ${specOnly[1]} | ${specOnly[2]} |`);
+            lines.push(`| Spec without consumer handler | ${missingHandler[0]} | ${missingHandler[1]} | ${missingHandler[2]} |`);
+            lines.push(`| Handler only (no spec) | ${handlerOnly[0]} | ${handlerOnly[1]} | ${handlerOnly[2]} |`);
+            lines.push('');
+            lines.push('<details>');
+            lines.push('<summary>What each metric means</summary>');
+            lines.push('');
+            lines.push('| Metric | Meaning |');
+            lines.push('|---|---|');
+            lines.push('| **Total endpoints** | Endpoints discovered in that source (OpenAPI ops / registered routes). |');
+            lines.push('| **Spec applies to consumer** | Schema operations whose `x-internal` targets this consumer (eligible there). Not "how many handlers already match a schema." |');
+            lines.push('| **Spec passes validation** | Schema-defined endpoints whose construct has no blocking schema-audit violations. |');
+            lines.push('| **Spec only (no handlers)** | In schemas, but no matching handler in **any** audited consumer. |');
+            lines.push('| **Spec without consumer handler** | Spec targets this consumer, but **that** consumer has no matching route yet (may still exist elsewhere). |');
+            lines.push('| **Handler only (no spec)** | Route registered in the consumer with no matching schema operation. |');
+            lines.push('');
+            lines.push('A `-` means the metric does not apply to that column. Full per-endpoint detail (including x-internal scope breakdown) is in the artifact.');
+            lines.push('');
+            lines.push('</details>');
             lines.push('');
 
             if (totalTs > 0) {

--- a/cmd/consumer-audit/main.go
+++ b/cmd/consumer-audit/main.go
@@ -114,10 +114,9 @@ func newTable(out io.Writer, cols ...any) table.Table {
 }
 
 // printAuditReport renders the top-level summary: one row per audit metric.
-// Columns are mutually exclusive sources: Schema (OpenAPI ops in this repo),
-// Meshery (Gorilla routes), Cloud (Echo routes). A "-" means the metric is
-// not applicable to that source. Metric labels are fixed strings also parsed
-// by .github/workflows/schema-audit.yml when posting the PR comment.
+// Columns are Schema (OpenAPI ops), Meshery (Gorilla routes), and Cloud
+// (Echo routes). Metric labels are fixed strings also parsed by
+// .github/workflows/schema-audit.yml when posting the PR comment.
 func printAuditReport(out io.Writer, result *validation.ConsumerAuditResult) {
 	s := result.Summary
 
@@ -132,7 +131,7 @@ func printAuditReport(out io.Writer, result *validation.ConsumerAuditResult) {
 	fmt.Fprintln(out, "Consumer Audit Report")
 	fmt.Fprintln(out)
 
-	// Keep labels stable: the CI comment job matches these exact strings.
+	// Keep metric labels stable: the CI comment job matches these exact strings.
 	t := newTable(out, "Metric", "Schema", "Meshery", "Cloud")
 	t.AddRow("Total endpoints", s.SchemaEndpoints, s.MesheryEndpoints, s.CloudEndpoints)
 	t.AddRow("Spec applies to consumer", "-", s.AnnotatedMeshery+s.AnnotatedBoth, s.AnnotatedCloud+s.AnnotatedBoth)
@@ -148,37 +147,12 @@ func printAuditReport(out io.Writer, result *validation.ConsumerAuditResult) {
 	t.AddRow("Handler only (no spec)", "-", s.ConsumerOnlyMeshery, s.ConsumerOnlyCloud)
 	t.Print()
 
+	// Only the two "missing handler" metrics need disambiguation; the rest
+	// are self-explanatory from the label.
 	fmt.Fprintln(out)
-	printAuditLegend(out)
-}
-
-// printAuditLegend explains each summary metric so the report is readable
-// without tribal knowledge of the consumer-audit pipeline.
-func printAuditLegend(out io.Writer) {
-	fmt.Fprintln(out, "What each metric means")
-	fmt.Fprintln(out, "  Columns: Schema = OpenAPI operations in meshery/schemas;")
-	fmt.Fprintln(out, "           Meshery = routes in meshery/meshery;")
-	fmt.Fprintln(out, "           Cloud = routes in meshery-cloud.")
-	fmt.Fprintln(out, "  \"-\" means the metric does not apply to that column.")
-	fmt.Fprintln(out)
-	fmt.Fprintln(out, "  Total endpoints")
-	fmt.Fprintln(out, "    Count of endpoints discovered in that source.")
-	fmt.Fprintln(out, "  Spec applies to consumer")
-	fmt.Fprintln(out, "    Schema operations whose x-internal targets this consumer")
-	fmt.Fprintln(out, "    (eligible to be implemented there). Not \"how many handlers")
-	fmt.Fprintln(out, "    already match a schema.\"")
-	fmt.Fprintln(out, "  Spec targets Meshery only / Cloud only / both consumers")
-	fmt.Fprintln(out, "    Breakdown of schema ops by x-internal scope (Schema column).")
-	fmt.Fprintln(out, "  Spec passes validation")
-	fmt.Fprintln(out, "    Schema-defined endpoints whose construct has no blocking")
-	fmt.Fprintln(out, "    schema-audit violations (Schema Completeness = TRUE).")
-	fmt.Fprintln(out, "  Spec only (no handlers)")
-	fmt.Fprintln(out, "    In schemas, but no matching handler in any audited consumer.")
-	fmt.Fprintln(out, "  Spec without consumer handler")
-	fmt.Fprintln(out, "    Spec targets this consumer, but that consumer has no route")
-	fmt.Fprintln(out, "    for it yet (per-consumer gap; may still exist elsewhere).")
-	fmt.Fprintln(out, "  Handler only (no spec)")
-	fmt.Fprintln(out, "    Route registered in the consumer with no matching schema op.")
+	fmt.Fprintln(out, "Note:")
+	fmt.Fprintln(out, "Spec only (no handlers) --> no matching handler in any audited consumer.")
+	fmt.Fprintln(out, "Spec without consumer handler --> this consumer is missing it (may exist elsewhere).")
 }
 
 type consumerActionSummary struct {

--- a/cmd/consumer-audit/main.go
+++ b/cmd/consumer-audit/main.go
@@ -113,10 +113,11 @@ func newTable(out io.Writer, cols ...any) table.Table {
 	return t
 }
 
-// printAuditReport renders the top-level summary: one row per audit dimension.
-// The x-annotation breakdown shows how schema-defined endpoints are distributed
-// across consumers. Schema Completeness is schema-wide (same value for all
-// consumers of a given endpoint), so it appears in the Schema column only.
+// printAuditReport renders the top-level summary: one row per audit metric.
+// Columns are mutually exclusive sources: Schema (OpenAPI ops in this repo),
+// Meshery (Gorilla routes), Cloud (Echo routes). A "-" means the metric is
+// not applicable to that source. Metric labels are fixed strings also parsed
+// by .github/workflows/schema-audit.yml when posting the PR comment.
 func printAuditReport(out io.Writer, result *validation.ConsumerAuditResult) {
 	s := result.Summary
 
@@ -128,23 +129,56 @@ func printAuditReport(out io.Writer, result *validation.ConsumerAuditResult) {
 	}
 
 	fmt.Fprintln(out)
-	fmt.Fprintln(out, "Audit Report")
+	fmt.Fprintln(out, "Consumer Audit Report")
 	fmt.Fprintln(out)
 
-	t := newTable(out, "Category", "Schema", "Meshery", "Cloud")
-	t.AddRow("Total Endpoints", s.SchemaEndpoints, s.MesheryEndpoints, s.CloudEndpoints)
-	t.AddRow("Schema Backed", "-", s.AnnotatedMeshery+s.AnnotatedBoth, s.AnnotatedCloud+s.AnnotatedBoth)
-	t.AddRow("x-Annotated (Meshery only)", s.AnnotatedMeshery, "-", "-")
-	t.AddRow("x-Annotated (Cloud only)", s.AnnotatedCloud, "-", "-")
-	t.AddRow("x-Annotated (Both)", s.AnnotatedBoth, "-", "-")
-	t.AddRow("Schema Completeness (TRUE)", s.SchemaCompletenessTrue, "-", "-")
-	t.AddRow("Schema Only", s.SchemaOnly, "-", "-")
-	t.AddRow("Unimplemented With Schema",
+	// Keep labels stable: the CI comment job matches these exact strings.
+	t := newTable(out, "Metric", "Schema", "Meshery", "Cloud")
+	t.AddRow("Total endpoints", s.SchemaEndpoints, s.MesheryEndpoints, s.CloudEndpoints)
+	t.AddRow("Spec applies to consumer", "-", s.AnnotatedMeshery+s.AnnotatedBoth, s.AnnotatedCloud+s.AnnotatedBoth)
+	t.AddRow("Spec targets Meshery only", s.AnnotatedMeshery, "-", "-")
+	t.AddRow("Spec targets Cloud only", s.AnnotatedCloud, "-", "-")
+	t.AddRow("Spec targets both consumers", s.AnnotatedBoth, "-", "-")
+	t.AddRow("Spec passes validation", s.SchemaCompletenessTrue, "-", "-")
+	t.AddRow("Spec only (no handlers)", s.SchemaOnly, "-", "-")
+	t.AddRow("Spec without consumer handler",
 		"-",
 		cell(s.SchemaOnlyMeshery, s.MesheryEndpoints > 0),
 		cell(s.SchemaOnlyCloud, s.CloudEndpoints > 0))
-	t.AddRow("Consumer Only", "-", s.ConsumerOnlyMeshery, s.ConsumerOnlyCloud)
+	t.AddRow("Handler only (no spec)", "-", s.ConsumerOnlyMeshery, s.ConsumerOnlyCloud)
 	t.Print()
+
+	fmt.Fprintln(out)
+	printAuditLegend(out)
+}
+
+// printAuditLegend explains each summary metric so the report is readable
+// without tribal knowledge of the consumer-audit pipeline.
+func printAuditLegend(out io.Writer) {
+	fmt.Fprintln(out, "What each metric means")
+	fmt.Fprintln(out, "  Columns: Schema = OpenAPI operations in meshery/schemas;")
+	fmt.Fprintln(out, "           Meshery = routes in meshery/meshery;")
+	fmt.Fprintln(out, "           Cloud = routes in meshery-cloud.")
+	fmt.Fprintln(out, "  \"-\" means the metric does not apply to that column.")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, "  Total endpoints")
+	fmt.Fprintln(out, "    Count of endpoints discovered in that source.")
+	fmt.Fprintln(out, "  Spec applies to consumer")
+	fmt.Fprintln(out, "    Schema operations whose x-internal targets this consumer")
+	fmt.Fprintln(out, "    (eligible to be implemented there). Not \"how many handlers")
+	fmt.Fprintln(out, "    already match a schema.\"")
+	fmt.Fprintln(out, "  Spec targets Meshery only / Cloud only / both consumers")
+	fmt.Fprintln(out, "    Breakdown of schema ops by x-internal scope (Schema column).")
+	fmt.Fprintln(out, "  Spec passes validation")
+	fmt.Fprintln(out, "    Schema-defined endpoints whose construct has no blocking")
+	fmt.Fprintln(out, "    schema-audit violations (Schema Completeness = TRUE).")
+	fmt.Fprintln(out, "  Spec only (no handlers)")
+	fmt.Fprintln(out, "    In schemas, but no matching handler in any audited consumer.")
+	fmt.Fprintln(out, "  Spec without consumer handler")
+	fmt.Fprintln(out, "    Spec targets this consumer, but that consumer has no route")
+	fmt.Fprintln(out, "    for it yet (per-consumer gap; may still exist elsewhere).")
+	fmt.Fprintln(out, "  Handler only (no spec)")
+	fmt.Fprintln(out, "    Route registered in the consumer with no matching schema op.")
 }
 
 type consumerActionSummary struct {

--- a/docs/schema-tooling.md
+++ b/docs/schema-tooling.md
@@ -75,26 +75,17 @@ On each run the job:
 1. Checks out `meshery/schemas` (the repo under test), then `meshery/meshery`, `layer5io/meshery-cloud`, and `layer5labs/meshery-extensions` under `./_consumer/`. The sibling checkouts use a PAT secret named `CI_CONSUMER_PAT` for private-repo access (`meshery-cloud` and `meshery-extensions` are private). Each sibling checkout has `continue-on-error: true`, so a missing PAT, insufficient scopes, or a temporary GitHub outage simply results in that column being skipped - the job still runs and posts a comment against whatever consumers *are* available. A skipped checkout does not fail the audit itself: the Go tool treats an unset `*_REPO` path as "not provided", not as an error.
 2. Invokes `make consumer-audit MESHERY_REPO=_consumer/meshery CLOUD_REPO=_consumer/meshery-cloud EXTENSIONS_REPO=_consumer/meshery-extensions VERBOSE=1` and pipes the output to both `/tmp/consumer-audit.txt` and the job log via `tee`. A non-zero exit fails the step - and therefore the job.
 3. Uploads the captured output as a build artifact named `consumer-audit-output` (retained for 14 days) so reviewers can download the raw per-endpoint list. This step runs on `if: always()`, so the artifact is available even when the audit step fails.
-4. Posts a summary comment on the PR listing the per-repo metrics pulled from the audit report table (see [summary metrics](#summary-metrics) below), plus a rolled-up count of TypeScript findings by kind (`case-flip`, `snake-case-wrapper`, `snake-case-param`) and the set of repos those findings span. The comment includes a collapsible legend for each metric. The comment step also runs on `if: always()` so reviewers see the divergence summary that explains why CI went red. The comment is keyed by an HTML marker and is upserted across runs so repeat pushes to the same PR update the existing comment rather than spamming new ones. Any sibling repo whose checkout failed is surfaced in a "Skipped consumer checkouts" note under the table so a zero in that column cannot be mistaken for perfect alignment.
+4. Posts a summary comment on the PR listing the per-repo metrics pulled from the audit report table (see [summary metrics](#summary-metrics) below), plus a rolled-up count of TypeScript findings by kind (`case-flip`, `snake-case-wrapper`, `snake-case-param`) and the set of repos those findings span. The comment includes a one-line note distinguishing the two "missing handler" metrics. The comment step also runs on `if: always()` so reviewers see the divergence summary that explains why CI went red. The comment is keyed by an HTML marker and is upserted across runs so repeat pushes to the same PR update the existing comment rather than spamming new ones. Any sibling repo whose checkout failed is surfaced in a "Skipped consumer checkouts" note under the table so a zero in that column cannot be mistaken for perfect alignment.
 
 ### Summary metrics
 
-The CLI (`cmd/consumer-audit`) and the PR comment share the same metric labels. Columns are sources: **Schema** (OpenAPI ops in this repo), **Meshery** (Gorilla routes), **Cloud** (Echo routes). A `-` means the metric does not apply to that column.
+The CLI (`cmd/consumer-audit`) and the PR comment share the same metric labels. Columns are sources: **Schema** (OpenAPI ops in this repo), **Meshery** (Gorilla routes), **Cloud** (Echo routes). Most labels are self-explanatory. The only pair that needs disambiguation:
 
-| Metric | What it counts |
-|---|---|
-| **Total endpoints** | Endpoints discovered in that source. |
-| **Spec applies to consumer** | Schema operations whose `x-internal` targets this consumer (eligible to be implemented there). *Not* "how many consumer handlers already match a schema." |
-| **Spec targets Meshery only / Cloud only / both consumers** | Breakdown of schema ops by `x-internal` scope (Schema column only; CLI full table). |
-| **Spec passes validation** | Schema-defined endpoints whose construct has no blocking schema-audit violations (formerly labeled "Schema Completeness (TRUE)"). |
-| **Spec only (no handlers)** | In schemas, but no matching handler in **any** audited consumer. |
-| **Spec without consumer handler** | Spec targets this consumer, but **that** consumer has no matching route yet (may still be implemented elsewhere). Formerly "Unimplemented With Schema." |
-| **Handler only (no spec)** | Route registered in the consumer with no matching schema operation. Formerly "Consumer Only." |
-
-These two gap rows are easy to mix up:
-
-- **Spec only (no handlers)** = global gap (nobody implements it).
-- **Spec without consumer handler** = per-consumer gap (this consumer is missing it).
+```
+Note:
+Spec only (no handlers) --> no matching handler in any audited consumer.
+Spec without consumer handler --> this consumer is missing it (may exist elsewhere).
+```
 
 ### Provisioning `CI_CONSUMER_PAT`
 

--- a/docs/schema-tooling.md
+++ b/docs/schema-tooling.md
@@ -75,7 +75,26 @@ On each run the job:
 1. Checks out `meshery/schemas` (the repo under test), then `meshery/meshery`, `layer5io/meshery-cloud`, and `layer5labs/meshery-extensions` under `./_consumer/`. The sibling checkouts use a PAT secret named `CI_CONSUMER_PAT` for private-repo access (`meshery-cloud` and `meshery-extensions` are private). Each sibling checkout has `continue-on-error: true`, so a missing PAT, insufficient scopes, or a temporary GitHub outage simply results in that column being skipped - the job still runs and posts a comment against whatever consumers *are* available. A skipped checkout does not fail the audit itself: the Go tool treats an unset `*_REPO` path as "not provided", not as an error.
 2. Invokes `make consumer-audit MESHERY_REPO=_consumer/meshery CLOUD_REPO=_consumer/meshery-cloud EXTENSIONS_REPO=_consumer/meshery-extensions VERBOSE=1` and pipes the output to both `/tmp/consumer-audit.txt` and the job log via `tee`. A non-zero exit fails the step - and therefore the job.
 3. Uploads the captured output as a build artifact named `consumer-audit-output` (retained for 14 days) so reviewers can download the raw per-endpoint list. This step runs on `if: always()`, so the artifact is available even when the audit step fails.
-4. Posts a summary comment on the PR listing the per-repo totals (`Total Endpoints`, `Schema Backed`, `Consumer Only`) pulled from the audit report table, plus a rolled-up count of TypeScript findings by kind (`case-flip`, `snake-case-wrapper`, `snake-case-param`) and the set of repos those findings span. The comment step also runs on `if: always()` so reviewers see the divergence summary that explains why CI went red. The comment is keyed by an HTML marker and is upserted across runs so repeat pushes to the same PR update the existing comment rather than spamming new ones. Any sibling repo whose checkout failed is surfaced in a "Skipped consumer checkouts" note under the table so a zero in that column cannot be mistaken for perfect alignment.
+4. Posts a summary comment on the PR listing the per-repo metrics pulled from the audit report table (see [summary metrics](#summary-metrics) below), plus a rolled-up count of TypeScript findings by kind (`case-flip`, `snake-case-wrapper`, `snake-case-param`) and the set of repos those findings span. The comment includes a collapsible legend for each metric. The comment step also runs on `if: always()` so reviewers see the divergence summary that explains why CI went red. The comment is keyed by an HTML marker and is upserted across runs so repeat pushes to the same PR update the existing comment rather than spamming new ones. Any sibling repo whose checkout failed is surfaced in a "Skipped consumer checkouts" note under the table so a zero in that column cannot be mistaken for perfect alignment.
+
+### Summary metrics
+
+The CLI (`cmd/consumer-audit`) and the PR comment share the same metric labels. Columns are sources: **Schema** (OpenAPI ops in this repo), **Meshery** (Gorilla routes), **Cloud** (Echo routes). A `-` means the metric does not apply to that column.
+
+| Metric | What it counts |
+|---|---|
+| **Total endpoints** | Endpoints discovered in that source. |
+| **Spec applies to consumer** | Schema operations whose `x-internal` targets this consumer (eligible to be implemented there). *Not* "how many consumer handlers already match a schema." |
+| **Spec targets Meshery only / Cloud only / both consumers** | Breakdown of schema ops by `x-internal` scope (Schema column only; CLI full table). |
+| **Spec passes validation** | Schema-defined endpoints whose construct has no blocking schema-audit violations (formerly labeled "Schema Completeness (TRUE)"). |
+| **Spec only (no handlers)** | In schemas, but no matching handler in **any** audited consumer. |
+| **Spec without consumer handler** | Spec targets this consumer, but **that** consumer has no matching route yet (may still be implemented elsewhere). Formerly "Unimplemented With Schema." |
+| **Handler only (no spec)** | Route registered in the consumer with no matching schema operation. Formerly "Consumer Only." |
+
+These two gap rows are easy to mix up:
+
+- **Spec only (no handlers)** = global gap (nobody implements it).
+- **Spec without consumer handler** = per-consumer gap (this consumer is missing it).
 
 ### Provisioning `CI_CONSUMER_PAT`
 


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1055

```
Consumer Audit Report

Metric                         Schema  Meshery  Cloud
Total endpoints                210     243      294
Spec applies to consumer       -       83       196
Spec targets Meshery only      14      -        -
Spec targets Cloud only        127     -        -
Spec targets both consumers    69      -        -
Spec passes validation         210     -        -
Spec only (no handlers)        18      -        -
Spec without consumer handler  -       18       25
Handler only (no spec)         -       174      122

Note:
Spec only (no handlers) --> no matching handler in any audited consumer.
Spec without consumer handler --> this consumer is missing it (may exist elsewhere).
```

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->
