### PR TITLE
Integer pagination params; org domain in listings; two response shapes matched to server

### DIFF
--- a/schemas/constructs/v1beta2/core/api.yml
+++ b/schemas/constructs/v1beta2/core/api.yml
@@ -974,7 +974,9 @@ components:
       in: query
       description: Get responses by pagesize (pass all to get all responses)
       schema:
-        type: integer
+        # Stays string: the contract admits the literal "all" sentinel,
+        # which the server middleware expands to an uncapped page.
+        type: string
     pageSize:
       name: pageSize
       in: query

--- a/schemas/constructs/v1beta2/core/api.yml
+++ b/schemas/constructs/v1beta2/core/api.yml
@@ -944,7 +944,7 @@ components:
       in: query
       description: Get responses by page
       schema:
-        type: string
+        type: integer
     userId:
       name: userId
       in: query
@@ -968,13 +968,13 @@ components:
       in: query
       description: Get responses by pagesize
       schema:
-        type: string
+        type: integer
     pagesizeWithAll:
       name: pagesize
       in: query
       description: Get responses by pagesize (pass all to get all responses)
       schema:
-        type: string
+        type: integer
     pageSize:
       name: pageSize
       in: query

--- a/schemas/constructs/v1beta2/credential/api.yml
+++ b/schemas/constructs/v1beta2/credential/api.yml
@@ -192,7 +192,7 @@ components:
       description: Get responses by pagesize. Deprecated alias of pageSize.
       deprecated: true
       schema:
-        type: string
+        type: integer
     search:
       $ref: "../../v1alpha1/core/api.yml#/components/parameters/search"
     order:

--- a/schemas/constructs/v1beta2/key/api.yml
+++ b/schemas/constructs/v1beta2/key/api.yml
@@ -179,7 +179,7 @@ components:
       description: Get responses by pagesize. Deprecated alias of pageSize.
       deprecated: true
       schema:
-        type: string
+        type: integer
     order:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/order
     search:

--- a/schemas/constructs/v1beta2/keychain/api.yml
+++ b/schemas/constructs/v1beta2/keychain/api.yml
@@ -252,7 +252,7 @@ components:
       description: Get responses by pagesize. Deprecated alias of pageSize.
       deprecated: true
       schema:
-        type: string
+        type: integer
     order:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/order
     search:

--- a/schemas/constructs/v1beta2/organization/api.yml
+++ b/schemas/constructs/v1beta2/organization/api.yml
@@ -632,6 +632,9 @@ components:
         region:
           $ref: "#/components/schemas/Text"
           description: Region of the organization.
+        domain:
+          $ref: "#/components/schemas/Text"
+          description: Custom domain assigned to the organization, when configured.
         owner:
           $ref: "#/components/schemas/Text"
           description: Display name of the organization owner.

--- a/schemas/constructs/v1beta2/role/api.yml
+++ b/schemas/constructs/v1beta2/role/api.yml
@@ -295,7 +295,7 @@ components:
       in: query
       description: Get responses by page size
       schema:
-        type: string
+        type: integer
     search:
       $ref: "../../v1alpha1/core/api.yml#/components/parameters/search"
     order:

--- a/schemas/constructs/v1beta2/schedule/api.yml
+++ b/schemas/constructs/v1beta2/schedule/api.yml
@@ -151,7 +151,7 @@ components:
       in: query
       description: Get responses by page size
       schema:
-        type: string
+        type: integer
     search:
       $ref: "../../v1alpha1/core/api.yml#/components/parameters/search"
     order:

--- a/schemas/constructs/v1beta2/team/api.yml
+++ b/schemas/constructs/v1beta2/team/api.yml
@@ -74,7 +74,7 @@ components:
       description: Get responses by pagesize. Deprecated alias of pageSize.
       deprecated: true
       schema:
-        type: string
+        type: integer
 
   securitySchemes:
     jwt:
@@ -424,11 +424,15 @@ paths:
         - $ref: "#/components/parameters/pagesize"
       responses:
         "200":
-          description: Team users mapping
+          description: Team members with their roles
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/UsersTeamsMappingPage"
+                # The deployed handler (GetUsersOfTeam) serves the
+                # TeamMembersPage projection - user rows with role names
+                # under `data` - not raw users-teams mappings
+                # (schema/handler parity).
+                $ref: "#/components/schemas/TeamMembersPage"
         "400":
           $ref: "#/components/responses/400"
         "401":

--- a/schemas/constructs/v1beta2/user/api.yml
+++ b/schemas/constructs/v1beta2/user/api.yml
@@ -441,13 +441,13 @@ components:
       in: query
       description: Get responses by page
       schema:
-        type: string
+        type: integer
     pageSize:
       name: pageSize
       in: query
       description: Get responses by page size
       schema:
-        type: string
+        type: integer
     search:
       $ref: "../core/api.yml#/components/parameters/search"
     order:

--- a/schemas/constructs/v1beta2/view/api.yml
+++ b/schemas/constructs/v1beta2/view/api.yml
@@ -60,7 +60,7 @@ components:
       description: Get responses by pagesize. Deprecated alias of pageSize.
       deprecated: true
       schema:
-        type: string
+        type: integer
     orgIdQuery:
       name: orgId
       in: query

--- a/schemas/constructs/v1beta3/academy/api.yml
+++ b/schemas/constructs/v1beta3/academy/api.yml
@@ -612,7 +612,9 @@ paths:
           content:
             application/json:
               schema:
-                type: object
+                # Mirrors the deployed handler's InstructorConsoleSummary
+                # (meshery-cloud handlers/academy/instructor-console.go).
+                $ref: '#/components/schemas/InstructorConsoleSummary'
         '400':
           description: Invalid request parameters
         '401':
@@ -967,6 +969,81 @@ components:
       required:
       - total
       - data
+    InstructorConsoleSummary:
+      type: object
+      description: >
+        Aggregate metrics for the instructor console, mirroring the deployed
+        handler's InstructorConsoleSummary struct.
+      properties:
+        orgConfig:
+          type: object
+          description: Academy module configuration for the organization.
+          properties:
+            module:
+              type: string
+              description: Academy module assigned to the organization.
+            version:
+              type: string
+              description: Version of the assigned academy module.
+        totalLearners:
+          type: integer
+          description: Total distinct learners registered for the organization.
+        totalActiveLearners:
+          type: integer
+          description: Learners with at least one active registration.
+        curricula:
+          type: array
+          description: Per-content-type registration counts.
+          items:
+            type: object
+            properties:
+              type:
+                type: string
+                description: Academy content type.
+              totalCount:
+                type: integer
+                description: Registrations for this content type.
+        registrationsSummary:
+          type: array
+          description: Per-status registration counts.
+          items:
+            type: object
+            properties:
+              status:
+                type: string
+                description: Registration status.
+              totalCount:
+                type: integer
+                description: Registrations in this status.
+        testsSummary:
+          type: object
+          description: Aggregate test outcomes across the organization.
+          properties:
+            totalPassed:
+              type: integer
+            totalFailed:
+              type: integer
+            totalAttempts:
+              type: integer
+        tests:
+          type: array
+          description: Per-test outcome counts.
+          items:
+            type: object
+            properties:
+              test:
+                $ref: '#/components/schemas/Quiz'
+                description: The test the counts refer to.
+              passed:
+                type: integer
+              failed:
+                type: integer
+              attempts:
+                type: integer
+        curriculaList:
+          $ref: '#/components/schemas/AcademyCurriculaWithMetricsListResponse'
+          description: Curricula with metrics for the organization.
+
     AcademyCurriculaWithMetricsListResponse:
       type: object
       properties:

--- a/schemas/constructs/v1beta3/environment/api.yml
+++ b/schemas/constructs/v1beta3/environment/api.yml
@@ -55,7 +55,7 @@ components:
       description: Get responses by pagesize. Deprecated alias of pageSize.
       deprecated: true
       schema:
-        type: string
+        type: integer
     orgIdQuery:
       name: orgId
       in: query

--- a/schemas/constructs/v1beta3/event/api.yml
+++ b/schemas/constructs/v1beta3/event/api.yml
@@ -317,7 +317,7 @@ components:
       description: Get responses by pagesize. Deprecated alias of pageSize.
       deprecated: true
       schema:
-        type: string
+        type: integer
     search:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/search
     order:

--- a/schemas/constructs/v1beta3/token/api.yml
+++ b/schemas/constructs/v1beta3/token/api.yml
@@ -204,7 +204,7 @@ components:
       description: Get responses by pagesize. Deprecated alias of pageSize.
       deprecated: true
       schema:
-        type: string
+        type: integer
     search:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/search
     order:

--- a/schemas/constructs/v1beta3/workspace/api.yml
+++ b/schemas/constructs/v1beta3/workspace/api.yml
@@ -550,7 +550,7 @@ components:
       description: Get responses by pagesize. Deprecated alias of pageSize.
       deprecated: true
       schema:
-        type: string
+        type: integer
     filter:
       name: filter
       in: query


### PR DESCRIPTION
## Summary

Four parity/uniformity corrections unblocking the meshery-cloud RTK consumer swap (follow-up to #1056):

1. **Integer pagination params** - every `page`/`pageSize`/`pagesize` query param across v1beta2/v1beta3 cloud constructs is now `type: integer` (was a string/integer mix). Wire-compatible (query strings carry the same digits); generated TS args become numeric, matching every caller. Published v1alpha1/v1beta1 versions untouched.
2. **organization** - `AvailableOrganization` gains `domain` (the entity schema already had it; the listing projection did not). The deployed listing responses carry it; custom-domain org-switch logic reads it.
3. **team** - `getTeamUsers` returns `TeamMembersPage`: the deployed handler (`GetUsersOfTeam`) serves member rows with role names under `data`, not raw users-teams mappings (schema/handler parity).
4. **academy** - `getAcademyAdminSummary` response typed as `InstructorConsoleSummary` (orgConfig, learner totals, curricula/registration summaries, test outcomes) instead of bare `object`, mirroring the deployed handler struct.

## Verification

- `make validate-schemas` - no blocking violations
- `make consumer-audit` - Consumer Only: 0 (both repos)
- Regenerated clients inspected: `GetTeamUsersApiResponse.data`, `AvailableOrganization.domain`, typed academy summary, numeric page args

Generated artifacts intentionally not committed (automation regenerates on master).