### PR TITLE
Live constructs resolve the shared page param from their own version's core

### DIFF
--- a/schemas/constructs/v1beta2/credential/api.yml
+++ b/schemas/constructs/v1beta2/credential/api.yml
@@ -183,7 +183,7 @@ components:
       schema:
         $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
     page:
-      $ref: "../../v1alpha1/core/api.yml#/components/parameters/page"
+      $ref: "../core/api.yml#/components/parameters/page"
     pageSize:
       $ref: "../core/api.yml#/components/parameters/pageSize"
     pagesize:

--- a/schemas/constructs/v1beta2/key/api.yml
+++ b/schemas/constructs/v1beta2/key/api.yml
@@ -170,7 +170,7 @@ components:
       schema:
         $ref: ../../v1alpha1/core/api.yml#/components/schemas/uuid
     page:
-      $ref: ../../v1alpha1/core/api.yml#/components/parameters/page
+      $ref: ../core/api.yml#/components/parameters/page
     pageSize:
       $ref: ../core/api.yml#/components/parameters/pageSize
     pagesize:

--- a/schemas/constructs/v1beta2/keychain/api.yml
+++ b/schemas/constructs/v1beta2/keychain/api.yml
@@ -243,7 +243,7 @@ components:
       schema:
         $ref: ../../v1alpha1/core/api.yml#/components/schemas/uuid
     page:
-      $ref: ../../v1alpha1/core/api.yml#/components/parameters/page
+      $ref: ../core/api.yml#/components/parameters/page
     pageSize:
       $ref: ../core/api.yml#/components/parameters/pageSize
     pagesize:

--- a/schemas/constructs/v1beta2/role/api.yml
+++ b/schemas/constructs/v1beta2/role/api.yml
@@ -289,7 +289,7 @@ components:
       schema:
         $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
     page:
-      $ref: "../../v1alpha1/core/api.yml#/components/parameters/page"
+      $ref: "../core/api.yml#/components/parameters/page"
     pageSize:
       name: pageSize
       in: query

--- a/schemas/constructs/v1beta2/schedule/api.yml
+++ b/schemas/constructs/v1beta2/schedule/api.yml
@@ -145,7 +145,7 @@ components:
       schema:
         $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
     page:
-      $ref: "../../v1alpha1/core/api.yml#/components/parameters/page"
+      $ref: "../core/api.yml#/components/parameters/page"
     pageSize:
       name: pageSize
       in: query

--- a/schemas/constructs/v1beta2/team/api.yml
+++ b/schemas/constructs/v1beta2/team/api.yml
@@ -65,7 +65,7 @@ components:
     order:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/order
     page:
-      $ref: ../../v1alpha1/core/api.yml#/components/parameters/page
+      $ref: ../core/api.yml#/components/parameters/page
     pageSize:
       $ref: ../core/api.yml#/components/parameters/pageSize
     pagesize:

--- a/schemas/constructs/v1beta2/view/api.yml
+++ b/schemas/constructs/v1beta2/view/api.yml
@@ -51,7 +51,7 @@ components:
     order:
       $ref: "../../v1alpha1/core/api.yml#/components/parameters/order"
     page:
-      $ref: "../../v1alpha1/core/api.yml#/components/parameters/page"
+      $ref: "../core/api.yml#/components/parameters/page"
     pageSize:
       $ref: "../core/api.yml#/components/parameters/pageSize"
     pagesize:

--- a/schemas/constructs/v1beta3/environment/api.yml
+++ b/schemas/constructs/v1beta3/environment/api.yml
@@ -46,7 +46,7 @@ components:
     order:
       $ref: ../../v1alpha1/core/api.yml#/components/parameters/order
     page:
-      $ref: ../../v1alpha1/core/api.yml#/components/parameters/page
+      $ref: ../../v1beta2/core/api.yml#/components/parameters/page
     pageSize:
       $ref: ../../v1beta2/core/api.yml#/components/parameters/pageSize
     pagesize:

--- a/schemas/constructs/v1beta3/performance_profile/api.yml
+++ b/schemas/constructs/v1beta3/performance_profile/api.yml
@@ -266,7 +266,7 @@ components:
     order:
       $ref: "../../v1alpha1/core/api.yml#/components/parameters/order"
     page:
-      $ref: "../../v1alpha1/core/api.yml#/components/parameters/page"
+      $ref: "../../v1beta2/core/api.yml#/components/parameters/page"
     pagesize:
       $ref: "../../v1alpha1/core/api.yml#/components/parameters/pagesize"
     from:

--- a/schemas/constructs/v1beta3/workspace/api.yml
+++ b/schemas/constructs/v1beta3/workspace/api.yml
@@ -541,7 +541,7 @@ components:
     order:
       $ref: "../../v1beta1/core/api.yml#/components/parameters/order"
     page:
-      $ref: "../../v1beta1/core/api.yml#/components/parameters/page"
+      $ref: "../../v1beta2/core/api.yml#/components/parameters/page"
     pageSize:
       $ref: "../../v1beta2/core/api.yml#/components/parameters/pageSize"
     pagesize:


### PR DESCRIPTION
Completes #1057: ten v1beta2/v1beta3 constructs still $ref'd the `page` parameter from the published v1alpha1/v1beta1 core files (`type: string`), so their generated args kept `page?: string` while `pageSize` became numeric. Repoints those refs to the same-version core `page` (integer, minimum 0 semantics unchanged on the wire). Published legacy versions untouched.

- `make validate-schemas` clean; regenerated args verified numeric (`GetWorkspacesApiArg`, `GetTeamsApiArg`, `GetTeamUsersApiArg`, `GetUserTokensApiArg`, `GetSchedulesApiArg`, …).
- Generated artifacts not committed (automation regenerates on master).