### PR TITLE
Define /api/system/kubernetes endpoints; add transient reachable flag to K8sContext

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -13,10 +13,11 @@ jobs:
     runs-on: ubuntu-latest   # ubuntu-24.04 is fine too, but latest is usually better
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - name: Label PR based on changed paths
         uses: actions/labeler@v6
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          # Optional: if you put config somewhere else
-          # configuration-path: .github/my-labels.yml
           # sync-labels: true     # remove labels that no longer match (careful!)

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Label PR based on changed paths
         uses: actions/labeler@v6

--- a/schemas/constructs/v1beta1/system/api.yml
+++ b/schemas/constructs/v1beta1/system/api.yml
@@ -148,6 +148,108 @@ paths:
         "500":
           description: Email configuration validation failed or the send attempt errored.
 
+  /api/system/kubernetes:
+    post:
+      x-internal: ["meshery"]
+      tags:
+        - System
+      summary: Import a kubeconfig
+      description: >-
+        Uploads a kubeconfig and registers each discovered context as a
+        Kubernetes connection. Unreachable contexts are still registered as
+        discovered connections; reachability only gates the transition to
+        connected. The optional `contexts` and `selectedContexts` form fields
+        scope and configure the import.
+      operationId: addKubernetesConfig
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/AddKubernetesConfigPayload"
+      responses:
+        "200":
+          description: Discovered contexts bucketed by import outcome.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/AddKubernetesConfigResponse"
+        "400":
+          description: >-
+            Missing or unparsable kubeconfig, or malformed `contexts` /
+            `selectedContexts` JSON.
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          description: Failed to retrieve the user token from the request context.
+
+  /api/system/kubernetes/contexts:
+    post:
+      x-internal: ["meshery"]
+      tags:
+        - System
+      summary: Discover kubeconfig contexts
+      description: >-
+        Parses an uploaded kubeconfig and returns its contexts - including
+        unreachable ones, flagged via `reachable` - without persisting any
+        connection. Lets a client present the discovered contexts for
+        selection before importing them.
+      operationId: discoverKubernetesContexts
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: "#/components/schemas/DiscoverKubernetesContextsPayload"
+      responses:
+        "200":
+          description: Contexts discovered in the uploaded kubeconfig.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "../../v1beta3/connection/api.yml#/components/schemas/K8sContext"
+        "400":
+          description: Missing or unparsable kubeconfig.
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          description: Failed to retrieve the provider token for the request.
+
+  /api/system/kubernetes/ping:
+    get:
+      x-internal: ["meshery"]
+      tags:
+        - System
+      summary: Ping a Kubernetes connection
+      description: >-
+        Verifies connectivity to the Kubernetes cluster behind a connection by
+        fetching the API server version.
+      operationId: pingKubernetes
+      parameters:
+        - name: connectionId
+          in: query
+          required: true
+          description: ID of the Kubernetes connection whose cluster to ping.
+          schema:
+            $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
+      responses:
+        "200":
+          description: Cluster is reachable.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/KubernetesPingResponse"
+        "400":
+          description: Missing `connectionId` query parameter, or the stored kubeconfig is invalid.
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          description: No Kubernetes context found for the given connection ID.
+        "500":
+          description: Failed to reach the cluster or fetch its server version.
+
   /api/system/sync:
     get:
       x-internal: ["meshery"]
@@ -685,3 +787,99 @@ components:
           description: Kubernetes contexts currently tracked by the Meshery server.
           items:
             $ref: "#/components/schemas/SystemSessionSyncK8sContext"
+
+    AddKubernetesConfigPayload:
+      type: object
+      description: >-
+        Multipart form payload for importing a kubeconfig. `contexts` and
+        `selectedContexts` are JSON-encoded strings because they travel as
+        multipart form fields alongside the file.
+      additionalProperties: false
+      required:
+        - k8sfile
+      properties:
+        k8sfile:
+          type: string
+          format: binary
+          description: Kubeconfig file contents.
+        contexts:
+          type: string
+          description: >-
+            JSON-encoded object mapping a discovered context ID to per-context
+            import options, e.g. `{"<contextId>": {"meshsyncDeploymentMode":
+            "operator", "name": "my-cluster"}}`. `meshsyncDeploymentMode`
+            selects how MeshSync runs for the resulting connection; `name`
+            overrides the connection name.
+          maxLength: 1048576
+        selectedContexts:
+          type: string
+          description: >-
+            JSON-encoded array of discovered context IDs to import. When
+            absent, every context discovered in the kubeconfig is imported.
+          maxLength: 1048576
+
+    DiscoverKubernetesContextsPayload:
+      type: object
+      description: Multipart form payload for kubeconfig context discovery.
+      additionalProperties: false
+      required:
+        - k8sfile
+      properties:
+        k8sfile:
+          type: string
+          format: binary
+          description: Kubeconfig file contents.
+
+    AddKubernetesConfigResponse:
+      type: object
+      description: >-
+        Discovered kubeconfig contexts bucketed by import outcome. Every
+        bucket is always present (empty when no context landed in it).
+      additionalProperties: false
+      required:
+        - registeredContexts
+        - connectedContexts
+        - ignoredContexts
+        - erroredContexts
+      properties:
+        registeredContexts:
+          type: array
+          description: Contexts newly registered as discovered connections.
+          items:
+            $ref: "../../v1beta3/connection/api.yml#/components/schemas/K8sContext"
+        connectedContexts:
+          type: array
+          description: >-
+            Contexts whose connection already exists in (or transitioned to)
+            the connected state.
+          items:
+            $ref: "../../v1beta3/connection/api.yml#/components/schemas/K8sContext"
+        ignoredContexts:
+          type: array
+          description: Contexts whose connection is in the ignored state.
+          items:
+            $ref: "../../v1beta3/connection/api.yml#/components/schemas/K8sContext"
+        erroredContexts:
+          type: array
+          description: >-
+            Contexts that could not be saved as connections. The failure
+            detail is recorded in the emitted event's metadata, not on the
+            context object.
+          items:
+            $ref: "../../v1beta3/connection/api.yml#/components/schemas/K8sContext"
+
+    KubernetesPingResponse:
+      type: object
+      description: Result of pinging a Kubernetes connection's API server.
+      additionalProperties: false
+      required:
+        - server_version
+      properties:
+        server_version:
+          type: string
+          description: >-
+            Version string reported by the cluster's API server. The wire
+            field is `server_version` - this endpoint's published wire casing
+            predates the camelCase convention and is preserved within this
+            API version.
+          maxLength: 128

--- a/schemas/constructs/v1beta3/connection/api.yml
+++ b/schemas/constructs/v1beta3/connection/api.yml
@@ -1223,6 +1223,16 @@ components:
           x-go-type-skip-optional-pointer: true
           x-oapi-codegen-extra-tags:
             json: "connectionId,omitempty"
+        reachable:
+          type: boolean
+          description: >-
+            Whether the context's API server answered a version probe when the
+            kubeconfig was processed. Populated during kubeconfig discovery and
+            import (`/api/system/kubernetes*`); not persisted with the
+            connection.
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "reachable"
 
     K8sContextPage:
       type: object

--- a/schemas/constructs/v1beta3/connection/api.yml
+++ b/schemas/constructs/v1beta3/connection/api.yml
@@ -1224,15 +1224,25 @@ components:
           x-oapi-codegen-extra-tags:
             json: "connectionId,omitempty"
         reachable:
-          type: boolean
+          $ref: "#/components/schemas/ConnectionReachability"
           description: >-
-            Whether the context's API server answered a version probe when the
-            kubeconfig was processed. Populated during kubeconfig discovery and
-            import (`/api/system/kubernetes*`); not persisted with the
-            connection.
+            Whether this context's API server answered the probe run while its
+            kubeconfig was processed. Discovery and import surface unreachable
+            contexts too, so they can still be registered; reachability only
+            gates the connected transition.
+          x-go-type: bool
           x-go-type-skip-optional-pointer: true
           x-oapi-codegen-extra-tags:
             json: "reachable"
+
+    ConnectionReachability:
+      type: boolean
+      description: >-
+        Whether the system behind a connection answered an ad hoc connectivity
+        probe. Connectivity checks run against many kinds of connections and
+        systems (Kubernetes API servers, telemetry systems such as Prometheus
+        and Grafana, and other managed platforms); a probe result is
+        point-in-time and never persisted with the connection.
 
     K8sContextPage:
       type: object

--- a/schemas/constructs/v1beta3/connection/api.yml
+++ b/schemas/constructs/v1beta3/connection/api.yml
@@ -1239,10 +1239,10 @@ components:
       type: boolean
       description: >-
         Whether the system behind a connection answered an ad hoc connectivity
-        probe. Connectivity checks run against many kinds of connections and
-        systems (Kubernetes API servers, telemetry systems such as Prometheus
-        and Grafana, and other managed platforms); a probe result is
-        point-in-time and never persisted with the connection.
+        probe. A probe is a point-in-time check of the connected system's
+        endpoint; its result is never persisted with the connection. For
+        example, probing a Kubernetes connection checks the cluster's API
+        server.
 
     K8sContextPage:
       type: object


### PR DESCRIPTION
**Notes for Reviewers**

Part of migrating meshery/meshery's hand-declared RTK endpoints onto the generated client (schemas-first mandate). This PR documents the `/api/system/kubernetes*` slice - the endpoints `ui/rtk-query/connection.ts` currently reaches with local `builder.mutation`/`builder.query` declarations.

### Endpoints added (`schemas/constructs/v1beta1/system/api.yml`, all `x-internal: ["meshery"]`)

| Operation | Route | Notes |
|---|---|---|
| `addKubernetesConfig` | `POST /api/system/kubernetes` | multipart kubeconfig import; optional `contexts` (per-context options) and `selectedContexts` (scoping) form fields; responds with `registeredContexts` / `connectedContexts` / `ignoredContexts` / `erroredContexts` buckets of `K8sContext` |
| `discoverKubernetesContexts` | `POST /api/system/kubernetes/contexts` | parse-only discovery for pre-import selection; surfaces unreachable contexts flagged via `reachable` |
| `pingKubernetes` | `GET /api/system/kubernetes/ping?connectionId=` | API-server version probe; `server_version` preserves this endpoint's published snake_case wire casing within this API version (documented on the property) |

Shapes were derived from the server handlers (`server/handlers/k8sconfig_handler.go`: `addK8SConfig`, `GetContextsFromK8SConfig`, `KubernetesPingHandler`), not from the UI's assumptions.

### K8sContext (`schemas/constructs/v1beta3/connection/api.yml`)

Adds the optional transient `reachable` flag to the `K8sContext` projection. Discovery and import responses carry it on the wire (`json:"reachable"` on the server struct) but the schema omitted it; with `additionalProperties: false` the schema would otherwise reject real payloads when reused for these endpoints.

### Deliberate choices

- The vestigial `DELETE /api/system/kubernetes` no-op handler is left undocumented.
- Generated hook names match what meshery/meshery already exports (`useAddKubernetesConfigMutation`, `useDiscoverKubernetesContextsMutation`, `useLazyPingKubernetesQuery`), so the downstream swap is a drop-in behind the existing thin wrappers.
- Generated artifacts (`models/`, `typescript/generated/`) are not committed; master automation regenerates them per AGENTS.md.

### Validation

- `make validate-schemas` - no blocking violations
- `make consumer-audit` - Consumer Only: 0
- `make build` (bundle, Go + RTK + TS generation, permissions, `test-golang`) - exit 0; bundle gains exactly the 3 new operations
- Generated Go: `Reachable bool json:"reachable"` matches the server struct

### Follow-up (meshery/meshery, after release + dependency bump)

Swap `addKubernetesConfig` / `discoverKubernetesContexts` / `pingKubernetes` in `ui/rtk-query/connection.ts` to the generated hooks, keeping `Connection_API_Connections` invalidation via `enhanceEndpoints` (same pattern as `performConnectionAction`).

**[Signed commits](https://github.com/meshery/schemas/blob/master/CONTRIBUTING.md)**
- [x] Yes, I signed my commits.
