### PR TITLE
Define connection registration state-machine endpoints (processConnectionRegistration, cancelConnectionRegister)

### DIFF
--- a/schemas/constructs/v1beta3/connection/api.yml
+++ b/schemas/constructs/v1beta3/connection/api.yml
@@ -107,6 +107,70 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
+  /api/integrations/connections/register:
+    post:
+      x-internal: ["meshery"]
+      tags:
+        - Connections
+      summary: Drive the connection registration state machine
+      description: >-
+        Dispatches a lifecycle event for an in-progress connection
+        registration. With status `initialize`, responds with the registration
+        bootstrap - the kind's connection (and credential, when one exists)
+        registry component definitions plus a tracker `id` the client echoes
+        on subsequent events. Every other status is forwarded to the tracked
+        registration's state machine and the response body is empty.
+      operationId: processConnectionRegistration
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ConnectionRegistrationEvent"
+      responses:
+        "200":
+          description: >-
+            Registration bootstrap for status `initialize`; empty body for
+            every other status.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ConnectionRegistrationBootstrap"
+        "400":
+          description: >-
+            Malformed payload, or no connection component is registered for
+            the requested kind.
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          description: >-
+            Failed to resolve the provider token, or to initialize / signal
+            the registration state machine.
+  /api/integrations/connections/register/{registrationId}:
+    delete:
+      x-internal: ["meshery"]
+      tags:
+        - Connections
+      summary: Cancel a connection registration
+      description: >-
+        Discards the in-progress registration state machine tracked by
+        `registrationId`. Nothing is persisted for the abandoned process.
+        Idempotent: unknown ids are ignored.
+      operationId: cancelConnectionRegister
+      parameters:
+        - name: registrationId
+          in: path
+          required: true
+          description: Registration process tracker id to discard.
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "204":
+          description: Registration process discarded.
+        "401":
+          $ref: "#/components/responses/401"
+
   /api/integrations/connections/{connectionId}:
     get:
       x-internal: ["cloud", "meshery"]
@@ -928,6 +992,159 @@ components:
         - type
         - subType
         - status
+
+    ConnectionRegistrationEvent:
+      type: object
+      description: >-
+        Lifecycle event for the connection registration state machine
+        (POST /api/integrations/connections/register). Unlike
+        `ConnectionPayload`, only `kind` and `status` are always present: an
+        `initialize` event carries just the kind, while `register` / `connect`
+        events carry the connection details assembled so far.
+      additionalProperties: false
+      required:
+        - kind
+        - status
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: >-
+            Registration process tracker. Returned by the `initialize`
+            bootstrap or minted client-side; echoed on every subsequent event
+            for the same registration.
+          x-go-name: ID
+          x-oapi-codegen-extra-tags:
+            json: "id,omitempty"
+        kind:
+          type: string
+          description: Connection kind (e.g. `kubernetes`, `grafana`, `prometheus`).
+          maxLength: 255
+          x-oapi-codegen-extra-tags:
+            json: "kind"
+        status:
+          type: string
+          description: >-
+            State-machine event to dispatch. `initialize` returns the
+            registration bootstrap; every other event advances the tracked
+            registration. `not found` is the machine's literal event name.
+          enum:
+            - initialize
+            - discovery
+            - register
+            - connect
+            - disconnect
+            - ignore
+            - delete
+            - not found
+            - noop
+            - exit
+          x-oapi-codegen-extra-tags:
+            json: "status"
+        name:
+          type: string
+          description: Connection name.
+          maxLength: 255
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "name,omitempty"
+        type:
+          type: string
+          description: Connection type.
+          maxLength: 255
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "type,omitempty"
+        subType:
+          type: string
+          description: Connection sub-type.
+          maxLength: 255
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "subType,omitempty"
+        model:
+          type: string
+          description: Registry model the connection's definition belongs to.
+          maxLength: 255
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "model,omitempty"
+        metadata:
+          type: object
+          description: Connection metadata gathered so far in the flow.
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "metadata,omitempty"
+        credentialSecret:
+          type: object
+          description: Credential secret material for the connection.
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "credentialSecret,omitempty"
+        credentialId:
+          type: string
+          format: uuid
+          description: Existing credential to associate instead of a new secret.
+          x-go-name: CredentialID
+          x-oapi-codegen-extra-tags:
+            json: "credentialId,omitempty"
+        skipCredentialVerification:
+          type: boolean
+          description: >-
+            When true the server registers the connection without verifying
+            the supplied credential first.
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "skipCredentialVerification"
+
+    ConnectionRegistrationBootstrap:
+      type: object
+      description: >-
+        Response to an `initialize` registration event: the registry component
+        definitions describing the kind's connection and credential, plus the
+        tracker id for the registration process. Component definitions carry
+        their RJSF form schema as a JSON-encoded string under `schema`.
+      additionalProperties: false
+      required:
+        - id
+        - connection
+      properties:
+        id:
+          type: string
+          format: uuid
+          description: Registration process tracker to echo on subsequent events.
+          x-go-name: ID
+          x-oapi-codegen-extra-tags:
+            json: "id"
+        connection:
+          type: object
+          description: >-
+            Registry component definition (`{Kind}Connection`) describing the
+            connection, including its JSON-encoded `schema`.
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "connection"
+        credential:
+          type: object
+          description: >-
+            Registry component definition (`{Kind}Credential`) describing the
+            credential, including its JSON-encoded `schema`. Absent when the
+            kind defines no credential component.
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "credential,omitempty"
 
     ConnectionStatusInfo:
       type: object

--- a/schemas/constructs/v1beta3/connection/api.yml
+++ b/schemas/constructs/v1beta3/connection/api.yml
@@ -163,11 +163,12 @@ paths:
           required: true
           description: Registration process tracker id to discard.
           schema:
-            type: string
-            format: uuid
+            $ref: "../../v1beta2/core/api.yml#/components/schemas/Uuid"
       responses:
         "204":
           description: Registration process discarded.
+        "400":
+          description: registrationId is not a valid UUID.
         "401":
           $ref: "#/components/responses/401"
 
@@ -1007,13 +1008,13 @@ components:
         - status
       properties:
         id:
-          type: string
-          format: uuid
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/Uuid"
           description: >-
             Registration process tracker. Returned by the `initialize`
             bootstrap or minted client-side; echoed on every subsequent event
             for the same registration.
           x-go-name: ID
+          x-go-type-skip-optional-pointer: true
           x-oapi-codegen-extra-tags:
             json: "id,omitempty"
         kind:
@@ -1088,8 +1089,7 @@ components:
           x-oapi-codegen-extra-tags:
             json: "credentialSecret,omitempty"
         credentialId:
-          type: string
-          format: uuid
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/Uuid"
           description: Existing credential to associate instead of a new secret.
           x-go-name: CredentialID
           x-oapi-codegen-extra-tags:
@@ -1116,8 +1116,7 @@ components:
         - connection
       properties:
         id:
-          type: string
-          format: uuid
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/Uuid"
           description: Registration process tracker to echo on subsequent events.
           x-go-name: ID
           x-oapi-codegen-extra-tags:


### PR DESCRIPTION
**Notes for Reviewers**

Second slice of migrating meshery/meshery's hand-declared RTK endpoints onto the generated client (follows #1062, which covered `/api/system/kubernetes*`). This PR documents the connection registration state-machine route that backs the Create Connection wizard's `verifyAndRegisterConnection`, `connectToConnection`, and `cancelConnectionRegister` local declarations in `ui/rtk-query/connection.ts`.

### Endpoints added (`schemas/constructs/v1beta3/connection/api.yml`, `x-internal: ["meshery"]`)

| Operation | Route | Notes |
|---|---|---|
| `processConnectionRegistration` | `POST /api/integrations/connections/register` | dispatches a lifecycle event; `initialize` responds with the registration bootstrap (`{id, connection, credential}` component definitions), every other status drives the tracked state machine and returns an empty body |
| `cancelConnectionRegister` | `DELETE /api/integrations/connections/register/{registrationId}` | 204; discards the tracked registration |

Shapes were derived from `server/handlers/connections_handlers.go` (`ProcessConnectionRegistration`, `handleRegistrationInitEvent`, `handleProcessTermination`) and the UI call sites (wizard `genericSteps` and the MeshSync `StepperContent`, which still uses `initialize`).

### Design decisions

- **`ConnectionRegistrationEvent` is a distinct schema, not a reuse of `ConnectionPayload`.** The published `ConnectionPayload` requires `name`/`type`/`subType`/`status`; the registration event legitimately carries only `kind` + `status` for `initialize`. It also carries `model` and `skipCredentialVerification`, which the published payload contract does not. Reusing and loosening `ConnectionPayload` would weaken the `registerConnection`/`updateConnection` contract.
- **`status` is an enum of the machines package's closed event set** (`initialize`, `discovery`, `register`, `connect`, `disconnect`, `ignore`, `delete`, `not found`, `noop`, `exit`). `not found` is the machine's literal event name.
- **Cancellation is defined per `docs/http-api-design.md`** (single delete via path id, 204, no request body) rather than the deployed legacy `DELETE /register` with a JSON body, which Rule "DELETE operations must not have a requestBody" rejects. A coordinated meshery/meshery PR adds the path-param route server-side; the legacy body form stays undocumented and is retired once consumers migrate.
- Hook-name parity where the route shape allows: `useCancelConnectionRegisterMutation` matches the UI's existing export; the two UI POST hooks share one route, so they become thin wrappers over the single generated `useProcessConnectionRegistrationMutation`.
- With `tag: true` codegen both mutations invalidate `Connection_API_Connections` out of the box, so the downstream swap drops the manual invalidation.

### Validation

- `make validate-schemas` - no blocking violations (the earlier body-DELETE draft was rejected by the validator and reworked to the path-param form)
- `make build` (bundle, Go + RTK + TS generation, permissions, `test-golang`) - exit 0
- Generated artifacts (`models/`, `typescript/generated/`) are not committed; master automation regenerates them per AGENTS.md.

### Coordinated changes

- meshery/meshery: add `DELETE /api/integrations/connections/register/{registrationId}` route (PR to follow; legacy body-DELETE kept during the deprecation window).
- meshery/meshery UI swap of the three local mutations onto the generated hooks lands after the npm release containing this and #1062, alongside the `/api/system/kubernetes*` swap.

**[Signed commits](https://github.com/meshery/schemas/blob/master/CONTRIBUTING.md)**
- [x] Yes, I signed my commits.
