### PR TITLE
Revert "Formalize ControllerStatusValue enum on ControllerStatus.status"

### DIFF
--- a/models/v1beta1/system/system.go
+++ b/models/v1beta1/system/system.go
@@ -32,18 +32,6 @@ const (
 	ControllerStatusControllerOPERATOR ControllerStatusController = "OPERATOR"
 )
 
-// Defines values for ControllerStatusValue.
-const (
-	CONNECTED   ControllerStatusValue = "CONNECTED"
-	DEPLOYED    ControllerStatusValue = "DEPLOYED"
-	DEPLOYING   ControllerStatusValue = "DEPLOYING"
-	ENABLED     ControllerStatusValue = "ENABLED"
-	NOTDEPLOYED ControllerStatusValue = "NOTDEPLOYED"
-	RUNNING     ControllerStatusValue = "RUNNING"
-	UNDEPLOYED  ControllerStatusValue = "UNDEPLOYED"
-	UNKOWN      ControllerStatusValue = "UNKOWN"
-)
-
 // ConnectionDiagnostics Diagnostics for a kubernetes connection's Meshery controllers, for rendering a "Diagnostics" section in the connection detail view.
 type ConnectionDiagnostics struct {
 	// ConnectionId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
@@ -109,8 +97,8 @@ type ControllerStatus struct {
 	// Controller The controller this status describes.
 	Controller ControllerStatusController `json:"controller" yaml:"controller"`
 
-	// Status Current status of a single Meshery controller (operator, MeshSync, or broker). Mirrors the MesheryControllerStatus GraphQL enum (server/internal/graphql/schema/schema.graphql) during the ongoing migration of controller-status consumers from GraphQL to this REST API; the literal values (including the published "UNKOWN" spelling) are load-bearing and must not be changed independently of that enum.
-	Status ControllerStatusValue `json:"status" yaml:"status"`
+	// Status Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN).
+	Status string `json:"status" yaml:"status"`
 
 	// Version Deployed controller version, when known.
 	Version string `json:"version" yaml:"version"`
@@ -118,9 +106,6 @@ type ControllerStatus struct {
 
 // ControllerStatusController The controller this status describes.
 type ControllerStatusController string
-
-// ControllerStatusValue Current status of a single Meshery controller (operator, MeshSync, or broker). Mirrors the MesheryControllerStatus GraphQL enum (server/internal/graphql/schema/schema.graphql) during the ongoing migration of controller-status consumers from GraphQL to this REST API; the literal values (including the published "UNKOWN" spelling) are load-bearing and must not be changed independently of that enum.
-type ControllerStatusValue string
 
 // EmailTestRequest Request body for sending a test email through the configured SMTP provider.
 type EmailTestRequest struct {

--- a/schemas/constructs/v1beta1/system/api.yml
+++ b/schemas/constructs/v1beta1/system/api.yml
@@ -408,26 +408,6 @@ components:
           minLength: 1
           maxLength: 1024
 
-    ControllerStatusValue:
-      type: string
-      description: >-
-        Current status of a single Meshery controller (operator, MeshSync, or
-        broker). Mirrors the MesheryControllerStatus GraphQL enum
-        (server/internal/graphql/schema/schema.graphql) during the ongoing
-        migration of controller-status consumers from GraphQL to this REST
-        API; the literal values (including the published "UNKOWN" spelling)
-        are load-bearing and must not be changed independently of that enum.
-      x-enum-casing-exempt: true
-      enum:
-        - DEPLOYED
-        - NOTDEPLOYED
-        - DEPLOYING
-        - UNKOWN
-        - UNDEPLOYED
-        - ENABLED
-        - RUNNING
-        - CONNECTED
-
     ControllerStatus:
       type: object
       description: >-
@@ -453,9 +433,10 @@ components:
             - BROKER
         status:
           type: string
-          $ref: "#/components/schemas/ControllerStatusValue"
-          x-go-type: ControllerStatusValue
-          description: Current controller status.
+          description: >-
+            Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING,
+            CONNECTED, UNKNOWN).
+          maxLength: 255
         version:
           type: string
           description: Deployed controller version, when known.

--- a/typescript/generated/v1beta1/system/System.ts
+++ b/typescript/generated/v1beta1/system/System.ts
@@ -237,11 +237,6 @@ export interface components {
             /** @description Human-readable status message. */
             message: string;
         };
-        /**
-         * @description Current status of a single Meshery controller (operator, MeshSync, or broker). Mirrors the MesheryControllerStatus GraphQL enum (server/internal/graphql/schema/schema.graphql) during the ongoing migration of controller-status consumers from GraphQL to this REST API; the literal values (including the published "UNKOWN" spelling) are load-bearing and must not be changed independently of that enum.
-         * @enum {string}
-         */
-        ControllerStatusValue: "DEPLOYED" | "NOTDEPLOYED" | "DEPLOYING" | "UNKOWN" | "UNDEPLOYED" | "ENABLED" | "RUNNING" | "CONNECTED";
         /** @description Status of a single Meshery controller (operator, MeshSync, or broker) for a kubernetes connection. Element type of the controller-status SSE stream and the operator status response. */
         ControllerStatus: {
             /**
@@ -254,11 +249,8 @@ export interface components {
              * @enum {string}
              */
             controller: "OPERATOR" | "MESHSYNC" | "BROKER";
-            /**
-             * @description Current controller status.
-             * @enum {string}
-             */
-            status: "DEPLOYED" | "NOTDEPLOYED" | "DEPLOYING" | "UNKOWN" | "UNDEPLOYED" | "ENABLED" | "RUNNING" | "CONNECTED";
+            /** @description Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN). */
+            status: string;
             /** @description Deployed controller version, when known. */
             version: string;
         };
@@ -767,11 +759,8 @@ export interface operations {
                          * @enum {string}
                          */
                         controller: "OPERATOR" | "MESHSYNC" | "BROKER";
-                        /**
-                         * @description Current controller status.
-                         * @enum {string}
-                         */
-                        status: "DEPLOYED" | "NOTDEPLOYED" | "DEPLOYING" | "UNKOWN" | "UNDEPLOYED" | "ENABLED" | "RUNNING" | "CONNECTED";
+                        /** @description Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN). */
+                        status: string;
                         /** @description Deployed controller version, when known. */
                         version: string;
                     };

--- a/typescript/generated/v1beta1/system/SystemSchema.ts
+++ b/typescript/generated/v1beta1/system/SystemSchema.ts
@@ -575,19 +575,8 @@ const SystemSchema: Record<string, unknown> = {
                     },
                     "status": {
                       "type": "string",
-                      "x-go-type": "ControllerStatusValue",
-                      "description": "Current controller status.",
-                      "x-enum-casing-exempt": true,
-                      "enum": [
-                        "DEPLOYED",
-                        "NOTDEPLOYED",
-                        "DEPLOYING",
-                        "UNKOWN",
-                        "UNDEPLOYED",
-                        "ENABLED",
-                        "RUNNING",
-                        "CONNECTED"
-                      ]
+                      "description": "Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN).",
+                      "maxLength": 255
                     },
                     "version": {
                       "type": "string",
@@ -1077,21 +1066,6 @@ const SystemSchema: Record<string, unknown> = {
           }
         }
       },
-      "ControllerStatusValue": {
-        "type": "string",
-        "description": "Current status of a single Meshery controller (operator, MeshSync, or broker). Mirrors the MesheryControllerStatus GraphQL enum (server/internal/graphql/schema/schema.graphql) during the ongoing migration of controller-status consumers from GraphQL to this REST API; the literal values (including the published \"UNKOWN\" spelling) are load-bearing and must not be changed independently of that enum.",
-        "x-enum-casing-exempt": true,
-        "enum": [
-          "DEPLOYED",
-          "NOTDEPLOYED",
-          "DEPLOYING",
-          "UNKOWN",
-          "UNDEPLOYED",
-          "ENABLED",
-          "RUNNING",
-          "CONNECTED"
-        ]
-      },
       "ControllerStatus": {
         "type": "object",
         "description": "Status of a single Meshery controller (operator, MeshSync, or broker) for a kubernetes connection. Element type of the controller-status SSE stream and the operator status response.",
@@ -1123,19 +1097,8 @@ const SystemSchema: Record<string, unknown> = {
           },
           "status": {
             "type": "string",
-            "x-go-type": "ControllerStatusValue",
-            "description": "Current controller status.",
-            "x-enum-casing-exempt": true,
-            "enum": [
-              "DEPLOYED",
-              "NOTDEPLOYED",
-              "DEPLOYING",
-              "UNKOWN",
-              "UNDEPLOYED",
-              "ENABLED",
-              "RUNNING",
-              "CONNECTED"
-            ]
+            "description": "Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN).",
+            "maxLength": 255
           },
           "version": {
             "type": "string",

--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -23,7 +23,6 @@ import { components as KeychainComponents } from "./generated/v1beta1/keychain/K
 import { components as OrganizationComponents } from "./generated/v1beta1/organization/Organization";
 import { components as RoleComponents } from "./generated/v1beta1/role/Role";
 import { components as ScheduleComponents } from "./generated/v1beta1/schedule/Schedule";
-import { components as SystemComponents } from "./generated/v1beta1/system/System";
 import { components as TeamComponents } from "./generated/v1beta1/team/Team";
 import { components as WorkspaceComponents } from "./generated/v1beta1/workspace/Workspace";
 import { components as InvitationComponents } from "./generated/v1beta1/invitation/Invitation";
@@ -131,10 +130,6 @@ export namespace v1beta1 {
   export type Category = CategoryComponents["schemas"]["CategoryDefinition"];
   export type Component = ComponentComponents["schemas"]["ComponentDefinition"];
   export type Connection = ConnectionComponents["schemas"]["Connection"];
-  export type ConnectionStatusValue =
-    ConnectionComponents["schemas"]["ConnectionStatusValue"];
-  export type ControllerStatusValue =
-    SystemComponents["schemas"]["ControllerStatusValue"];
   export type Credential = CredentialComponents["schemas"]["Credential"];
   export type Design = PatternComponents["schemas"]["PatternFile"];
   export type Environment = EnvironmentComponents["schemas"]["Environment"];

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -3424,8 +3424,8 @@ export type GetOperatorControllerStatusApiResponse = /** status 200 Operator con
   connectionId: string;
   /** The controller this status describes. */
   controller: "OPERATOR" | "MESHSYNC" | "BROKER";
-  /** Current controller status. */
-  status: "DEPLOYED" | "NOTDEPLOYED" | "DEPLOYING" | "UNKOWN" | "UNDEPLOYED" | "ENABLED" | "RUNNING" | "CONNECTED";
+  /** Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN). */
+  status: string;
   /** Deployed controller version, when known. */
   version: string;
 };


### PR DESCRIPTION
**Notes for Reviewers**

Reverts #1064. That PR's commit carried a tool-generated identity in its `Signed-off-by` trailer, which this repo's AGENTS.md explicitly disallows ("No AI attribution in commits, PR descriptions, comments, or code"). Reverting rather than rewriting `master` history. The `ControllerStatusValue` change itself will be reopened on a clean commit.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
