### PR TITLE
Formalize ControllerStatusValue enum on ControllerStatus.status

### DIFF
--- a/models/v1beta1/system/system.go
+++ b/models/v1beta1/system/system.go
@@ -32,6 +32,18 @@ const (
 	ControllerStatusControllerOPERATOR ControllerStatusController = "OPERATOR"
 )
 
+// Defines values for ControllerStatusValue.
+const (
+	CONNECTED   ControllerStatusValue = "CONNECTED"
+	DEPLOYED    ControllerStatusValue = "DEPLOYED"
+	DEPLOYING   ControllerStatusValue = "DEPLOYING"
+	ENABLED     ControllerStatusValue = "ENABLED"
+	NOTDEPLOYED ControllerStatusValue = "NOTDEPLOYED"
+	RUNNING     ControllerStatusValue = "RUNNING"
+	UNDEPLOYED  ControllerStatusValue = "UNDEPLOYED"
+	UNKOWN      ControllerStatusValue = "UNKOWN"
+)
+
 // ConnectionDiagnostics Diagnostics for a kubernetes connection's Meshery controllers, for rendering a "Diagnostics" section in the connection detail view.
 type ConnectionDiagnostics struct {
 	// ConnectionId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
@@ -97,8 +109,8 @@ type ControllerStatus struct {
 	// Controller The controller this status describes.
 	Controller ControllerStatusController `json:"controller" yaml:"controller"`
 
-	// Status Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN).
-	Status string `json:"status" yaml:"status"`
+	// Status Current status of a single Meshery controller (operator, MeshSync, or broker). Mirrors the MesheryControllerStatus GraphQL enum (server/internal/graphql/schema/schema.graphql) during the ongoing migration of controller-status consumers from GraphQL to this REST API; the literal values (including the published "UNKOWN" spelling) are load-bearing and must not be changed independently of that enum.
+	Status ControllerStatusValue `json:"status" yaml:"status"`
 
 	// Version Deployed controller version, when known.
 	Version string `json:"version" yaml:"version"`
@@ -106,6 +118,9 @@ type ControllerStatus struct {
 
 // ControllerStatusController The controller this status describes.
 type ControllerStatusController string
+
+// ControllerStatusValue Current status of a single Meshery controller (operator, MeshSync, or broker). Mirrors the MesheryControllerStatus GraphQL enum (server/internal/graphql/schema/schema.graphql) during the ongoing migration of controller-status consumers from GraphQL to this REST API; the literal values (including the published "UNKOWN" spelling) are load-bearing and must not be changed independently of that enum.
+type ControllerStatusValue string
 
 // EmailTestRequest Request body for sending a test email through the configured SMTP provider.
 type EmailTestRequest struct {

--- a/schemas/constructs/v1beta1/system/api.yml
+++ b/schemas/constructs/v1beta1/system/api.yml
@@ -408,6 +408,26 @@ components:
           minLength: 1
           maxLength: 1024
 
+    ControllerStatusValue:
+      type: string
+      description: >-
+        Current status of a single Meshery controller (operator, MeshSync, or
+        broker). Mirrors the MesheryControllerStatus GraphQL enum
+        (server/internal/graphql/schema/schema.graphql) during the ongoing
+        migration of controller-status consumers from GraphQL to this REST
+        API; the literal values (including the published "UNKOWN" spelling)
+        are load-bearing and must not be changed independently of that enum.
+      x-enum-casing-exempt: true
+      enum:
+        - DEPLOYED
+        - NOTDEPLOYED
+        - DEPLOYING
+        - UNKOWN
+        - UNDEPLOYED
+        - ENABLED
+        - RUNNING
+        - CONNECTED
+
     ControllerStatus:
       type: object
       description: >-
@@ -433,10 +453,9 @@ components:
             - BROKER
         status:
           type: string
-          description: >-
-            Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING,
-            CONNECTED, UNKNOWN).
-          maxLength: 255
+          $ref: "#/components/schemas/ControllerStatusValue"
+          x-go-type: ControllerStatusValue
+          description: Current controller status.
         version:
           type: string
           description: Deployed controller version, when known.

--- a/typescript/generated/v1beta1/system/System.ts
+++ b/typescript/generated/v1beta1/system/System.ts
@@ -237,6 +237,11 @@ export interface components {
             /** @description Human-readable status message. */
             message: string;
         };
+        /**
+         * @description Current status of a single Meshery controller (operator, MeshSync, or broker). Mirrors the MesheryControllerStatus GraphQL enum (server/internal/graphql/schema/schema.graphql) during the ongoing migration of controller-status consumers from GraphQL to this REST API; the literal values (including the published "UNKOWN" spelling) are load-bearing and must not be changed independently of that enum.
+         * @enum {string}
+         */
+        ControllerStatusValue: "DEPLOYED" | "NOTDEPLOYED" | "DEPLOYING" | "UNKOWN" | "UNDEPLOYED" | "ENABLED" | "RUNNING" | "CONNECTED";
         /** @description Status of a single Meshery controller (operator, MeshSync, or broker) for a kubernetes connection. Element type of the controller-status SSE stream and the operator status response. */
         ControllerStatus: {
             /**
@@ -249,8 +254,11 @@ export interface components {
              * @enum {string}
              */
             controller: "OPERATOR" | "MESHSYNC" | "BROKER";
-            /** @description Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN). */
-            status: string;
+            /**
+             * @description Current controller status.
+             * @enum {string}
+             */
+            status: "DEPLOYED" | "NOTDEPLOYED" | "DEPLOYING" | "UNKOWN" | "UNDEPLOYED" | "ENABLED" | "RUNNING" | "CONNECTED";
             /** @description Deployed controller version, when known. */
             version: string;
         };
@@ -759,8 +767,11 @@ export interface operations {
                          * @enum {string}
                          */
                         controller: "OPERATOR" | "MESHSYNC" | "BROKER";
-                        /** @description Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN). */
-                        status: string;
+                        /**
+                         * @description Current controller status.
+                         * @enum {string}
+                         */
+                        status: "DEPLOYED" | "NOTDEPLOYED" | "DEPLOYING" | "UNKOWN" | "UNDEPLOYED" | "ENABLED" | "RUNNING" | "CONNECTED";
                         /** @description Deployed controller version, when known. */
                         version: string;
                     };

--- a/typescript/generated/v1beta1/system/SystemSchema.ts
+++ b/typescript/generated/v1beta1/system/SystemSchema.ts
@@ -575,8 +575,19 @@ const SystemSchema: Record<string, unknown> = {
                     },
                     "status": {
                       "type": "string",
-                      "description": "Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN).",
-                      "maxLength": 255
+                      "x-go-type": "ControllerStatusValue",
+                      "description": "Current controller status.",
+                      "x-enum-casing-exempt": true,
+                      "enum": [
+                        "DEPLOYED",
+                        "NOTDEPLOYED",
+                        "DEPLOYING",
+                        "UNKOWN",
+                        "UNDEPLOYED",
+                        "ENABLED",
+                        "RUNNING",
+                        "CONNECTED"
+                      ]
                     },
                     "version": {
                       "type": "string",
@@ -1066,6 +1077,21 @@ const SystemSchema: Record<string, unknown> = {
           }
         }
       },
+      "ControllerStatusValue": {
+        "type": "string",
+        "description": "Current status of a single Meshery controller (operator, MeshSync, or broker). Mirrors the MesheryControllerStatus GraphQL enum (server/internal/graphql/schema/schema.graphql) during the ongoing migration of controller-status consumers from GraphQL to this REST API; the literal values (including the published \"UNKOWN\" spelling) are load-bearing and must not be changed independently of that enum.",
+        "x-enum-casing-exempt": true,
+        "enum": [
+          "DEPLOYED",
+          "NOTDEPLOYED",
+          "DEPLOYING",
+          "UNKOWN",
+          "UNDEPLOYED",
+          "ENABLED",
+          "RUNNING",
+          "CONNECTED"
+        ]
+      },
       "ControllerStatus": {
         "type": "object",
         "description": "Status of a single Meshery controller (operator, MeshSync, or broker) for a kubernetes connection. Element type of the controller-status SSE stream and the operator status response.",
@@ -1097,8 +1123,19 @@ const SystemSchema: Record<string, unknown> = {
           },
           "status": {
             "type": "string",
-            "description": "Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN).",
-            "maxLength": 255
+            "x-go-type": "ControllerStatusValue",
+            "description": "Current controller status.",
+            "x-enum-casing-exempt": true,
+            "enum": [
+              "DEPLOYED",
+              "NOTDEPLOYED",
+              "DEPLOYING",
+              "UNKOWN",
+              "UNDEPLOYED",
+              "ENABLED",
+              "RUNNING",
+              "CONNECTED"
+            ]
           },
           "version": {
             "type": "string",

--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -23,6 +23,7 @@ import { components as KeychainComponents } from "./generated/v1beta1/keychain/K
 import { components as OrganizationComponents } from "./generated/v1beta1/organization/Organization";
 import { components as RoleComponents } from "./generated/v1beta1/role/Role";
 import { components as ScheduleComponents } from "./generated/v1beta1/schedule/Schedule";
+import { components as SystemComponents } from "./generated/v1beta1/system/System";
 import { components as TeamComponents } from "./generated/v1beta1/team/Team";
 import { components as WorkspaceComponents } from "./generated/v1beta1/workspace/Workspace";
 import { components as InvitationComponents } from "./generated/v1beta1/invitation/Invitation";
@@ -130,6 +131,10 @@ export namespace v1beta1 {
   export type Category = CategoryComponents["schemas"]["CategoryDefinition"];
   export type Component = ComponentComponents["schemas"]["ComponentDefinition"];
   export type Connection = ConnectionComponents["schemas"]["Connection"];
+  export type ConnectionStatusValue =
+    ConnectionComponents["schemas"]["ConnectionStatusValue"];
+  export type ControllerStatusValue =
+    SystemComponents["schemas"]["ControllerStatusValue"];
   export type Credential = CredentialComponents["schemas"]["Credential"];
   export type Design = PatternComponents["schemas"]["PatternFile"];
   export type Environment = EnvironmentComponents["schemas"]["Environment"];

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -3424,8 +3424,8 @@ export type GetOperatorControllerStatusApiResponse = /** status 200 Operator con
   connectionId: string;
   /** The controller this status describes. */
   controller: "OPERATOR" | "MESHSYNC" | "BROKER";
-  /** Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN). */
-  status: string;
+  /** Current controller status. */
+  status: "DEPLOYED" | "NOTDEPLOYED" | "DEPLOYING" | "UNKOWN" | "UNDEPLOYED" | "ENABLED" | "RUNNING" | "CONNECTED";
   /** Deployed controller version, when known. */
   version: string;
 };


### PR DESCRIPTION
**Notes for Reviewers**

Reopens #1064 (reverted in #1065 solely to drop an AI-tool identity that had leaked into that commit's `Signed-off-by` trailer) on a clean commit. Same content, same rationale:

Prompted by an audit of meshery/meshery#20686: `ui/utils/Enum.ts` hand-rolls both `CONNECTION_STATES` and `CONTROLLER_STATES` locally instead of sourcing them from `@meshery/schemas`, which is a DRY / source-of-truth violation per this repo's own charter ("meshery/schemas becomes the permanent, authoritative source of truth" once a construct is migrated).

- `CONNECTION_STATES` already exactly duplicates the existing `ConnectionStatusValue` enum (`schemas/constructs/v1beta1/connection/api.yml`) - no schema change needed there, it just wasn't exported at a stable TS import path.
- `CONTROLLER_STATES` had no schema-side equivalent at all: `ControllerStatus.status` (`schemas/constructs/v1beta1/system/api.yml`) was a free-form `string` with only an example-value description ("e.g. DEPLOYED, NOTDEPLOYED, RUNNING, CONNECTED, UNKNOWN"), even though its own description says this REST field "Replaces the `getOperatorStatus` GraphQL query" - i.e. it's meant to formalize the existing `MesheryControllerStatus` GraphQL enum (`server/internal/graphql/schema/schema.graphql` in meshery/meshery: `DEPLOYED`, `NOTDEPLOYED`, `DEPLOYING`, `UNKOWN`, `UNDEPLOYED`, `ENABLED`, `RUNNING`, `CONNECTED`).

**What changed**

1. Added a new `ControllerStatusValue` enum schema in `schemas/constructs/v1beta1/system/api.yml`, with the same 8 values (including the published `UNKOWN` spelling, preserved as-is since it's already load-bearing in the GraphQL enum) as `MesheryControllerStatus`. Marked `x-enum-casing-exempt: true` since these are pre-existing published uppercase values, not new enum literals. Referenced it from `ControllerStatus.status` via `$ref` + `x-go-type` (not a bare `$ref` - that renames the Go field itself to the ref'd type name).
2. Exported both `ConnectionStatusValue` and `ControllerStatusValue` as consumable `v1beta1` TS types in `typescript/index.ts`, next to the existing `Connection` export, so downstream repos can type-check local status constants against the schema instead of duplicating the literal list.

This only changes the Go field's *type* (`string` → `ControllerStatusValue`, itself a `string` type) - the JSON wire shape is unchanged. `system.ControllerStatus` isn't currently constructed anywhere in meshery/meshery's server code, so blast radius there is effectively zero.

**Follow-up (tracked separately, not in this PR):** meshery/meshery#20714.

**Verification**
- [x] `make build` (bundle-openapi, generate-golang, generate-ts, generate-rtk, generate-permissions, build-ts)
- [x] `go test ./...`
- [x] `npm run build`
- [x] `make validate-schemas`
- [x] `make consumer-audit`

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
