### PR TITLE
Formalize ControllerStatusValue enum on ControllerStatus.status

### DIFF
--- a/schemas/constructs/v1beta1/system/api.yml
+++ b/schemas/constructs/v1beta1/system/api.yml
@@ -408,6 +408,26 @@ components:
           minLength: 1
           maxLength: 1024
 
+    ControllerStatusValue:
+      type: string
+      description: >-
+        Current status of a single Meshery controller (operator, MeshSync, or
+        broker). Mirrors the MesheryControllerStatus GraphQL enum
+        (server/internal/graphql/schema/schema.graphql) during the ongoing
+        migration of controller-status consumers from GraphQL to this REST
+        API; the literal values (including the published "UNKOWN" spelling)
+        are load-bearing and must not be changed independently of that enum.
+      x-enum-casing-exempt: true
+      enum:
+        - DEPLOYED
+        - NOTDEPLOYED
+        - DEPLOYING
+        - UNKOWN
+        - UNDEPLOYED
+        - ENABLED
+        - RUNNING
+        - CONNECTED
+
     ControllerStatus:
       type: object
       description: >-
@@ -433,10 +453,9 @@ components:
             - BROKER
         status:
           type: string
-          description: >-
-            Current controller status (e.g. DEPLOYED, NOTDEPLOYED, RUNNING,
-            CONNECTED, UNKNOWN).
-          maxLength: 255
+          $ref: "#/components/schemas/ControllerStatusValue"
+          x-go-type: ControllerStatusValue
+          description: Current controller status.
         version:
           type: string
           description: Deployed controller version, when known.

--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -23,6 +23,7 @@ import { components as KeychainComponents } from "./generated/v1beta1/keychain/K
 import { components as OrganizationComponents } from "./generated/v1beta1/organization/Organization";
 import { components as RoleComponents } from "./generated/v1beta1/role/Role";
 import { components as ScheduleComponents } from "./generated/v1beta1/schedule/Schedule";
+import { components as SystemComponents } from "./generated/v1beta1/system/System";
 import { components as TeamComponents } from "./generated/v1beta1/team/Team";
 import { components as WorkspaceComponents } from "./generated/v1beta1/workspace/Workspace";
 import { components as InvitationComponents } from "./generated/v1beta1/invitation/Invitation";
@@ -130,6 +131,10 @@ export namespace v1beta1 {
   export type Category = CategoryComponents["schemas"]["CategoryDefinition"];
   export type Component = ComponentComponents["schemas"]["ComponentDefinition"];
   export type Connection = ConnectionComponents["schemas"]["Connection"];
+  export type ConnectionStatusValue =
+    ConnectionComponents["schemas"]["ConnectionStatusValue"];
+  export type ControllerStatusValue =
+    SystemComponents["schemas"]["ControllerStatusValue"];
   export type Credential = CredentialComponents["schemas"]["Credential"];
   export type Design = PatternComponents["schemas"]["PatternFile"];
   export type Environment = EnvironmentComponents["schemas"]["Environment"];


### PR DESCRIPTION
**Notes for Reviewers**

Re-lands #1064 (reverted in #1065), re-authored with proper attribution.

Identical schema-source change: `ControllerStatus.status` gets a strict `ControllerStatusValue` enum mirroring the `MesheryControllerStatus` GraphQL enum it replaces, referenced via `$ref` + `x-go-type` so the Go field stays `Status`; `typescript/index.ts` exports both `ConnectionStatusValue` and `ControllerStatusValue` as consumable v1beta1 types so meshery/meshery can type-check its local status constants against schemas instead of hand-rolling them.

Differences from #1064:
- Only schema sources are committed (`api.yml`, `typescript/index.ts`); generated artifacts (`models/`, `typescript/generated/`, `typescript/rtk/`) are left to master automation per AGENTS.md.

Validation: `make validate-schemas` clean, full `make build` (Go + RTK + TS generation, `test-golang`) exit 0.

**[Signed commits](https://github.com/meshery/schemas/blob/master/CONTRIBUTING.md)**
- [x] Yes, I signed my commits.