### PR TITLE
ci: gate release publish on in-flight artifact generation

### DIFF
--- a/.github/workflows/publish-schemas.yml
+++ b/.github/workflows/publish-schemas.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   id-token: write
+  actions: read
 
 jobs:
   wait-for-artifacts:

--- a/.github/workflows/publish-schemas.yml
+++ b/.github/workflows/publish-schemas.yml
@@ -9,7 +9,37 @@ permissions:
   id-token: write
 
 jobs:
+  wait-for-artifacts:
+    # Block the release fan-out until any in-flight artifact generation on master
+    # has settled, so we publish generated artifacts rather than stale sources.
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Wait for in-flight artifact generation
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const workflow = 'generate-artifacts-from-schemas.yml';
+            const active = ['queued', 'in_progress', 'waiting', 'requested', 'pending'];
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+            for (let i = 0; i < 60; i++) {              // ~30 min ceiling
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: workflow,
+                branch: 'master',
+              });
+              const running = data.workflow_runs.filter(r => active.includes(r.status));
+              if (running.length === 0) {
+                core.info('Artifacts settled. Proceeding.');
+                return;
+              }
+              core.info(`Waiting on: ${running.map(r => r.html_url).join(', ')}`);
+              await sleep(30000);
+            }
+            core.setFailed('Timed out waiting for artifact generation to finish.');
+
   update-schema-version:
+    needs: wait-for-artifacts
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## What

Adds a `wait-for-artifacts` preflight job to `publish-schemas.yml` that blocks the release fan-out until any in-flight `generate-artifacts-from-schemas.yml` run on `master` has settled.

## Why

The release fan-out (`publish-schemas.yml` → npm/docs/notify) is triggered by `release: published`, while artifact generation runs on `push: master`. If a human publishes the draft release while an artifact-generation run is still in flight, the publish flow can `git pull --ff-only` before the `Generate build artifacts from schemas` commit lands, publishing stale sources.

## How

- New `wait-for-artifacts` job polls `listWorkflowRuns` for `generate-artifacts-from-schemas.yml` on `master`, sleeping 30s between checks (up to ~30 min), until no run is `queued`/`in_progress`/`waiting`/`requested`/`pending`; fails on timeout.
- `update-schema-version` now `needs: wait-for-artifacts`, which already gates the full downstream chain.

Uses the default `GITHUB_TOKEN` (read scope covers `listWorkflowRuns`); no new permissions required.