### PR TITLE
ci: bump meshery/schemas in wasm engine submodule on release

### DIFF
--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -67,8 +67,19 @@ jobs:
           cache: true
       - name: Bump schemas dependency
         run: |
+          set -eo pipefail
           go get "github.com/meshery/schemas@v${{ env.RELEASE_VERSION }}"
           go mod tidy
+          # The wasm engine is a separate Go module that pins meshery/schemas
+          # independently; bump it too so the repo stays on one schemas version
+          # (see server/policies/wasm/go.mod).
+          if [ -f server/policies/wasm/go.mod ]; then
+            (
+              cd server/policies/wasm
+              go get "github.com/meshery/schemas@v${{ env.RELEASE_VERSION }}"
+              go mod tidy
+            )
+          fi
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v8
         with:
@@ -83,6 +94,8 @@ jobs:
           add-paths: |
             go.mod
             go.sum
+            server/policies/wasm/go.mod
+            server/policies/wasm/go.sum
           body: |
             Bump `github.com/meshery/schemas` to v${{ env.RELEASE_VERSION }}
 


### PR DESCRIPTION
## What

Extends the `bump-meshery` job in `notify-dependents.yml` to also bump `github.com/meshery/schemas` in the standalone wasm engine module at `server/policies/wasm/go.mod`, and includes that module's `go.mod`/`go.sum` in the auto-generated bump PR.

## Why

`meshery/meshery` builds the wasm engine as its **own** Go module, which pins `github.com/meshery/schemas` independently of the repo root. The bump job previously ran `go get`/`go mod tidy` only at the root, so after a release the wasm module stayed on an older schemas version (e.g. root on `v1.3.30` while `server/policies/wasm/go.mod` remained on `v1.3.26`). That leaves the repo split across two schemas versions and can produce inconsistent builds (`make wasm-engine` vs `make server`).

## How

- After the root `go get`/`go mod tidy`, the step `cd`s into `server/policies/wasm` and repeats the bump, guarded by `if [ -f server/policies/wasm/go.mod ]` so it no-ops if the module ever moves/is removed.
- `add-paths` now also lists `server/policies/wasm/go.mod` and `server/policies/wasm/go.sum` so the changes land in the generated PR.
- Only the `bump-meshery` job is touched; `bump-meshkit` has no such submodule.

Added `set -eo pipefail` so a failure in either bump fails the step.