### PR TITLE
State the registry alias contract precisely

### DIFF
--- a/schemas/constructs/v1beta1/registry/api.yml
+++ b/schemas/constructs/v1beta1/registry/api.yml
@@ -7,9 +7,10 @@ info:
     credentials, and policies (and, in the future, workflows and profiles)
     are registered into service. Registered capabilities can be used in
     designs, views, tests, policies, and workflows. These operations are
-    served under `/api/registry`; the legacy `/api/meshmodels` and
-    `/api/meshmodel` routes remain available on Meshery Server as deprecated
-    aliases of the same operations.
+    served under `/api/registry`; the legacy `/api/meshmodels` routes remain
+    available on Meshery Server as deprecated aliases of the same
+    operations, and the singular `/api/meshmodel/components/register`
+    registrant route is retained for backward compatibility.
   version: v1beta1
   contact:
     name: Meshery Maintainers


### PR DESCRIPTION
Doc-only follow-up to #1073: the registry construct description implied every operation is also aliased under the singular `/api/meshmodel` prefix. Meshery Server aliases the full surface only under `/api/meshmodels`; the singular prefix retains just the `components/register` registrant route. Matches the wording shipped in meshery/meshery#20775.

No wire or generated-client change; rides the next regular release.