### PR TITLE
fix: add self-paced contributor training link to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/ci.md
+++ b/.github/ISSUE_TEMPLATE/ci.md
@@ -25,4 +25,4 @@ assignees: ''
 - 🎨 Wireframes and designs for Meshery UI in [Figma](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](http://discuss.meshery.io) and [Community Slack](https://slack.meshery.io)
 - 🧪 [Meshery Test Plan Spreadsheet](https://docs.google.com/spreadsheets/d/13Ir4gfaKoAX9r8qYjAFFl_U9ntke4X5ndREY1T7bnVs/edit#gid=0)
-
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -19,3 +19,4 @@ assignees: ''
 - 🛠 [Meshery Build & Release Strategy](https://docs.meshery.io/project/contributing/build-and-release)
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](http://discuss.meshery.io) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/fbug_report.md
+++ b/.github/ISSUE_TEMPLATE/fbug_report.md
@@ -36,3 +36,4 @@ assignees: ''
    - Meshery documentation [site](https://docs.meshery.io/) and [source](https://github.com/meshery/meshery/tree/master/docs)
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](http://discuss.meshery.io) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -27,3 +27,4 @@ assignees: ''
    - Meshery documentation [site](https://docs.meshery.io/) and [source](https://github.com/meshery/meshery/tree/master/docs)
 - 🎨 Wireframes and designs for Meshery UI in [Figma](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](http://discuss.meshery.io) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/meshery-extensions_bug.md
+++ b/.github/ISSUE_TEMPLATE/meshery-extensions_bug.md
@@ -31,3 +31,4 @@ assignees: ''
 - 📚 [Meshery Extensibility Providers](https://docs.meshery.io/extensibility/providers)
 - ⌨️ [Meshery API Docs](https://docs.meshery.io/extensibility/api)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](http://discuss.meshery.io) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/meshery-extensions_feature.md
+++ b/.github/ISSUE_TEMPLATE/meshery-extensions_feature.md
@@ -30,3 +30,4 @@ assignees: ''
 - 📚 [Meshery Extensibility Providers](https://docs.meshery.io/extensibility/providers)
 - ⌨️ [Meshery API Docs](https://docs.meshery.io/extensibility/api)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](http://discuss.meshery.io) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/meshery-ui_bug.md
+++ b/.github/ISSUE_TEMPLATE/meshery-ui_bug.md
@@ -30,3 +30,4 @@ assignees: ''
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
 - 🖥 [Contributing to Meshery UI](https://docs.meshery.io/project/contributing/contributing-ui)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](http://discuss.meshery.io) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/meshery-ui_feature.md
+++ b/.github/ISSUE_TEMPLATE/meshery-ui_feature.md
@@ -28,3 +28,4 @@ assignees: ''
 - 🎨 Wireframes and [designs for Meshery UI](https://www.figma.com/file/SMP3zxOjZztdOLtgN4dS2W/Meshery-UI) in Figma [(open invite)](https://www.figma.com/team_invite/redeem/GvB8SudhEOoq3JOvoLaoMs)
 - 🖥 [Contributing to Meshery UI](https://docs.meshery.io/project/contributing/contributing-ui)
 - 🙋🏾🙋🏼 Questions: [Discussion Forum](http://discuss.meshery.io) and [Community Slack](https://slack.meshery.io)
+- 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)

--- a/.github/ISSUE_TEMPLATE/models.md
+++ b/.github/ISSUE_TEMPLATE/models.md
@@ -30,6 +30,7 @@ assignees: ''
  - [Contributing Models](https://docs.meshery.io/project/contributing/contributing-models)
    - [Contributing Components](https://docs.meshery.io/project/contributing/contributing-components)
    - [Contributing Relationships](https://docs.meshery.io/project/contributing/contributing-relationships)
+   - 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
 
  <!-- ### Instructions for Policies
  - [Contributing Policies](https://docs.meshery.io/project/contributing/contributing-policies)

--- a/.github/ISSUE_TEMPLATE/models.md
+++ b/.github/ISSUE_TEMPLATE/models.md
@@ -30,7 +30,7 @@ assignees: ''
  - [Contributing Models](https://docs.meshery.io/project/contributing/contributing-models)
    - [Contributing Components](https://docs.meshery.io/project/contributing/contributing-components)
    - [Contributing Relationships](https://docs.meshery.io/project/contributing/contributing-relationships)
-   - 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
+ - 📺 [Self-paced Contributor Trainings](https://meshery.io/talks-and-trainings#trainings)
 
  <!-- ### Instructions for Policies
  - [Contributing Policies](https://docs.meshery.io/project/contributing/contributing-policies)


### PR DESCRIPTION
**Notes for Reviewers**

This PR fixes #1069

Added self-paced contributor training link  to the following 9, each in the location most consistent with that template's own footer structure:

- `ci.md`
- `documentation.md`
- `fbug_report.md`
- `feature_request.md`
- `meshery-extensions_bug.md`
- `meshery-extensions_feature.md`
- `meshery-ui_bug.md`
- `meshery-ui_feature.md`
- `models.md`

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added links to self-paced contributor training resources across issue templates.
  * Contributors can now access training materials directly when reporting bugs, requesting features, or submitting documentation and model-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->