### PR TITLE
fix : updated discussion links

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -3,7 +3,7 @@
 # Configuration for new-issue-welcome - https://github.com/behaviorbot/new-issue-welcome
 # Comment to be posted to on first time issues
 newIssueWelcomeComment: >
-  Thanks for opening this issue. A contributor will be by to give feedback soon. In the meantime, please review the [Contributors' Welcome Guide](https://docs.meshery.io/project/community), engage in the [discussion forum](https://meshery.io/community#community-forums), and be sure to join the [community Slack](https://slack.meshery.io/).
+  Thanks for opening this issue. A contributor will be by to give feedback soon. In the meantime, please review the [Contributors' Welcome Guide](https://docs.meshery.io/project/community), engage in the [discussion forum](https://discuss.meshery.io), and be sure to join the [community Slack](https://slack.meshery.io/).
 # Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
 # Comment to be posted to on PRs from first time contributors in your repository
 newPRWelcomeComment: >


### PR DESCRIPTION
**Notes for Reviewers**

This PR updates the community discussion forum link by replacing the [old URL](http://meshery.io/community#discussion-forums) with https://discuss.meshery.io.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [ ] Yes, I signed my commits.
