### PR TITLE
fix(forms): hide session-derived organizationId in environment & workspace forms

### DIFF
--- a/schemas/constructs/v1beta3/environment/forms/createOrEdit.ui.json
+++ b/schemas/constructs/v1beta3/environment/forms/createOrEdit.ui.json
@@ -1,7 +1,7 @@
 {
   "ui:options": { "label": false },
   "organizationId": {
-    "ui:disabled": false
+    "ui:widget": "hidden"
   },
   "ui:order": ["organizationId", "name", "description"]
 }

--- a/schemas/constructs/v1beta3/workspace/forms/createOrEdit.ui.json
+++ b/schemas/constructs/v1beta3/workspace/forms/createOrEdit.ui.json
@@ -1,8 +1,7 @@
 {
   "ui:options": { "label": false },
   "organizationId": {
-    "ui:disabled": false,
-    "ui:widget": "select"
+    "ui:widget": "hidden"
   },
   "ui:order": ["organizationId", "name", "description"]
 }


### PR DESCRIPTION
## What

Hide the session-derived **Organization** field in the create/edit **environment** and **workspace** RJSF form UI schemas.

## Why

A workspace/environment always belongs to the user's active organization, which is derived from the session - it is not something a user picks. But the canonical form UI schemas exposed the field:

| Form | `organizationId` uiSchema (before) | Rendered result |
|---|---|---|
| `v1beta3/environment/forms/createOrEdit.ui.json` | `"ui:disabled": false` | editable text input |
| `v1beta3/workspace/forms/createOrEdit.ui.json` | `"ui:widget": "select"` (no enum) | empty, **required** dropdown that blocks creation |

This is the source-of-truth half of the fix for the two Meshery UI bugs below.

## Change

Set `organizationId` to `"ui:widget": "hidden"` in both UI schemas. The field stays present in form data (consumers seed it from the session and submit it) but is no longer displayed.

- Only the `*.ui.json` presentation hints change; the form `*.json` schemas (field names, types, `required`) are untouched, so they remain a strict subset of their canonical constructs.
- `go test ./validation/ -run 'TestForm|TestEveryForm'` passes.

## Downstream / release coupling

These schemas are re-exported by `@sistent/sistent` (`createAndEdit{Environment,Workspace}{Schema,UiSchema}`) and consumed by `meshery/meshery`. The field becomes fully hidden in the app once this ships through `@meshery/schemas` -> `@sistent/sistent` -> a dep bump in `meshery/meshery`. The consumer-side field-name/session-seeding fix is in the companion Meshery PR.

Refs meshery/meshery#20823
Refs meshery/meshery#20795
