### PR TITLE
fix(forms): render catalog compatibility field as a select widget

### DIFF
--- a/schemas/constructs/v1beta2/catalog/forms/publish.ui.json
+++ b/schemas/constructs/v1beta2/catalog/forms/publish.ui.json
@@ -1,4 +1,7 @@
 {
   "ui:options": { "label": false },
+  "compatibility": {
+    "ui:widget": "select"
+  },
   "ui:order": ["type", "compatibility", "patternInfo", "patternCaveats"]
 }


### PR DESCRIPTION
## What

Add `"compatibility": { "ui:widget": "select" }` to the canonical catalog **publish** form UI schema (`v1beta2/catalog/forms/publish.ui.json`).

## Why

The `compatibility` field (array of technology tags) has no widget hint, so RJSF falls back to its default array rendering. Consumers have been compensating by patching the widget onto the uiSchema at the call site - e.g. meshery-cloud's catalog InfoModal (layer5io/meshery-cloud#5743) does:

```js
newUiSchema.compatibility = { ...newUiSchema.compatibility, "ui:widget": "select" };
```

That duplicates a presentation decision that belongs to the construct and drifts per-consumer. The reviewer on that PR asked exactly this: *"why is this change not being made in meshery/schemas?"*

## Change

Define the widget once in the canonical `publish.ui.json`. Consumers already import `CatalogPublishRjsfUiSchemaV1Beta2` from `@meshery/schemas`, so they can drop the local patch and render consistently.

- Only the `.ui.json` presentation hints change; the form `.json` schema (fields, types, enums, required) is untouched, so it stays a strict subset of the canonical catalog construct.
- `go test ./validation/ -run 'TestForm|TestEveryForm'` passes.

## Downstream

Once released and bumped, layer5io/meshery-cloud#5743 can remove its local `compatibility` uiSchema patch and consume the canonical widget.

Refs layer5io/meshery-cloud#5743
