### PR TITLE
fix(rtk): read MeshKit error envelope in camelCase (#1081)

### DIFF
--- a/.github/workflows/generate-artifacts-from-schemas.yml
+++ b/.github/workflows/generate-artifacts-from-schemas.yml
@@ -29,6 +29,9 @@ jobs:
 
       - name: Install build dependencies
         uses: actions/setup-node@v7
+        with:
+          # >= 22.6 for `node --test` native TypeScript type-stripping (make test-ts).
+          node-version: '22'
       - run: |
           npm i
           go version 
@@ -45,6 +48,11 @@ jobs:
         shell: bash
         run: |
           make site-data-test
+
+      - name: TypeScript unit tests
+        shell: bash
+        run: |
+          make test-ts
 
       - name: Site data generation
         shell: bash

--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ generate-site-index: site-data-generate
 #-----------------------------------------------------------------------------
 # OpenAPI spec
 #-----------------------------------------------------------------------------
-.PHONY: setup generate-ts publish-ts bundle-openapi generate-golang generate-rtk test-rtk golangci validate-schemas validate-schemas-strict audit-schemas audit-schemas-full audit-schemas-style-full audit-schemas-debt-full
+.PHONY: setup generate-ts publish-ts bundle-openapi generate-golang generate-rtk test-rtk test-ts golangci validate-schemas validate-schemas-strict audit-schemas audit-schemas-full audit-schemas-style-full audit-schemas-debt-full
 
 ## (Re)Initialize Golang (go.mod) and Node (package.json) manifests
 setup:
@@ -83,6 +83,10 @@ generate-rtk: bundle-openapi
 ## Run RTK Query generation regression tests
 test-rtk:
 	node --test tests/generate-rtk.test.js
+
+## Run TypeScript unit tests (node --test with native type-stripping; needs Node >= 22.6)
+test-ts:
+	npm test
 
 ## Generate Golang Models (legacy alias for generate-golang)
 golang-generate: generate-golang

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "build:golang": "node ./build/generate-golang.js",
     "build:rtk": "node ./build/generate-rtk.js",
     "build:all": "node ./build/index.js all",
+    "test": "node --test \"typescript/**/*.test.ts\"",
     "test:validate-schemas": "go test ./validation/...",
     "generate:types": "node ./build/generate-typescript.js",
     "generate:permissions:ts": "node ./build/generate-permissions-ts.js",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,6 +9,8 @@
     "esModuleInterop": true,
     "resolveJsonModule": true
   },
-  "include": ["./typescript"]
+  "include": ["./typescript"],
+  "//exclude": "Test files run under Node's native TypeScript test runner (node --test), which requires explicit .ts import extensions for ESM resolution — a form tsc's node moduleResolution rejects (TS5097). They are executed at runtime, never part of the tsup-built dist, so exclude them from the project typecheck.",
+  "exclude": ["typescript/**/*.test.ts"]
 }
 

--- a/typescript/rtk/api.test.ts
+++ b/typescript/rtk/api.test.ts
@@ -1,0 +1,92 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { BaseQueryFn, FetchBaseQueryError } from "@reduxjs/toolkit/query/react";
+import { withMeshkitErrorTransform } from "./api.ts";
+
+/**
+ * Builds a stub inner BaseQueryFn that resolves to a non-2xx error carrying the
+ * given JSON body, so we can drive it through withMeshkitErrorTransform.
+ */
+function innerReturning(data: unknown): BaseQueryFn<unknown, unknown, FetchBaseQueryError> {
+  return async () => ({
+    error: { status: 500, data } as FetchBaseQueryError,
+  });
+}
+
+async function run(data: unknown) {
+  const wrapped = withMeshkitErrorTransform(innerReturning(data));
+  const result = await wrapped({}, {} as never, {});
+  return (result.error as { meshkit?: Record<string, unknown> }).meshkit;
+}
+
+// Regression guard for meshery/schemas#1081: the server emits the MeshKit error
+// envelope in camelCase, but the transform used to read snake_case, so
+// probableCause / suggestedRemediation / longDescription always came back
+// undefined. This asserts all SIX fields survive a realistic camelCase body.
+test("withMeshkitErrorTransform maps all six fields from a camelCase server body", async () => {
+  const meshkit = await run({
+    error: "Failed to reach the connection",
+    code: "meshery-server-1033",
+    severity: "ERROR",
+    probableCause: ["The connection endpoint is unreachable", "Credentials expired"],
+    suggestedRemediation: ["Verify the endpoint URL", "Re-authenticate the connection"],
+    longDescription: ["The server could not establish a session with the target."],
+  });
+
+  assert.ok(meshkit, "meshkit metadata should be attached");
+  assert.equal(meshkit.message, "Failed to reach the connection");
+  assert.equal(meshkit.code, "meshery-server-1033");
+  assert.equal(meshkit.severity, "ERROR");
+  assert.deepEqual(meshkit.probableCause, [
+    "The connection endpoint is unreachable",
+    "Credentials expired",
+  ]);
+  assert.deepEqual(meshkit.suggestedRemediation, [
+    "Verify the endpoint URL",
+    "Re-authenticate the connection",
+  ]);
+  assert.deepEqual(meshkit.longDescription, [
+    "The server could not establish a session with the target.",
+  ]);
+});
+
+// Transitional tolerance: a legacy producer still emitting snake_case must not
+// silently drop the arrays.
+test("withMeshkitErrorTransform falls back to legacy snake_case fields", async () => {
+  const meshkit = await run({
+    error: "Legacy producer error",
+    probable_cause: ["legacy cause"],
+    suggested_remediation: ["legacy remediation"],
+    long_description: ["legacy detail"],
+  });
+
+  assert.ok(meshkit);
+  assert.deepEqual(meshkit.probableCause, ["legacy cause"]);
+  assert.deepEqual(meshkit.suggestedRemediation, ["legacy remediation"]);
+  assert.deepEqual(meshkit.longDescription, ["legacy detail"]);
+});
+
+// camelCase must win when a producer somehow emits both spellings.
+test("withMeshkitErrorTransform prefers camelCase over snake_case", async () => {
+  const meshkit = await run({
+    error: "Both casings present",
+    probableCause: ["camel cause"],
+    probable_cause: ["snake cause"],
+    suggestedRemediation: ["camel remediation"],
+    suggested_remediation: ["snake remediation"],
+    longDescription: ["camel detail"],
+    long_description: ["snake detail"],
+  });
+
+  assert.ok(meshkit);
+  assert.deepEqual(meshkit.probableCause, ["camel cause"]);
+  assert.deepEqual(meshkit.suggestedRemediation, ["camel remediation"]);
+  assert.deepEqual(meshkit.longDescription, ["camel detail"]);
+});
+
+// A non-MeshKit error body (no string `error` field) passes through untouched.
+test("withMeshkitErrorTransform leaves non-MeshKit error bodies untouched", async () => {
+  const wrapped = withMeshkitErrorTransform(innerReturning({ notMeshkit: true }));
+  const result = await wrapped({}, {} as never, {});
+  assert.equal((result.error as { meshkit?: unknown }).meshkit, undefined);
+});

--- a/typescript/rtk/api.ts
+++ b/typescript/rtk/api.ts
@@ -1,4 +1,5 @@
-import { createApi, fetchBaseQuery, BaseQueryFn, FetchBaseQueryError } from "@reduxjs/toolkit/query/react";
+import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
+import type { BaseQueryFn, FetchBaseQueryError } from "@reduxjs/toolkit/query/react";
 
 // RootState interface for proper typing
 interface RootState {
@@ -22,9 +23,10 @@ const MESHERY_BASE_URL = process.env.RTK_MESHERY_ENDPOINT_PREFIX ?? "";
 /**
  * Structured MeshKit error metadata extracted from a non-2xx JSON response body.
  *
- * Field names are JS-side camelCase, mapped from the server's snake_case wire
- * fields. Pairs with the meshery server migration that promotes every non-2xx
- * response from `text/plain` to `application/json` with a MeshKit error envelope.
+ * Field names are JS-side camelCase, matching the server's camelCase wire
+ * fields one-to-one. Pairs with the meshery server migration that promotes
+ * every non-2xx response from `text/plain` to `application/json` with a MeshKit
+ * error envelope.
  */
 export interface MeshkitError {
   /** Human-readable short description (`error` on the wire). */
@@ -33,11 +35,11 @@ export interface MeshkitError {
   code?: string;
   /** Severity level, e.g. `ERROR`, `WARNING`, `FATAL`. */
   severity?: string;
-  /** Probable causes that produced the error (`probable_cause` on the wire). */
+  /** Probable causes that produced the error (`probableCause` on the wire). */
   probableCause?: string[];
-  /** Suggested remediations to recover (`suggested_remediation` on the wire). */
+  /** Suggested remediations to recover (`suggestedRemediation` on the wire). */
   suggestedRemediation?: string[];
-  /** Long-form description lines (`long_description` on the wire). */
+  /** Long-form description lines (`longDescription` on the wire). */
   longDescription?: string[];
 }
 
@@ -56,13 +58,28 @@ export type MeshkitFetchBaseQueryError = FetchBaseQueryError & {
   meshkit?: MeshkitError;
 };
 
-/** Wire-shape of a MeshKit error JSON body (snake_case, server-emitted). */
+/**
+ * Wire-shape of a MeshKit error JSON body.
+ *
+ * Meshery Server emits this envelope in camelCase (see
+ * `server/models/httputil/httputil.go` in meshery/meshery, and the camelCase
+ * wire contract in `docs/identifier-naming-contributor-guide.md`). The
+ * snake_case variants are retained only as an optional transitional fallback in
+ * case any deployed producer still emits the legacy spelling; camelCase takes
+ * precedence when reading (see {@link withMeshkitErrorTransform}).
+ */
 interface MeshkitErrorBody {
   error: string;
   code?: string;
   severity?: string;
+  probableCause?: string[];
+  suggestedRemediation?: string[];
+  longDescription?: string[];
+  /** @deprecated legacy snake_case fallback; camelCase is the contract. */
   probable_cause?: string[];
+  /** @deprecated legacy snake_case fallback; camelCase is the contract. */
   suggested_remediation?: string[];
+  /** @deprecated legacy snake_case fallback; camelCase is the contract. */
   long_description?: string[];
 }
 
@@ -75,8 +92,15 @@ interface MeshkitErrorBody {
  * type inference into endpoint hooks so consumers read `error?.meshkit.*`
  * with full IntelliSense. Non-MeshKit error bodies pass through untouched
  * (just typed under the wider error type with `meshkit` left undefined).
+ *
+ * The structured array fields are read in camelCase (the server's actual wire
+ * form), falling back to the legacy snake_case spelling only if a deployed
+ * producer still emits it. camelCase always wins when both are present.
+ *
+ * Exported for regression testing - the failure mode is invisible (optional
+ * fields silently resolve to `undefined` when the casing is wrong).
  */
-function withMeshkitErrorTransform<Args, Result, DefinitionExtraOptions, Meta>(
+export function withMeshkitErrorTransform<Args, Result, DefinitionExtraOptions, Meta>(
   inner: BaseQueryFn<Args, Result, FetchBaseQueryError, DefinitionExtraOptions, Meta>,
 ): BaseQueryFn<Args, Result, MeshkitFetchBaseQueryError, DefinitionExtraOptions, Meta> {
   return async (args, api, extraOptions) => {
@@ -92,9 +116,9 @@ function withMeshkitErrorTransform<Args, Result, DefinitionExtraOptions, Meta>(
               message: body.error,
               code: body.code,
               severity: body.severity,
-              probableCause: body.probable_cause,
-              suggestedRemediation: body.suggested_remediation,
-              longDescription: body.long_description,
+              probableCause: body.probableCause ?? body.probable_cause,
+              suggestedRemediation: body.suggestedRemediation ?? body.suggested_remediation,
+              longDescription: body.longDescription ?? body.long_description,
             },
           };
           return { error: errorWithMeshkit, meta: result.meta };

--- a/typescript/rtk/api.ts
+++ b/typescript/rtk/api.ts
@@ -1,5 +1,15 @@
 import { createApi, fetchBaseQuery } from "@reduxjs/toolkit/query/react";
-import type { BaseQueryFn, FetchBaseQueryError } from "@reduxjs/toolkit/query/react";
+import { withMeshkitErrorTransform } from "./meshkitError";
+
+// The MeshKit error surface lives in ./meshkitError so it can be unit-tested
+// without loading the React-coupled RTK runtime this module pulls in (see the
+// module doc there). Re-exported here so `@meshery/schemas/api` consumers keep
+// importing these from the same place; tsup inlines them into the `api` bundle.
+export {
+  withMeshkitErrorTransform,
+  type MeshkitError,
+  type MeshkitFetchBaseQueryError,
+} from "./meshkitError";
 
 // RootState interface for proper typing
 interface RootState {
@@ -19,118 +29,6 @@ export const MESHERY_PROD_URL = "https://playground.meshery.io/";
 // Environment variable defaults
 const CLOUD_BASE_URL = process.env.RTK_CLOUD_ENDPOINT_PREFIX ?? "";
 const MESHERY_BASE_URL = process.env.RTK_MESHERY_ENDPOINT_PREFIX ?? "";
-
-/**
- * Structured MeshKit error metadata extracted from a non-2xx JSON response body.
- *
- * Field names are JS-side camelCase, matching the server's camelCase wire
- * fields one-to-one. Pairs with the meshery server migration that promotes
- * every non-2xx response from `text/plain` to `application/json` with a MeshKit
- * error envelope.
- */
-export interface MeshkitError {
-  /** Human-readable short description (`error` on the wire). */
-  message: string;
-  /** Structured error code, e.g. `meshery-server-1033`. */
-  code?: string;
-  /** Severity level, e.g. `ERROR`, `WARNING`, `FATAL`. */
-  severity?: string;
-  /** Probable causes that produced the error (`probableCause` on the wire). */
-  probableCause?: string[];
-  /** Suggested remediations to recover (`suggestedRemediation` on the wire). */
-  suggestedRemediation?: string[];
-  /** Long-form description lines (`longDescription` on the wire). */
-  longDescription?: string[];
-}
-
-/**
- * Extension of {@link FetchBaseQueryError} that carries optional MeshKit
- * metadata on `meshkit`. The raw response body is still available on `data`
- * for backward compatibility — `meshkit` is undefined when the response was
- * not a MeshKit JSON envelope.
- *
- * Defined as an intersection rather than an `interface ... extends` because
- * `FetchBaseQueryError` is a discriminated union (HTTP status / FETCH_ERROR /
- * PARSING_ERROR / TIMEOUT_ERROR / CUSTOM_ERROR), and TypeScript only allows
- * extending object types with statically known members.
- */
-export type MeshkitFetchBaseQueryError = FetchBaseQueryError & {
-  meshkit?: MeshkitError;
-};
-
-/**
- * Wire-shape of a MeshKit error JSON body.
- *
- * Meshery Server emits this envelope in camelCase (see
- * `server/models/httputil/httputil.go` in meshery/meshery, and the camelCase
- * wire contract in `docs/identifier-naming-contributor-guide.md`). The
- * snake_case variants are retained only as an optional transitional fallback in
- * case any deployed producer still emits the legacy spelling; camelCase takes
- * precedence when reading (see {@link withMeshkitErrorTransform}).
- */
-interface MeshkitErrorBody {
-  error: string;
-  code?: string;
-  severity?: string;
-  probableCause?: string[];
-  suggestedRemediation?: string[];
-  longDescription?: string[];
-  /** @deprecated legacy snake_case fallback; camelCase is the contract. */
-  probable_cause?: string[];
-  /** @deprecated legacy snake_case fallback; camelCase is the contract. */
-  suggested_remediation?: string[];
-  /** @deprecated legacy snake_case fallback; camelCase is the contract. */
-  long_description?: string[];
-}
-
-/**
- * Wraps a {@link BaseQueryFn} so non-2xx responses carrying a MeshKit JSON
- * envelope have their structured fields surfaced onto `error.meshkit`.
- *
- * The error type widens from {@link FetchBaseQueryError} to
- * {@link MeshkitFetchBaseQueryError} — that propagates through `createApi`'s
- * type inference into endpoint hooks so consumers read `error?.meshkit.*`
- * with full IntelliSense. Non-MeshKit error bodies pass through untouched
- * (just typed under the wider error type with `meshkit` left undefined).
- *
- * The structured array fields are read in camelCase (the server's actual wire
- * form), falling back to the legacy snake_case spelling only if a deployed
- * producer still emits it. camelCase always wins when both are present.
- *
- * Exported for regression testing - the failure mode is invisible (optional
- * fields silently resolve to `undefined` when the casing is wrong).
- */
-export function withMeshkitErrorTransform<Args, Result, DefinitionExtraOptions, Meta>(
-  inner: BaseQueryFn<Args, Result, FetchBaseQueryError, DefinitionExtraOptions, Meta>,
-): BaseQueryFn<Args, Result, MeshkitFetchBaseQueryError, DefinitionExtraOptions, Meta> {
-  return async (args, api, extraOptions) => {
-    const result = await inner(args, api, extraOptions);
-    if (result.error) {
-      const errData = result.error.data;
-      if (typeof errData === "object" && errData !== null) {
-        const body = errData as Partial<MeshkitErrorBody>;
-        if (typeof body.error === "string") {
-          const errorWithMeshkit: MeshkitFetchBaseQueryError = {
-            ...result.error,
-            meshkit: {
-              message: body.error,
-              code: body.code,
-              severity: body.severity,
-              probableCause: body.probableCause ?? body.probable_cause,
-              suggestedRemediation: body.suggestedRemediation ?? body.suggested_remediation,
-              longDescription: body.longDescription ?? body.long_description,
-            },
-          };
-          return { error: errorWithMeshkit, meta: result.meta };
-        }
-      }
-      // Non-MeshKit error body — widen the error type without adding `meshkit`.
-      return { error: result.error as MeshkitFetchBaseQueryError, meta: result.meta };
-    }
-    // Success case — `data` is set, `error` is undefined.
-    return { data: result.data as Result, meta: result.meta };
-  };
-}
 
 const baseQueryCloud = fetchBaseQuery({
   baseUrl: CLOUD_BASE_URL,

--- a/typescript/rtk/meshkitError.test.ts
+++ b/typescript/rtk/meshkitError.test.ts
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import type { BaseQueryFn, FetchBaseQueryError } from "@reduxjs/toolkit/query/react";
-import { withMeshkitErrorTransform } from "./api.ts";
+import { withMeshkitErrorTransform } from "./meshkitError.ts";
 
 /**
  * Builds a stub inner BaseQueryFn that resolves to a non-2xx error carrying the

--- a/typescript/rtk/meshkitError.ts
+++ b/typescript/rtk/meshkitError.ts
@@ -1,0 +1,127 @@
+import type { BaseQueryFn, FetchBaseQueryError } from "@reduxjs/toolkit/query/react";
+
+/**
+ * Pure MeshKit error-envelope handling, deliberately isolated from the
+ * React-coupled RTK Query runtime in {@link ./api}.
+ *
+ * `./api` value-imports `createApi`/`fetchBaseQuery` from
+ * `@reduxjs/toolkit/query/react`, whose entry point transitively requires
+ * `react-redux` (and `react`) — peer dependencies that are present in a
+ * consuming UI but not installed in this schema repo's test/CI environment.
+ * Keeping this module's only RTK dependency an `import type` (fully erased at
+ * runtime) lets {@link withMeshkitErrorTransform} be exercised under Node's
+ * native TypeScript test runner without pulling in that runtime graph. `./api`
+ * re-exports this surface so package consumers see no change.
+ */
+
+/**
+ * Structured MeshKit error metadata extracted from a non-2xx JSON response body.
+ *
+ * Field names are JS-side camelCase, matching the server's camelCase wire
+ * fields one-to-one. Pairs with the meshery server migration that promotes
+ * every non-2xx response from `text/plain` to `application/json` with a MeshKit
+ * error envelope.
+ */
+export interface MeshkitError {
+  /** Human-readable short description (`error` on the wire). */
+  message: string;
+  /** Structured error code, e.g. `meshery-server-1033`. */
+  code?: string;
+  /** Severity level, e.g. `ERROR`, `WARNING`, `FATAL`. */
+  severity?: string;
+  /** Probable causes that produced the error (`probableCause` on the wire). */
+  probableCause?: string[];
+  /** Suggested remediations to recover (`suggestedRemediation` on the wire). */
+  suggestedRemediation?: string[];
+  /** Long-form description lines (`longDescription` on the wire). */
+  longDescription?: string[];
+}
+
+/**
+ * Extension of {@link FetchBaseQueryError} that carries optional MeshKit
+ * metadata on `meshkit`. The raw response body is still available on `data`
+ * for backward compatibility — `meshkit` is undefined when the response was
+ * not a MeshKit JSON envelope.
+ *
+ * Defined as an intersection rather than an `interface ... extends` because
+ * `FetchBaseQueryError` is a discriminated union (HTTP status / FETCH_ERROR /
+ * PARSING_ERROR / TIMEOUT_ERROR / CUSTOM_ERROR), and TypeScript only allows
+ * extending object types with statically known members.
+ */
+export type MeshkitFetchBaseQueryError = FetchBaseQueryError & {
+  meshkit?: MeshkitError;
+};
+
+/**
+ * Wire-shape of a MeshKit error JSON body.
+ *
+ * Meshery Server emits this envelope in camelCase (see
+ * `server/models/httputil/httputil.go` in meshery/meshery, and the camelCase
+ * wire contract in `docs/identifier-naming-contributor-guide.md`). The
+ * snake_case variants are retained only as an optional transitional fallback in
+ * case any deployed producer still emits the legacy spelling; camelCase takes
+ * precedence when reading (see {@link withMeshkitErrorTransform}).
+ */
+interface MeshkitErrorBody {
+  error: string;
+  code?: string;
+  severity?: string;
+  probableCause?: string[];
+  suggestedRemediation?: string[];
+  longDescription?: string[];
+  /** @deprecated legacy snake_case fallback; camelCase is the contract. */
+  probable_cause?: string[];
+  /** @deprecated legacy snake_case fallback; camelCase is the contract. */
+  suggested_remediation?: string[];
+  /** @deprecated legacy snake_case fallback; camelCase is the contract. */
+  long_description?: string[];
+}
+
+/**
+ * Wraps a {@link BaseQueryFn} so non-2xx responses carrying a MeshKit JSON
+ * envelope have their structured fields surfaced onto `error.meshkit`.
+ *
+ * The error type widens from {@link FetchBaseQueryError} to
+ * {@link MeshkitFetchBaseQueryError} — that propagates through `createApi`'s
+ * type inference into endpoint hooks so consumers read `error?.meshkit.*`
+ * with full IntelliSense. Non-MeshKit error bodies pass through untouched
+ * (just typed under the wider error type with `meshkit` left undefined).
+ *
+ * The structured array fields are read in camelCase (the server's actual wire
+ * form), falling back to the legacy snake_case spelling only if a deployed
+ * producer still emits it. camelCase always wins when both are present.
+ *
+ * Exported for regression testing - the failure mode is invisible (optional
+ * fields silently resolve to `undefined` when the casing is wrong).
+ */
+export function withMeshkitErrorTransform<Args, Result, DefinitionExtraOptions, Meta>(
+  inner: BaseQueryFn<Args, Result, FetchBaseQueryError, DefinitionExtraOptions, Meta>,
+): BaseQueryFn<Args, Result, MeshkitFetchBaseQueryError, DefinitionExtraOptions, Meta> {
+  return async (args, api, extraOptions) => {
+    const result = await inner(args, api, extraOptions);
+    if (result.error) {
+      const errData = result.error.data;
+      if (typeof errData === "object" && errData !== null) {
+        const body = errData as Partial<MeshkitErrorBody>;
+        if (typeof body.error === "string") {
+          const errorWithMeshkit: MeshkitFetchBaseQueryError = {
+            ...result.error,
+            meshkit: {
+              message: body.error,
+              code: body.code,
+              severity: body.severity,
+              probableCause: body.probableCause ?? body.probable_cause,
+              suggestedRemediation: body.suggestedRemediation ?? body.suggested_remediation,
+              longDescription: body.longDescription ?? body.long_description,
+            },
+          };
+          return { error: errorWithMeshkit, meta: result.meta };
+        }
+      }
+      // Non-MeshKit error body — widen the error type without adding `meshkit`.
+      return { error: result.error as MeshkitFetchBaseQueryError, meta: result.meta };
+    }
+    // Success case — `data` is set, `error` is undefined.
+    return { data: result.data as Result, meta: result.meta };
+  };
+}


### PR DESCRIPTION
## What & why

Fixes #1081.

`withMeshkitErrorTransform` in `typescript/rtk/api.ts` read the MeshKit error envelope with **snake_case** keys (`probable_cause`, `suggested_remediation`, `long_description`), but Meshery Server serializes that envelope in **camelCase** (`probableCause`, `suggestedRemediation`, `longDescription`) - the wire contract documented in [`docs/identifier-naming-contributor-guide.md`](https://github.com/meshery/schemas/blob/master/docs/identifier-naming-contributor-guide.md) and enforced by the server's `errorResponse` struct (`server/models/httputil/httputil.go` in meshery/meshery).

As a result `error.meshkit.probableCause`, `suggestedRemediation`, and `longDescription` resolved to `undefined` for **every** consumer of the generated RTK client. Only `message`, `code`, and `severity` survived (identical spelling on both sides). Any UI surfacing MeshKit remediation showed a degraded error with no guidance.

- **Symptom:** the three array fields always `undefined`.
- **Root cause:** the client transform read the wrong casing; the doc comment asserting a snake_case wire form was the incorrect premise.
- **Fix:** read camelCase (contract-correct), falling back to the legacy snake_case spelling only if a deployed producer still emits it, with **camelCase taking precedence**. Corrected the misleading doc comments.

## Schema-driven / source-of-truth

`typescript/rtk/api.ts` is the hand-written RTK `apiFile` referenced by `cloud-rtk-config.ts` / `meshery-rtk-config.ts` - **not** a generated artifact (`build/generate-rtk.js` emits only `cloud.ts` / `meshery.ts`). So the fix is applied to the authoritative source and the built client is regenerated from it.

## Changes

- `typescript/rtk/api.ts`
  - Reads switched to `body.probableCause ?? body.probable_cause` (and the other two) - camelCase primary, snake_case fallback, camelCase precedence.
  - `MeshkitErrorBody` wire interface now camelCase, with `@deprecated` snake_case fields retained only as a transitional fallback.
  - Corrected the three misleading doc comments.
  - Split the type-only RTK imports to `import type` and exported `withMeshkitErrorTransform` so it can be exercised under Node's native TypeScript test runner.
- `typescript/rtk/api.test.ts` (new) - regression test, zero new deps, `node --test`.
- `package.json` - added `npm test` (`node --test "typescript/**/*.test.ts"`).

## Test plan

- `npm test` - 4 cases, all green:
  1. all six fields land from a realistic camelCase server body,
  2. legacy snake_case fallback still populates the arrays,
  3. camelCase wins when both spellings are present,
  4. a non-MeshKit error body passes through untouched.
- **Verified the test catches the regression:** reverting the reads to snake_case-only fails cases 1 and 3.
- `npm run build` - rebuilt `dist/api.js` / `dist/api.mjs` now emit `probableCause:(...)!=null?...:r.probable_cause` (was `probableCause:r.probable_cause`). `dist/` is not committed (produced by the publish workflow).

The failure mode is invisible (optional fields silently `undefined`), so the regression test is the guard that keeps it from recurring.

## Follow-up (separate repo, not in this PR)

`meshery/meshery` carries a consumer-side stopgap in `ui/utils/helpers/meshkitError.ts` (defensive parsing tolerant of both casings, falling back to the raw response body). That is a deliberate stopgap for this upstream defect, not a contract fork - it should be removed once this lands and `@meshery/schemas` is bumped in meshery/meshery.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured MeshKit error details, including messages, codes, severity, causes, remediation, and descriptions.
  * Supports both current camelCase and legacy snake_case error responses.

* **Bug Fixes**
  * Non-MeshKit errors now pass through without incorrectly adding MeshKit metadata.

* **Tests**
  * Added automated coverage for error mapping and fallback behavior.
  * TypeScript tests now run through the standard test and artifact-generation workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->