### PR TITLE
fix(ci): bound wait-for-module polling with per-request and job timeouts

### DIFF
--- a/.github/workflows/notify-dependents.yml
+++ b/.github/workflows/notify-dependents.yml
@@ -62,6 +62,10 @@ jobs:
     runs-on: ubuntu-24.04
     needs: resolve-version
     if: ${{ needs.resolve-version.outputs.release_version != '' }}
+    # Hard safety net: the per-request curl timeouts below already bound each
+    # attempt, but cap the whole job too so a pathological stall can never hold
+    # a runner open toward the 6-hour Actions default.
+    timeout-minutes: 10
     env:
       RELEASE_VERSION: ${{ needs.resolve-version.outputs.release_version }}
       MODULE: github.com/meshery/schemas
@@ -84,11 +88,15 @@ jobs:
             # Capture the HTTP status rather than relying on curl's exit code, so
             # the poll log surfaces the exact 404/500 the version is transiently
             # returning while indexing. Without -f, curl exits 0 on an HTTP error
-            # and still prints the status; on a connection-level failure it
-            # prints 000. Either way the code is non-200 and we keep polling (no
-            # `set -e`, so the non-zero exit does not abort the step).
-            info_code=$(curl -s -o /dev/null -w '%{http_code}' "$info_url")
-            sumdb_code=$(curl -s -o /dev/null -w '%{http_code}' "$sumdb_url")
+            # and still prints the status; on a connection-level failure or a
+            # timeout it prints 000. Either way the code is non-200 and we keep
+            # polling (no `set -e`, so the non-zero exit does not abort the step).
+            # --connect-timeout / --max-time bound each request so a stalled TLS
+            # handshake or half-open socket can't hang an attempt indefinitely
+            # past the retry window (the sumdb lookup fetches+hashes the module,
+            # so allow it a little more headroom than a plain .info fetch).
+            info_code=$(curl -s --connect-timeout 10 --max-time 20 -o /dev/null -w '%{http_code}' "$info_url")
+            sumdb_code=$(curl -s --connect-timeout 10 --max-time 20 -o /dev/null -w '%{http_code}' "$sumdb_url")
             if [ "$info_code" = "200" ] && [ "$sumdb_code" = "200" ]; then
               echo "::notice::${MODULE}@${version} is resolvable on proxy.golang.org and sum.golang.org (attempt ${attempt}/${max_attempts})."
               exit 0


### PR DESCRIPTION
**Notes for Reviewers**

Follow-up to #1088 (merged), addressing the one actionable CodeRabbit review comment on that PR: the `wait-for-module` polling `curl` calls were unbounded.

### Problem
In the `wait-for-module` gate added by #1088, neither `curl` invocation set `--connect-timeout`/`--max-time`, and the job had no `timeout-minutes`. `curl`'s default has no total request timeout, so on a stalled TLS handshake or half-open socket a single attempt could hang indefinitely — blowing past the intended `~5 min` retry window toward the GitHub Actions 6-hour default job timeout and tying up a runner.

### Fix
- Bound each request: `--connect-timeout 10 --max-time 20`. Slightly more headroom than a plain fetch for the `sum.golang.org` lookup, which fetches and hashes the module before answering.
- Add a hard safety net at the job level: `timeout-minutes: 10`.

Status capture and retry behavior are unchanged: a per-request timeout surfaces as HTTP code `000`, which is already treated the same as any other non-200 and retried on the next attempt.

### Testing
- **Happy path** (indexed `v1.3.37`): both endpoints still return 200 in ~0.2s; gate exits 0 on attempt 1.
- **Stalled endpoint** (blackholed IP): request now returns `000` at the timeout bound instead of hanging.
- **Timing sanity**: normal full-exhaustion (30 × ~10s sleeps + fast curls) ≈ 5.2 min, comfortably under the 10-min job cap; a pathological all-stall run is cut off at 10 min rather than running for hours.
- YAML parses; job dependency graph (`bump-meshery` / `bump-meshkit` → `wait-for-module`) unchanged.

No schema files touched, so `make validate-schemas` / `consumer-audit` do not apply.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an overall time limit to dependency availability checks.
  * Improved network request timeouts during module and checksum service polling.
  * Prevented stalled checks from occupying runners indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->