### PR TITLE
Generate core connection kind constants for Go and TypeScript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ generate-site-index: site-data-generate
 #-----------------------------------------------------------------------------
 # OpenAPI spec
 #-----------------------------------------------------------------------------
-.PHONY: setup generate-ts publish-ts bundle-openapi generate-golang generate-rtk test-rtk test-ts golangci validate-schemas validate-schemas-strict audit-schemas audit-schemas-full audit-schemas-style-full audit-schemas-debt-full
+.PHONY: setup generate-ts generate-enums-ts test-enums-ts publish-ts bundle-openapi generate-golang generate-rtk test-rtk test-ts golangci validate-schemas validate-schemas-strict audit-schemas audit-schemas-full audit-schemas-style-full audit-schemas-debt-full
 
 ## (Re)Initialize Golang (go.mod) and Node (package.json) manifests
 setup:
@@ -57,6 +57,15 @@ setup:
 ## Generate typescript library, json templates, yaml templates
 generate-ts:
 	npm run generate:types
+
+## Generate TypeScript runtime constants for `x-ts-const` OpenAPI enums (requires bundle-openapi)
+generate-enums-ts:
+	npm run generate:enums:ts
+	$(MAKE) --no-print-directory test-enums-ts
+
+## Run enum constant generation regression tests
+test-enums-ts:
+	node --test tests/generate-enums-ts.test.js
 
 ## Bundle Typescript library, json templates, yaml templates
 build-ts: generate-ts
@@ -251,7 +260,7 @@ schemas-versions-latest:
 		| sort
 
 ## Generate and bundle schema package (bundles OpenAPI, generates Go, RTK, TypeScript, and permissions)
-build: validate-schemas bundle-openapi generate-golang  generate-rtk generate-ts generate-permissions build-ts test-golang
+build: validate-schemas bundle-openapi generate-golang  generate-rtk generate-ts generate-enums-ts generate-permissions build-ts test-golang
 
 #-----------------------------------------------------------------------------
 # Dependencies

--- a/build/generate-enums-ts.js
+++ b/build/generate-enums-ts.js
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+/**
+ * generate-enums-ts.js - TypeScript Runtime Constants from OpenAPI String Enums
+ *
+ * DESCRIPTION:
+ *   openapi-typescript (build/generate-typescript.js) turns a string `enum` into a
+ *   TYPE-ONLY union: `"meshery" | "kubernetes" | ...`. That is erased at runtime,
+ *   so a consumer that needs to *compare against* an enum member still has to
+ *   hand-write the literal - which is exactly the drift this repo exists to
+ *   prevent. Go has no such gap: oapi-codegen already emits real constants.
+ *
+ *   This script closes it by emitting a frozen runtime object (plus its derived
+ *   type) for every enum that opts in with `x-ts-const`.
+ *
+ * WHAT IT DOES:
+ *   1. Walks the bundled construct specs in _openapi_build/constructs/
+ *   2. Collects every `components.schemas.*` entry that is a string enum AND
+ *      declares `x-ts-const: <ExportedName>`
+ *   3. Writes typescript/constants/<version>/<construct>.ts with one
+ *      `export const <ExportedName>` + `export type <SchemaName>` per enum
+ *   4. Writes typescript/constants/index.ts re-exporting all of them, which
+ *      typescript/index.ts re-exports in turn (`export * from "./constants"`)
+ *
+ *   Keys are camelCased from the enum value ("not found" -> notFound), matching
+ *   the repo's camelCase wire convention; values are the literals verbatim.
+ *
+ *   Output lives OUTSIDE typescript/generated/ on purpose: build/generate-schema-dts.js
+ *   copies everything under typescript/generated/ verbatim into dist/ as .d.ts,
+ *   which is only valid for type-only files. These files declare runtime values,
+ *   so they are bundled by tsup's main (dts: true) entry via typescript/index.ts.
+ *
+ * USAGE:
+ *   node build/generate-enums-ts.js
+ *
+ * PREREQUISITES:
+ *   Run bundle-openapi.js first to populate _openapi_build/.
+ *
+ * OUTPUT:
+ *   - typescript/constants/<version>/<construct>.ts
+ *   - typescript/constants/index.ts
+ */
+
+const fs = require("fs");
+const path = require("path");
+const logger = require("./lib/logger");
+const config = require("./lib/config");
+const paths = require("./lib/paths");
+
+const OUTPUT_DIR = "typescript/constants";
+const OPT_IN_EXTENSION = "x-ts-const";
+// Optional. The emitted TypeScript type name, when it should differ from the
+// schema name. Go names are scoped by their construct package (connection.CoreKind)
+// but these are exported from the @meshery/schemas root, so a schema name that
+// reads fine in Go can be too generic in TypeScript.
+const TYPE_NAME_EXTENSION = "x-ts-type";
+
+const HEADER =
+  `/**\n` +
+  ` * This file was automatically generated from the OpenAPI schemas by\n` +
+  ` * build/generate-enums-ts.js. DO NOT EDIT.\n` +
+  ` *\n` +
+  ` * To change these values, edit the enum's \`${OPT_IN_EXTENSION}\` schema in\n` +
+  ` * schemas/constructs/ and re-run \`make generate-enums-ts\`.\n` +
+  ` */\n`;
+
+/**
+ * Convert an enum value to a safe camelCase object key.
+ * "not found" -> "notFound", "in_cluster" -> "inCluster", "K8s" -> "k8s"
+ * @param {string} value - Enum value
+ * @returns {string} camelCase identifier
+ */
+function toCamelCaseKey(value) {
+  const words = String(value)
+    .split(/[^A-Za-z0-9]+/)
+    .filter(Boolean);
+
+  if (words.length === 0) {
+    throw new Error(`Enum value ${JSON.stringify(value)} has no identifier characters`);
+  }
+
+  const [first, ...rest] = words;
+  const key =
+    first.toLowerCase() +
+    rest.map((w) => w.charAt(0).toUpperCase() + w.slice(1).toLowerCase()).join("");
+
+  // A leading digit is not a valid identifier start; the emitter quotes those.
+  return key;
+}
+
+/**
+ * @param {string} key - Candidate object key
+ * @returns {string} The key, quoted if it is not a bare identifier
+ */
+function quoteKeyIfNeeded(key) {
+  return /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(key) ? key : JSON.stringify(key);
+}
+
+/**
+ * Collect opted-in string enums from a parsed OpenAPI spec.
+ * @param {Object} spec - Parsed OpenAPI document
+ * @param {string} label - "<version>/<construct>", used in error messages
+ * @returns {Array<{constName: string, typeName: string, schemaName: string, description: string|undefined, values: string[]}>}
+ */
+function collectEnumsFromSpec(spec, label) {
+  const schemas = (spec && spec.components && spec.components.schemas) || {};
+  const collected = [];
+
+  for (const [schemaName, schema] of Object.entries(schemas)) {
+    if (!schema || typeof schema !== "object") continue;
+
+    const constName = schema[OPT_IN_EXTENSION];
+    if (!constName) continue;
+
+    if (schema.type !== "string" || !Array.isArray(schema.enum)) {
+      throw new Error(
+        `${label}: ${schemaName} declares ${OPT_IN_EXTENSION} but is not a string enum`,
+      );
+    }
+
+    collected.push({
+      constName,
+      typeName: schema[TYPE_NAME_EXTENSION] || schemaName,
+      schemaName,
+      description: schema.description,
+      values: schema.enum.map(String),
+    });
+  }
+
+  return collected.sort((a, b) => a.constName.localeCompare(b.constName));
+}
+
+/**
+ * Collect opted-in string enums from a bundled construct spec on disk.
+ * @param {Object} pkg - Package definition from config.getSchemaPackages()
+ * @returns {Array} Enums, see collectEnumsFromSpec
+ */
+function collectEnums(pkg) {
+  const inputPath = paths.fromRoot(config.getBundledOutputPath(pkg));
+  if (!paths.fileExists(inputPath)) {
+    return [];
+  }
+
+  let spec;
+  try {
+    spec = JSON.parse(fs.readFileSync(inputPath, "utf-8"));
+  } catch (err) {
+    logger.warn(`Could not parse ${paths.relativePath(inputPath)}: ${err.message}`);
+    return [];
+  }
+
+  return collectEnumsFromSpec(spec, `${pkg.version}/${pkg.name}`);
+}
+
+/**
+ * Render one construct's constants file.
+ * @param {string} label - "<version>/<construct>", cited in the source comment
+ * @param {Array} enums - Enums collected for the construct
+ * @returns {string} File contents
+ */
+function renderConstructFile(label, enums) {
+  const blocks = enums.map((e) => {
+    const seen = new Map();
+    const entries = e.values.map((value) => {
+      const key = toCamelCaseKey(value);
+      if (seen.has(key)) {
+        throw new Error(
+          `${label}: ${e.typeName} values ${JSON.stringify(seen.get(key))} and ${JSON.stringify(value)} both map to key "${key}"`,
+        );
+      }
+      seen.set(key, value);
+      return `  ${quoteKeyIfNeeded(key)}: ${JSON.stringify(value)},`;
+    });
+
+    const source = `${label} components.schemas.${e.schemaName || e.typeName}`;
+    const doc = e.description
+      ? `/**\n * ${e.description.replace(/\n/g, "\n * ")}\n *\n * Source: ${source}\n */\n`
+      : `/** Source: ${source} */\n`;
+
+    return (
+      doc +
+      `export const ${e.constName} = {\n${entries.join("\n")}\n} as const;\n\n` +
+      `export type ${e.typeName} =\n` +
+      `  (typeof ${e.constName})[keyof typeof ${e.constName}];\n`
+    );
+  });
+
+  return `${HEADER}\n${blocks.join("\n")}`;
+}
+
+/**
+ * Render the aggregating index re-exported by typescript/index.ts.
+ * @param {Array<{relativeImport: string}>} files - Emitted construct files
+ * @returns {string} File contents
+ */
+function renderIndexFile(files) {
+  const lines = files.map((f) => `export * from "${f.relativeImport}";`);
+  return `${HEADER}\n${lines.join("\n")}\n`;
+}
+
+/**
+ * Remove stale generated files so a deleted/renamed enum does not linger.
+ * @param {Set<string>} keepPaths - Absolute paths that were just written
+ */
+function pruneStaleFiles(keepPaths) {
+  const root = paths.fromRoot(OUTPUT_DIR);
+  if (!paths.dirExists(root)) return;
+
+  const walk = (dir) => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        if (fs.readdirSync(full).length === 0) fs.rmdirSync(full);
+      } else if (entry.name.endsWith(".ts") && !keepPaths.has(full)) {
+        fs.unlinkSync(full);
+        logger.info(`Removed stale: ${paths.relativePath(full)}`);
+      }
+    }
+  };
+
+  walk(root);
+}
+
+/**
+ * Check prerequisites
+ */
+function checkPrerequisites() {
+  const buildDir = paths.fromRoot(config.paths.buildDir);
+  if (!paths.dirExists(buildDir)) {
+    logger.error("_openapi_build/ directory not found.");
+    logger.info("Run 'node build/bundle-openapi.js' first.");
+    process.exit(1);
+  }
+}
+
+/**
+ * Main entry point
+ */
+function main() {
+  const startTime = Date.now();
+
+  try {
+    process.chdir(paths.getProjectRoot());
+
+    logger.header("🔢 Generating TypeScript enum constants...");
+
+    checkPrerequisites();
+
+    const written = [];
+    const keepPaths = new Set();
+    let enumCount = 0;
+
+    for (const pkg of config.getSchemaPackages()) {
+      const enums = collectEnums(pkg);
+      if (enums.length === 0) continue;
+
+      const relativePath = `${OUTPUT_DIR}/${pkg.version}/${pkg.name}.ts`;
+      const outputPath = paths.fromRoot(relativePath);
+      paths.ensureParentDir(outputPath);
+      fs.writeFileSync(
+        outputPath,
+        renderConstructFile(`${pkg.version}/${pkg.name}`, enums),
+        "utf-8",
+      );
+
+      keepPaths.add(outputPath);
+      written.push({ relativeImport: `./${pkg.version}/${pkg.name}` });
+      enumCount += enums.length;
+
+      logger.success(
+        `Generated: ${relativePath} (${enums.map((e) => e.constName).join(", ")})`,
+      );
+    }
+
+    const indexPath = paths.fromRoot(`${OUTPUT_DIR}/index.ts`);
+    paths.ensureParentDir(indexPath);
+    // Sorted so the file is stable regardless of package discovery order.
+    written.sort((a, b) => a.relativeImport.localeCompare(b.relativeImport));
+    fs.writeFileSync(indexPath, renderIndexFile(written), "utf-8");
+    keepPaths.add(indexPath);
+
+    pruneStaleFiles(keepPaths);
+
+    const duration = ((Date.now() - startTime) / 1000).toFixed(2);
+    logger.blank();
+    logger.success(
+      `Enum constant generation complete: ${enumCount} enum(s) across ${written.length} construct(s) (${duration}s)`,
+    );
+    logger.outputFiles([`${OUTPUT_DIR}/<version>/<construct>.ts`, `${OUTPUT_DIR}/index.ts`]);
+  } catch (err) {
+    logger.error(err.message);
+    console.error(err.stack);
+    process.exit(1);
+  }
+}
+
+module.exports = {
+  collectEnumsFromSpec,
+  main,
+  renderConstructFile,
+  renderIndexFile,
+  toCamelCaseKey,
+};
+
+if (require.main === module) {
+  main();
+}

--- a/docs/schema-authoring-reference.md
+++ b/docs/schema-authoring-reference.md
@@ -242,6 +242,65 @@ Use `x-generate-db-helpers: true` on a schema component to auto-generate `Scan`/
 - `x-internal: ["meshery"]` - Meshery-only (`_openapi_build/meshery_openapi.yml`)
 - `x-internal: ["cloud", "meshery"]` - both bundled outputs
 
+## x-ts-const annotation (runtime constants for string enums)
+
+oapi-codegen already emits real Go constants for every string `enum`. `openapi-typescript`
+does not: it emits a **type-only** union (`"meshery" | "kubernetes" | ...`), which is erased at
+runtime. A TypeScript consumer that needs to *compare a value against* an enum member is
+therefore forced to hand-write the literal — exactly the drift this repo exists to prevent.
+
+Add `x-ts-const: <ExportedName>` to a string enum to also emit a runtime object:
+
+```yaml
+    CoreKind:
+      type: string
+      description: A core connection kind that receives bespoke, kind-specific handling.
+      x-go-name: CoreKind
+      x-ts-const: CoreConnectionKinds
+      x-ts-type: CoreConnectionKind
+      enum: [meshery, kubernetes, prometheus, grafana, github]
+      # oapi-codegen only prefixes enum constants on collision; without explicit
+      # varnames this leaks bare `Kubernetes`, `Grafana`, ... into the Go package.
+      x-enum-varnames:
+        - CoreKindMeshery
+        - CoreKindKubernetes
+        # ...
+```
+
+`make generate-enums-ts` (part of `make build`) then writes
+`typescript/constants/<version>/<construct>.ts`:
+
+```ts
+export const CoreConnectionKinds = {
+  meshery: "meshery",
+  kubernetes: "kubernetes",
+  // ...
+} as const;
+
+export type CoreConnectionKind =
+  (typeof CoreConnectionKinds)[keyof typeof CoreConnectionKinds];
+```
+
+Notes:
+
+- Object keys are camelCased from the value (`"not found"` → `notFound`); values are verbatim.
+- `x-ts-type` is optional; without it the TypeScript type takes the schema name. Use it when
+  the schema name is too generic once un-scoped: Go names are qualified by their construct
+  package (`connection.CoreKind`) but the TypeScript names are exported from the
+  `@meshery/schemas` root, where `CoreKind` alone would not say what it is a kind *of*.
+- Output lands in `typescript/constants/`, **not** `typescript/generated/`.
+  `build/generate-schema-dts.js` copies everything under `typescript/generated/` verbatim into
+  `dist/` as `.d.ts`, which is only valid for type-only files. These files declare runtime
+  values, so they are bundled by tsup's main (`dts: true`) entry via `typescript/index.ts`,
+  which re-exports them with `export * from "./constants"` — a newly annotated enum flows
+  through without editing `index.ts`.
+- An enum a schema field `$ref`s **closes** that field's value set. To name well-known values
+  of a field that must stay open-ended (e.g. connection `kind`), define the enum but do not
+  reference it; `skip-prune: true` in `build/openapi.config.yml` keeps unreferenced component
+  schemas in the generated output.
+- Regression tests: `tests/generate-enums-ts.test.js` (run by `make generate-enums-ts`) —
+  includes a drift check asserting the committed TS and Go constants match the `api.yml` enum.
+
 ## SQL Driver (`Scan`/`Value`) Implementation Rules
 
 When manually implementing `sql.Scanner` and `driver.Valuer` for map-like types:

--- a/models/v1beta3/connection/connection.go
+++ b/models/v1beta3/connection/connection.go
@@ -61,6 +61,15 @@ const (
 	Registered   ConnectionStatusValue = "registered"
 )
 
+// Defines values for CoreKind.
+const (
+	CoreKindGithub     CoreKind = "github"
+	CoreKindGrafana    CoreKind = "grafana"
+	CoreKindKubernetes CoreKind = "kubernetes"
+	CoreKindMeshery    CoreKind = "meshery"
+	CoreKindPrometheus CoreKind = "prometheus"
+)
+
 // Connection Meshery Connections are managed and unmanaged resources that either through discovery or manual entry are tracked by Meshery. Learn more at https://docs.meshery.io/concepts/logical/connections
 type Connection struct {
 	// Id A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
@@ -346,6 +355,9 @@ type ConnectionsStatusPage struct {
 	// TotalCount Total number of status entries
 	TotalCount int `json:"totalCount" yaml:"totalCount"`
 }
+
+// CoreKind A core connection kind that receives bespoke, kind-specific handling in Meshery. The `kind` field itself remains an open-ended string; this names only the kinds with special behavior.
+type CoreKind string
 
 // K8sContext Kubernetes-specific authentication context projected from a kubernetes connection and its credential. Connection metadata supplies the context identity (id, name, server, version, deployment type, instance and server IDs); the credential secret supplies the auth and cluster material. This is a response projection, not a stored table row.
 type K8sContext struct {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "test": "node --test \"typescript/**/*.test.ts\"",
     "test:validate-schemas": "go test ./validation/...",
     "generate:types": "node ./build/generate-typescript.js",
+    "generate:enums:ts": "node ./build/generate-enums-ts.js",
     "generate:permissions:ts": "node ./build/generate-permissions-ts.js",
     "generate:permissions:go": "node ./build/generate-permission-golang.js",
     "diff:permissions": "node ./build/diff-permissions.js",

--- a/schemas/constructs/v1beta3/connection/api.yml
+++ b/schemas/constructs/v1beta3/connection/api.yml
@@ -627,6 +627,45 @@ components:
     Connection:
       $ref: "./connection.yaml"
 
+    # A connection's `kind` is an OPEN-ENDED string (see `kind` in
+    # ./connection.yaml): any kind registered in the registry is valid and the set
+    # grows over time. This enum does NOT close that set - it only names the
+    # core kinds that Meshery gives bespoke handling across the stack: dedicated
+    # import/registration flows, telemetry integrations, credential forms, and
+    # ping/health checks. Consumers compare `kind` against these constants instead
+    # of re-declaring the literal strings.
+    #
+    # Deliberately NOT referenced by the `kind` field of any schema - referencing
+    # it would close the set. It is emitted only because `skip-prune: true`
+    # (build/openapi.config.yml) keeps unreferenced component schemas.
+    #
+    # Go constants come from oapi-codegen (models/v1beta3/connection); the
+    # TypeScript runtime constants come from build/generate-enums-ts.js, which
+    # keys off `x-ts-const` below. The Go/schema name is unqualified because it is
+    # already scoped by the `connection` package; the TypeScript names carry
+    # "Connection" because they are exported from the `@meshery/schemas` root.
+    CoreKind:
+      type: string
+      description: A core connection kind that receives bespoke, kind-specific handling in Meshery. The `kind` field itself remains an open-ended string; this names only the kinds with special behavior.
+      x-go-name: CoreKind
+      x-ts-const: CoreConnectionKinds
+      x-ts-type: CoreConnectionKind
+      enum:
+        - meshery
+        - kubernetes
+        - prometheus
+        - grafana
+        - github
+      # Without explicit varnames oapi-codegen emits unprefixed constants
+      # (`Kubernetes`, `Grafana`, ...) into the package namespace, because it only
+      # prefixes on collision.
+      x-enum-varnames:
+        - CoreKindMeshery
+        - CoreKindKubernetes
+        - CoreKindPrometheus
+        - CoreKindGrafana
+        - CoreKindGithub
+
     ConnectionDefinition:
       description: A connection definition is an uninitialized connection, authored per-model (in a model's `connections/` folder) and registered into the registry alongside components and relationships. It conforms to the connection schema; the dynamic, kind-specific shape is carried in `metadata`. The `model` association scopes the definition to its owning model.
       # Self-referential x-go-type: oapi-codegen emits `type ConnectionDefinition =

--- a/tests/generate-enums-ts.test.js
+++ b/tests/generate-enums-ts.test.js
@@ -1,0 +1,180 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const {
+  collectEnumsFromSpec,
+  renderConstructFile,
+  renderIndexFile,
+  toCamelCaseKey,
+} = require("../build/generate-enums-ts");
+
+function specWith(schemas) {
+  return { components: { schemas } };
+}
+
+test("collectEnumsFromSpec picks up only schemas that opt in with x-ts-const", () => {
+  const enums = collectEnumsFromSpec(
+    specWith({
+      // Opted in.
+      CoreKind: {
+        type: "string",
+        description: "Core kinds",
+        "x-ts-const": "CoreConnectionKinds",
+        enum: ["meshery", "kubernetes"],
+      },
+      // A string enum WITHOUT the extension stays type-only.
+      ConnectionStatusValue: {
+        type: "string",
+        enum: ["discovered", "connected"],
+      },
+      // Not an enum at all.
+      Connection: { type: "object", properties: {} },
+    }),
+    "v1beta3/connection",
+  );
+
+  assert.equal(enums.length, 1);
+  assert.equal(enums[0].constName, "CoreConnectionKinds");
+  assert.equal(enums[0].typeName, "CoreKind");
+  assert.deepEqual(enums[0].values, ["meshery", "kubernetes"]);
+});
+
+test("collectEnumsFromSpec honours x-ts-type when the TS type name differs from the schema name", () => {
+  // Go names are scoped by their construct package (connection.CoreKind); the TS
+  // names are exported from the @meshery/schemas root and need more qualification.
+  const [withOverride] = collectEnumsFromSpec(
+    specWith({
+      CoreKind: {
+        type: "string",
+        "x-ts-const": "CoreConnectionKinds",
+        "x-ts-type": "CoreConnectionKind",
+        enum: ["kubernetes"],
+      },
+    }),
+    "v1beta3/connection",
+  );
+  assert.equal(withOverride.typeName, "CoreConnectionKind");
+  assert.equal(withOverride.schemaName, "CoreKind");
+
+  // Absent the override, the schema name is used verbatim.
+  const [withoutOverride] = collectEnumsFromSpec(
+    specWith({
+      SomeKind: { type: "string", "x-ts-const": "SomeKinds", enum: ["a"] },
+    }),
+    "v1beta3/connection",
+  );
+  assert.equal(withoutOverride.typeName, "SomeKind");
+
+  // The doc comment still cites the SCHEMA name, so the generated file points
+  // back at the api.yml entry it came from.
+  const output = renderConstructFile("v1beta3/connection", [withOverride]);
+  assert.match(output, /Source: v1beta3\/connection components\.schemas\.CoreKind/);
+  assert.match(output, /export type CoreConnectionKind =/);
+});
+
+test("collectEnumsFromSpec fails loudly when x-ts-const is put on a non-string-enum schema", () => {
+  assert.throws(
+    () =>
+      collectEnumsFromSpec(
+        specWith({ Broken: { type: "object", "x-ts-const": "Broken" } }),
+        "v1beta3/connection",
+      ),
+    /declares x-ts-const but is not a string enum/,
+  );
+});
+
+test("renderConstructFile emits a frozen const plus a type derived from it", () => {
+  const output = renderConstructFile("v1beta3/connection", [
+    {
+      constName: "CoreConnectionKinds",
+      typeName: "CoreKind",
+      description: "First class kinds",
+      values: ["meshery", "kubernetes"],
+    },
+  ]);
+
+  assert.match(output, /DO NOT EDIT/);
+  assert.match(output, /Source: v1beta3\/connection components\.schemas\.CoreKind/);
+  assert.match(output, /export const CoreConnectionKinds = \{/);
+  assert.match(output, /^ {2}meshery: "meshery",$/m);
+  assert.match(output, /^ {2}kubernetes: "kubernetes",$/m);
+  assert.match(output, /\} as const;/);
+  assert.match(
+    output,
+    /export type CoreKind =\s*\n\s*\(typeof CoreConnectionKinds\)\[keyof typeof CoreConnectionKinds\];/,
+  );
+});
+
+test("toCamelCaseKey camelCases multi-word enum values", () => {
+  assert.equal(toCamelCaseKey("kubernetes"), "kubernetes");
+  assert.equal(toCamelCaseKey("not found"), "notFound");
+  assert.equal(toCamelCaseKey("in_cluster"), "inCluster");
+  assert.equal(toCamelCaseKey("out-of-cluster"), "outOfCluster");
+});
+
+test("renderConstructFile rejects two enum values that collide on one key", () => {
+  assert.throws(
+    () =>
+      renderConstructFile("v1beta3/connection", [
+        {
+          constName: "Colliding",
+          typeName: "Collide",
+          values: ["not found", "not_found"],
+        },
+      ]),
+    /both map to key "notFound"/,
+  );
+});
+
+test("renderIndexFile re-exports every emitted construct file", () => {
+  const output = renderIndexFile([
+    { relativeImport: "./v1beta3/connection" },
+    { relativeImport: "./v1beta1/system" },
+  ]);
+
+  assert.match(output, /export \* from "\.\/v1beta3\/connection";/);
+  assert.match(output, /export \* from "\.\/v1beta1\/system";/);
+});
+
+test("the committed CoreConnectionKinds output matches the schema it is generated from", () => {
+  const root = path.join(__dirname, "..");
+
+  // The api.yml enum is the single source of truth; the committed TS constants
+  // and the Go constants must not drift from it.
+  const apiYml = fs.readFileSync(
+    path.join(root, "schemas/constructs/v1beta3/connection/api.yml"),
+    "utf8",
+  );
+  const enumBlock = apiYml
+    .split("CoreKind:")[1]
+    .split("x-enum-varnames:")[0];
+  const kinds = [...enumBlock.matchAll(/^\s+- (\w+)$/gm)].map((m) => m[1]);
+  assert.ok(kinds.length > 0, "no enum values parsed out of api.yml");
+
+  const ts = fs.readFileSync(
+    path.join(root, "typescript/constants/v1beta3/connection.ts"),
+    "utf8",
+  );
+  for (const kind of kinds) {
+    assert.match(
+      ts,
+      new RegExp(`^ {2}${kind}: "${kind}",$`, "m"),
+      `typescript/constants is missing "${kind}" — re-run \`make generate-enums-ts\``,
+    );
+  }
+
+  const go = fs.readFileSync(
+    path.join(root, "models/v1beta3/connection/connection.go"),
+    "utf8",
+  );
+  for (const kind of kinds) {
+    const goName = "CoreKind" + kind[0].toUpperCase() + kind.slice(1);
+    assert.match(
+      go,
+      new RegExp(`${goName}\\s+CoreKind = "${kind}"`),
+      `models/v1beta3/connection is missing ${goName} — re-run \`make generate-golang\``,
+    );
+  }
+});

--- a/typescript/constants/index.ts
+++ b/typescript/constants/index.ts
@@ -1,0 +1,9 @@
+/**
+ * This file was automatically generated from the OpenAPI schemas by
+ * build/generate-enums-ts.js. DO NOT EDIT.
+ *
+ * To change these values, edit the enum's `x-ts-const` schema in
+ * schemas/constructs/ and re-run `make generate-enums-ts`.
+ */
+
+export * from "./v1beta3/connection";

--- a/typescript/constants/v1beta3/connection.ts
+++ b/typescript/constants/v1beta3/connection.ts
@@ -1,0 +1,23 @@
+/**
+ * This file was automatically generated from the OpenAPI schemas by
+ * build/generate-enums-ts.js. DO NOT EDIT.
+ *
+ * To change these values, edit the enum's `x-ts-const` schema in
+ * schemas/constructs/ and re-run `make generate-enums-ts`.
+ */
+
+/**
+ * A core connection kind that receives bespoke, kind-specific handling in Meshery. The `kind` field itself remains an open-ended string; this names only the kinds with special behavior.
+ *
+ * Source: v1beta3/connection components.schemas.CoreKind
+ */
+export const CoreConnectionKinds = {
+  meshery: "meshery",
+  kubernetes: "kubernetes",
+  prometheus: "prometheus",
+  grafana: "grafana",
+  github: "github",
+} as const;
+
+export type CoreConnectionKind =
+  (typeof CoreConnectionKinds)[keyof typeof CoreConnectionKinds];

--- a/typescript/generated/v1beta3/connection/Connection.ts
+++ b/typescript/generated/v1beta3/connection/Connection.ts
@@ -575,6 +575,11 @@ export interface components {
              */
             schemaVersion: string;
         };
+        /**
+         * @description A core connection kind that receives bespoke, kind-specific handling in Meshery. The `kind` field itself remains an open-ended string; this names only the kinds with special behavior.
+         * @enum {string}
+         */
+        CoreKind: "meshery" | "kubernetes" | "prometheus" | "grafana" | "github";
         /** @description A connection definition is an uninitialized connection, authored per-model (in a model's `connections/` folder) and registered into the registry alongside components and relationships. It conforms to the connection schema; the dynamic, kind-specific shape is carried in `metadata`. The `model` association scopes the definition to its owning model. */
         ConnectionDefinition: unknown;
         /** @description Represents a page of connection definitions with meta information about the total count */

--- a/typescript/generated/v1beta3/connection/ConnectionSchema.ts
+++ b/typescript/generated/v1beta3/connection/ConnectionSchema.ts
@@ -10681,6 +10681,27 @@ const ConnectionSchema: Record<string, unknown> = {
           }
         }
       },
+      "CoreKind": {
+        "type": "string",
+        "description": "A core connection kind that receives bespoke, kind-specific handling in Meshery. The `kind` field itself remains an open-ended string; this names only the kinds with special behavior.",
+        "x-go-name": "CoreKind",
+        "x-ts-const": "CoreConnectionKinds",
+        "x-ts-type": "CoreConnectionKind",
+        "enum": [
+          "meshery",
+          "kubernetes",
+          "prometheus",
+          "grafana",
+          "github"
+        ],
+        "x-enum-varnames": [
+          "CoreKindMeshery",
+          "CoreKindKubernetes",
+          "CoreKindPrometheus",
+          "CoreKindGrafana",
+          "CoreKindGithub"
+        ]
+      },
       "ConnectionDefinition": {
         "description": "A connection definition is an uninitialized connection, authored per-model (in a model's `connections/` folder) and registered into the registry alongside components and relationships. It conforms to the connection schema; the dynamic, kind-specific shape is carried in `metadata`. The `model` association scopes the definition to its owning model.",
         "x-go-type": "ConnectionDefinition"

--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -91,6 +91,16 @@ import RelationshipDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/rela
 import RelationshipDefinitionV1Alpha3OpenApiSchema from "./generated/v1alpha3/relationship/RelationshipSchema";
 import type * as core from "./generated/v1alpha1/core/Core";
 
+// Runtime constants generated from OpenAPI string enums that opt in with
+// `x-ts-const` (see build/generate-enums-ts.js). openapi-typescript emits those
+// enums as type-only unions, which are erased at runtime; these are the real
+// values to compare against. Exported with `export *` so a newly annotated enum
+// flows through without editing this file.
+//
+// Includes CoreConnectionKinds - note that a connection's `kind` stays an
+// open-ended string; that enum only names the kinds with bespoke handling.
+export * from "./constants";
+
 // Export schemas
 export {
   core,


### PR DESCRIPTION
Connection kinds like `kubernetes`, `grafana` and `prometheus` are currently re-declared as string literals in every consumer. This defines them once in the schema and generates the constants from it.

- Add a `CoreKind` string enum to the v1beta3 connection schema, naming the connection kinds that receive bespoke, kind-specific handling (dedicated import flows, telemetry integrations, credential forms, ping/health checks).
- The connection `kind` field itself stays an **open-ended string** — the enum is deliberately not referenced by any field, so it names the well-known kinds without closing the set. It is emitted because `skip-prune: true` keeps unreferenced component schemas.
- Go constants come for free from oapi-codegen (`connection.CoreKindKubernetes`, …). `x-enum-varnames` is required here because oapi-codegen only prefixes enum constants on collision, and would otherwise emit bare `Kubernetes` / `Grafana` into the package namespace.
- Add `build/generate-enums-ts.js` for the TypeScript side. `openapi-typescript` emits string enums as a type-only union that is erased at runtime, so there is no value to compare against; the generator emits a real `as const` object plus its derived type for any enum annotated with `x-ts-const`.
- Output goes to `typescript/constants/`, not `typescript/generated/` — `generate-schema-dts.js` copies the latter verbatim into `dist/` as `.d.ts`, which is only valid for type-only files. `typescript/index.ts` re-exports with `export *`, so a newly annotated enum flows through without editing it.
- Optional `x-ts-type` sets the TypeScript type name when the schema name is too generic un-scoped: Go names are qualified by their construct package (`connection.CoreKind`), while the TypeScript names are exported from the `@meshery/schemas` root (`CoreConnectionKinds` / `CoreConnectionKind`).
- Wire `generate-enums-ts` into `make build` and add `tests/generate-enums-ts.test.js` (8 tests), including a drift check that parses the enum out of `api.yml` and asserts the committed TypeScript and Go constants still match it.
- Document the annotation in `docs/schema-authoring-reference.md`.

### Verification

- `make validate-schemas` clean; `go build ./...` and `go test ./...` pass.
- `node --test tests/generate-enums-ts.test.js` — 8/8; RTK regression tests still 2/2.
- `npm run build` emits `CoreConnectionKinds` in `dist/index.js` and `CoreConnectionKind` in `dist/index.d.ts`.
- RTK client regeneration produces no diff (no new paths).

### Follow-up

A companion PR in `meshery/meshery` removes the hardcoded `CONNECTION_KINDS` map from `ui/utils/Enum.ts` and consumes `CoreConnectionKinds` from here. It needs a published `@meshery/schemas` containing this export before it can go green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added TypeScript runtime constants and union types for supported OpenAPI string enums.
  - Added core connection kind constants for GitHub, Grafana, Kubernetes, Meshery, and Prometheus.
  - Made generated constants available through the main TypeScript package entry point.

- **Documentation**
  - Documented the `x-ts-const` schema annotation and generated output behavior.

- **Tests**
  - Added validation for enum generation, naming, exports, and synchronization with API and Go definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->