### PR TITLE
fix: normalize empty credential/user UUIDs before hashing registrant identity

### DIFF
--- a/models/v1beta1/connection/connection_helper.go
+++ b/models/v1beta1/connection/connection_helper.go
@@ -16,13 +16,36 @@ import (
 var connectionCreation sync.Mutex //Each entity will perform a check and if the connection already doesn't exist, it will create a connection. This lock will make sure that there are no race conditions.
 
 func (h *Connection) GenerateID() (uuid.UUID, error) {
-	byt, err := json.Marshal(h)
+	// Normalize a copy before hashing so that a semantically-empty identity
+	// field (nil OR the zero UUID) collapses to a single canonical form. A
+	// model's registrant blob may omit credential_id/user_id (marshals to
+	// null) or carry a present-but-zero UUID (marshals to the all-zero
+	// string); both mean "no credential/user" yet previously produced
+	// different md5s, and therefore duplicate content-addressed connection
+	// rows for the same registrant. Normalization must not mutate the
+	// caller's Connection or the persisted row, so we operate on a copy and
+	// only the identity computation observes the canonical form.
+	normalized := *h
+	normalized.CredentialID = canonicalizeUUIDPtr(normalized.CredentialID)
+	normalized.UserID = canonicalizeUUIDPtr(normalized.UserID)
+
+	byt, err := json.Marshal(&normalized)
 	if err != nil {
 		return uuid.UUID{}, err
 	}
 
 	hash := md5.Sum(byt)
 	return uuid.UUID(hash), nil
+}
+
+// canonicalizeUUIDPtr reduces a semantically-empty UUID pointer to nil so that
+// an absent field and a present-but-zero UUID hash identically. A non-zero
+// UUID is returned unchanged so it still participates in identity.
+func canonicalizeUUIDPtr(id *core.Uuid) *core.Uuid {
+	if id == nil || *id == uuid.Nil {
+		return nil
+	}
+	return id
 }
 
 func (h *Connection) Create(db *database.Handler) (uuid.UUID, error) {

--- a/models/v1beta1/connection/connection_helper_test.go
+++ b/models/v1beta1/connection/connection_helper_test.go
@@ -1,0 +1,126 @@
+package connection
+
+import (
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/meshery/schemas/models/core"
+	"github.com/stretchr/testify/assert"
+)
+
+// baseConnection returns a minimal, deterministic registrant-style Connection
+// used as the fixed baseline for identity tests.
+func baseConnection() *Connection {
+	return &Connection{
+		Name:    "artifacthub",
+		Type:    "registry",
+		SubType: "",
+		Kind:    "artifacthub",
+		Status:  ConnectionStatusRegistered,
+	}
+}
+
+func uuidPtr(u core.Uuid) *core.Uuid {
+	return &u
+}
+
+// TestGenerateID_EmptyCredentialAndUserAreIdentityNeutral asserts the core fix
+// for meshery/meshery#20950: an absent (nil) identity field and a
+// present-but-zero UUID must produce the same content-addressed id, because
+// both are semantically empty.
+func TestGenerateID_EmptyCredentialAndUserAreIdentityNeutral(t *testing.T) {
+	zero := core.Uuid(uuid.Nil)
+
+	cases := []struct {
+		name         string
+		credentialID *core.Uuid
+		userID       *core.Uuid
+	}{
+		{"nil credential, nil user", nil, nil},
+		{"zero credential, nil user", uuidPtr(zero), nil},
+		{"nil credential, zero user", nil, uuidPtr(zero)},
+		{"zero credential, zero user", uuidPtr(zero), uuidPtr(zero)},
+	}
+
+	// The nil/nil variant is the canonical baseline every other empty
+	// variant must collapse onto.
+	baseline := baseConnection()
+	baselineID, err := baseline.GenerateID()
+	assert.NoError(t, err)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			conn := baseConnection()
+			conn.CredentialID = tc.credentialID
+			conn.UserID = tc.userID
+
+			got, err := conn.GenerateID()
+			assert.NoError(t, err)
+			assert.Equal(t, baselineID, got,
+				"semantically-empty credential/user must not change identity")
+		})
+	}
+}
+
+// TestGenerateID_DoesNotMutateCaller asserts normalization operates on a copy;
+// the caller's zero-UUID pointers must survive the call untouched.
+func TestGenerateID_DoesNotMutateCaller(t *testing.T) {
+	zero := core.Uuid(uuid.Nil)
+	conn := baseConnection()
+	conn.CredentialID = uuidPtr(zero)
+	conn.UserID = uuidPtr(zero)
+
+	_, err := conn.GenerateID()
+	assert.NoError(t, err)
+
+	assert.NotNil(t, conn.CredentialID, "caller's CredentialID must not be nilled")
+	assert.NotNil(t, conn.UserID, "caller's UserID must not be nilled")
+	assert.Equal(t, zero, *conn.CredentialID)
+	assert.Equal(t, zero, *conn.UserID)
+}
+
+// TestGenerateID_NonZeroCredentialParticipatesInIdentity asserts that a real,
+// non-zero credential/user still contributes to identity - only the empty case
+// is collapsed.
+func TestGenerateID_NonZeroCredentialParticipatesInIdentity(t *testing.T) {
+	nonZeroCred := core.Uuid(uuid.Must(uuid.NewV4()))
+	nonZeroUser := core.Uuid(uuid.Must(uuid.NewV4()))
+
+	emptyID, err := baseConnection().GenerateID()
+	assert.NoError(t, err)
+
+	withCred := baseConnection()
+	withCred.CredentialID = uuidPtr(nonZeroCred)
+	withCredID, err := withCred.GenerateID()
+	assert.NoError(t, err)
+	assert.NotEqual(t, emptyID, withCredID,
+		"a non-zero credential must produce a distinct identity")
+
+	withUser := baseConnection()
+	withUser.UserID = uuidPtr(nonZeroUser)
+	withUserID, err := withUser.GenerateID()
+	assert.NoError(t, err)
+	assert.NotEqual(t, emptyID, withUserID,
+		"a non-zero user must produce a distinct identity")
+
+	// Two distinct non-zero credentials must not collide.
+	assert.NotEqual(t, withCredID, withUserID)
+}
+
+// TestGenerateID_IdenticalConnectionsHashEqual is the no-regression baseline:
+// two fully-identical Connections must still hash equal.
+func TestGenerateID_IdenticalConnectionsHashEqual(t *testing.T) {
+	cred := core.Uuid(uuid.Must(uuid.NewV4()))
+
+	a := baseConnection()
+	a.CredentialID = uuidPtr(cred)
+	b := baseConnection()
+	b.CredentialID = uuidPtr(cred)
+
+	aID, err := a.GenerateID()
+	assert.NoError(t, err)
+	bID, err := b.GenerateID()
+	assert.NoError(t, err)
+
+	assert.Equal(t, aID, bID)
+}


### PR DESCRIPTION
## What

Make the content-addressed identity of a registrant `Connection` ignore `credential_id` and `user_id` when they are **semantically empty**, so an absent field and a present-but-zero UUID hash identically.

Fixes meshery/meshery#20950.

## Root cause

- **Symptom** - Two indistinguishable `connections` rows exist per registrant kind (confirmed live: two `artifacthub` registrant rows, 4517 vs 36 references), and any one-time collapse gets reintroduced on the next registration.
- **Root cause** - Registrant identity is `md5` over the whole v1beta1 `Connection`. `CredentialID` and `UserID` are `*core.Uuid`. A model's `registrant` blob that **omits** them marshals to `null`; one that carries a **present-but-zero** UUID marshals to `"00000000-0000-0000-0000-000000000000"`. Same registrant, two JSON encodings, two md5s -> two distinct content-addressed ids. The shipped `model.json` blobs are non-uniform in this respect, so every future registration re-creates both variants.
- **Fix** - In `models/v1beta1/connection/connection_helper.go`, `GenerateID()` now normalizes a **copy** of the `Connection` before hashing: a `CredentialID`/`UserID` that is `nil` **OR** the zero UUID (`uuid.Nil`) collapses to `nil`. Absent and zero now hash identically; a **non-zero** value still participates in identity unchanged. Normalization operates on a copy, so the caller's `Connection` and the persisted row's actual field values are untouched - only the identity computation sees the canonical form.
- **Watch for** - `CredentialID` and `UserID` are the only `*core.Uuid` pointer fields on `Connection` carrying the absent-vs-zero ambiguity, so they are the only two normalized. `ID` is a non-pointer `core.Uuid` (no null/zero ambiguity in marshalling) and is intentionally not touched.

This PR stops the **reintroduction** of duplicate rows at the source. It does **not** perform the separate one-time collapse/migration of already-duplicated rows (repoint `registries.registrant_id` to the surviving connection and delete siblings) - that remains needed and is out of scope here.

## Tests

Added `connection_helper_test.go` in the connection package proving:

- `CredentialID = nil` and `CredentialID = zeroUUID` produce the **same** id (same for `UserID`, and both empty together).
- A **non-zero** `CredentialID`/`UserID` produces a **different** id from the empty case, and two distinct non-zero values do not collide.
- No-regression baseline: two fully-identical Connections still hash equal.
- Normalization does not mutate the caller's `Connection` (zero-UUID pointers survive the call).

`go test ./models/v1beta1/connection/...` -> `ok`. `go vet` and `go build ./models/...` clean.

## Codegen

None. `GenerateID` is hand-written Go in `connection_helper.go` (not OpenAPI-derived); no generated Go/TS artifact regenerates from it.

## Downstream

`meshery` consumes `@meshery/schemas`. Once this publishes, **meshery must bump `@meshery/schemas`** to pick up the collapsed identity - until then it keeps generating both variants.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate connection IDs when credential or user identities are empty, whether represented as missing or zero-valued identifiers.
  * Preserved connection data while generating IDs.

* **Tests**
  * Added coverage for identity-neutral values, non-empty identities, unchanged input data, and consistent IDs for identical connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->