### PR TITLE
Add missing x-superseded-by annotations

### DIFF
--- a/schemas/constructs/v1beta1/badge/api.yml
+++ b/schemas/constructs/v1beta1/badge/api.yml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   title: Badge
   x-deprecated: true
+  x-superseded-by: v1beta2
   description: OpenAPI schema for managing badges.
   version: v1beta1
   contact:

--- a/schemas/constructs/v1beta1/credential/api.yml
+++ b/schemas/constructs/v1beta1/credential/api.yml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   title: credential
   x-deprecated: true
+  x-superseded-by: v1beta2
   description: Documentation for Meshery Cloud REST APIs for Credentials
   contact:
     name: Meshery Maintainers

--- a/schemas/constructs/v1beta1/key/api.yml
+++ b/schemas/constructs/v1beta1/key/api.yml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   title: Key
   x-deprecated: true
+  x-superseded-by: v1beta2
   description: OpenAPI schema for authorization key management in Meshery.
   version: v1beta1
   contact:

--- a/schemas/constructs/v1beta1/keychain/api.yml
+++ b/schemas/constructs/v1beta1/keychain/api.yml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   title: Keychain
   x-deprecated: true
+  x-superseded-by: v1beta2
   description: OpenAPI schema for keychain management in Meshery.
   version: v1beta1
   contact:

--- a/schemas/constructs/v1beta1/view/api.yml
+++ b/schemas/constructs/v1beta1/view/api.yml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   title: View
   x-deprecated: true
+  x-superseded-by: v1beta2
   description: OpenAPI schema for managing Meshery views — saved perspectives with filters and metadata.
   version: v1beta1
   contact:

--- a/schemas/constructs/v1beta2/event/api.yml
+++ b/schemas/constructs/v1beta2/event/api.yml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   title: Events
   x-deprecated: true
+  x-superseded-by: v1beta3
   description: OpenAPI schema for Meshery events and system notifications.
   version: v1beta2
   contact:

--- a/schemas/constructs/v1beta2/invitation/api.yml
+++ b/schemas/constructs/v1beta2/invitation/api.yml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   title: Invitation
   x-deprecated: true
+  x-superseded-by: v1beta3
   description: OpenAPI schema for managing invitations.
   version: v1beta2
   contact:

--- a/schemas/constructs/v1beta2/plan/api.yml
+++ b/schemas/constructs/v1beta2/plan/api.yml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   title: Plan
   x-deprecated: true
+  x-superseded-by: v1beta3
   description: OpenAPI schema for subscription plan management in Meshery Cloud.
   version: v1beta2
   contact:

--- a/schemas/constructs/v1beta2/subscription/api.yml
+++ b/schemas/constructs/v1beta2/subscription/api.yml
@@ -2,6 +2,7 @@ openapi: 3.0.0
 info:
   title: Subscription
   x-deprecated: true
+  x-superseded-by: v1beta3
   description: API for managing subscriptions using various payment processors in a SaaS application.
   version: v1beta2
   contact:


### PR DESCRIPTION
**Notes for Reviewers**

## Summary

This PR adds missing `x-superseded-by` annotations to deprecated schemas where newer schema versions already exist.

## Changes

- Added `x-superseded-by: v1beta2` to deprecated `v1beta1` schemas.
- Added `x-superseded-by: v1beta3` to deprecated `v1beta2` schemas.

This PR fixes #995



**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API metadata to clearly identify superseded versions.
  * v1beta1 Badge, Credential, Key, Keychain, and View specifications now point to v1beta2.
  * v1beta2 Event, Invitation, Plan, and Subscription specifications now point to v1beta3.
  * Existing deprecation indicators remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->