### PR TITLE
fix(validation): validate every non-deprecated construct version

### DIFF
--- a/schemas/constructs/v1alpha1/capability/templates/capability_template.json
+++ b/schemas/constructs/v1alpha1/capability/templates/capability_template.json
@@ -7,7 +7,7 @@
   "type": "",
   "subType": "",
   "key": "",
-  "entityState": {},
+  "entityState": [],
   "status": "enabled",
   "metadata": {}
 }

--- a/schemas/constructs/v1alpha1/capability/templates/capability_template.yaml
+++ b/schemas/constructs/v1alpha1/capability/templates/capability_template.yaml
@@ -6,7 +6,7 @@ kind: {}
 type: ''
 subType: ''
 key: ''
-entityState: {}
+entityState: []
 status: enabled
 metadata: {}
 

--- a/schemas/constructs/v1alpha2/catalog/catalog.yaml
+++ b/schemas/constructs/v1alpha2/catalog/catalog.yaml
@@ -1,4 +1,5 @@
 type: object
+additionalProperties: false
 properties:
   publishedVersion:
     description: Tracks the specific content version that has been made available in the Catalog.

--- a/schemas/constructs/v1alpha2/catalog/templates/catalog_template.json
+++ b/schemas/constructs/v1alpha2/catalog/templates/catalog_template.json
@@ -1,9 +1,9 @@
 {
   "publishedVersion": "",
-  "class": {},
-  "compatibility": {},
+  "class": "",
+  "compatibility": [],
   "patternCaveats": "",
   "patternInfo": "",
   "type": "Deployment",
-  "snapshotURL": {}
+  "snapshotURL": []
 }

--- a/schemas/constructs/v1alpha2/catalog/templates/catalog_template.yaml
+++ b/schemas/constructs/v1alpha2/catalog/templates/catalog_template.yaml
@@ -1,8 +1,8 @@
 publishedVersion: ''
-class: {}
-compatibility: {}
+class: ""
+compatibility: []
 patternCaveats: ''
 patternInfo: ''
 type: Deployment
-snapshotURL: {}
+snapshotURL: []
 

--- a/validation/audit.go
+++ b/validation/audit.go
@@ -48,7 +48,7 @@ func walkValidatedConstructSpecs(rootDir string, fn func(constructSpec) error) e
 		return versionEntries[i].Name() < versionEntries[j].Name()
 	})
 
-	latestByConstruct := make(map[string]constructSpec)
+	var specs []constructSpec
 	for _, vEntry := range versionEntries {
 		if !vEntry.IsDir() {
 			continue
@@ -97,17 +97,14 @@ func walkValidatedConstructSpecs(rootDir string, fn func(constructSpec) error) e
 				spec.Doc = doc
 			}
 
-			prev, ok := latestByConstruct[spec.Construct]
-			if !ok || compareAPIVersions(spec.Version, prev.Version) > 0 {
-				latestByConstruct[spec.Construct] = spec
-			}
+			// Validate every non-deprecated version of a construct
+			// independently. Older non-deprecated versions must not be
+			// shadowed by a newer one; only versions marked x-deprecated
+			// are skipped (see the isDeprecatedDoc check above).
+			specs = append(specs, spec)
 		}
 	}
 
-	specs := make([]constructSpec, 0, len(latestByConstruct))
-	for _, spec := range latestByConstruct {
-		specs = append(specs, spec)
-	}
 	sort.Slice(specs, func(i, j int) bool {
 		if specs[i].Construct != specs[j].Construct {
 			return specs[i].Construct < specs[j].Construct

--- a/validation/audit_test.go
+++ b/validation/audit_test.go
@@ -1,0 +1,39 @@
+package validation
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestWalkValidatedConstructSpecs_VisitsAllNonDeprecatedVersions ensures the
+// walker validates every non-deprecated version of a construct independently,
+// rather than only the highest version. An older, non-deprecated version must
+// not be shadowed by a newer one; only versions marked x-deprecated are skipped.
+func TestWalkValidatedConstructSpecs_VisitsAllNonDeprecatedVersions(t *testing.T) {
+	root := t.TempDir()
+	write := func(version, construct, body string) {
+		dir := filepath.Join(root, "schemas", "constructs", version, construct)
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "api.yml"), []byte(body), 0o644))
+	}
+	const live = "openapi: 3.0.0\ninfo:\n  title: t\n  version: 1.0.0\npaths: {}\n"
+	const deprecated = "openapi: 3.0.0\ninfo:\n  title: t\n  version: 1.0.0\n  x-deprecated: true\npaths: {}\n"
+
+	write("v1alpha1", "widget", live) // older, non-deprecated -> must be visited
+	write("v1beta1", "widget", live)  // newer, non-deprecated -> must be visited
+	write("v1alpha1", "legacy", deprecated)
+
+	visited := map[string]bool{}
+	require.NoError(t, walkValidatedConstructSpecs(root, func(s constructSpec) error {
+		visited[s.Version+"/"+s.Construct] = true
+		return nil
+	}))
+
+	assert.True(t, visited["v1alpha1/widget"], "older non-deprecated version must still be validated")
+	assert.True(t, visited["v1beta1/widget"], "newer non-deprecated version must be validated")
+	assert.False(t, visited["v1alpha1/legacy"], "deprecated version must be skipped")
+}

--- a/validation/casing.go
+++ b/validation/casing.go
@@ -15,8 +15,8 @@ import (
 // and Phase 4.A administratively closed with every legacy directory
 // carrying `info.x-deprecated: true`. The audit walker
 // (validation/audit.go::walkValidatedConstructSpecs) skips deprecated
-// specs and only processes the latest non-deprecated API version per
-// construct, so the historical lowercase-suffix names enumerated by the
+// specs and processes every non-deprecated API version of a construct,
+// so the historical lowercase-suffix names enumerated by the
 // old allowlist (`userid`, `orgid`, `workspaceid`, `pageurl`,
 // `avatarurl`, …) can no longer reach the audit on any live resource:
 // the only occurrences that remain in the source tree are inside


### PR DESCRIPTION
## Description

Fixes #1090.

`walkValidatedConstructSpecs` deduplicated construct specs to the highest version per construct, so any non-deprecated *older* version was silently excluded from every validation rule (even under `--strict-consistency --no-baseline`). This walks every non-deprecated version independently; only versions marked `x-deprecated` are skipped.

Enabling validation on the previously-uncovered `v1alpha1/capability` and `v1alpha2/catalog` specs surfaced pre-existing violations, fixed here so the suite stays green:
- template default types corrected (empty array/string instead of `{}`)
- `additionalProperties: false` added to `catalog.yaml` per the entity-schema rule

## Testing

`make validate-schemas` now reports no blocking violations (it was failing on the 5 newly-covered files). Added `TestWalkValidatedConstructSpecs`; `go test ./validation/...` passes. The generated `v1alpha2/catalog` model is unaffected (no `AdditionalProperties` field to change).

## Documentation

Updated the now-stale walker note in `casing.go`. No user-facing documentation changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Schema Updates**
  - Updated capability and catalog templates with corrected field value shapes.
  - Catalog schemas now reject unspecified properties, improving validation consistency.
  - Standardized deployment template fields such as class, compatibility, and snapshot URL.

- **Validation**
  - Validation now evaluates all non-deprecated API versions, including older versions.
  - Deprecated versions continue to be excluded from validation results.

- **Tests**
  - Added coverage confirming all non-deprecated versions are processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->