### PR TITLE
Declare 409 label conflict on createOrUpdateBadge

### DIFF
--- a/schemas/constructs/v1beta2/badge/api.yml
+++ b/schemas/constructs/v1beta2/badge/api.yml
@@ -85,6 +85,8 @@ paths:
           $ref: "#/components/responses/400"
         "401":
           $ref: "#/components/responses/401"
+        "409":
+          $ref: "#/components/responses/BadgeLabelConflict"
         "500":
           $ref: "#/components/responses/500"
 
@@ -149,6 +151,15 @@ components:
       $ref: "../../v1alpha1/core/api.yml#/components/responses/404"
     500:
       $ref: "../../v1alpha1/core/api.yml#/components/responses/500"
+    BadgeLabelConflict:
+      description: >-
+        Badge label conflict. The badge label is already owned by a different
+        organization, so the upsert was refused rather than overwriting another
+        organization's badge.
+      content:
+        text/plain:
+          schema:
+            type: string
 
   parameters:
     badgeId:

--- a/typescript/generated/v1beta2/badge/Badge.ts
+++ b/typescript/generated/v1beta2/badge/Badge.ts
@@ -264,6 +264,15 @@ export interface components {
                 "text/plain": string;
             };
         };
+        /** @description Badge label conflict. The badge label is already owned by a different organization, so the upsert was refused rather than overwriting another organization's badge. */
+        BadgeLabelConflict: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "text/plain": string;
+            };
+        };
     };
     parameters: {
         /** @description Badge ID */
@@ -534,6 +543,15 @@ export interface operations {
             };
             /** @description Expired JWT token used or insufficient privilege */
             401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "text/plain": string;
+                };
+            };
+            /** @description Badge label conflict. The badge label is already owned by a different organization, so the upsert was refused rather than overwriting another organization's badge. */
+            409: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/typescript/generated/v1beta2/badge/BadgeSchema.ts
+++ b/typescript/generated/v1beta2/badge/BadgeSchema.ts
@@ -540,6 +540,16 @@ const BadgeSchema: Record<string, unknown> = {
               }
             }
           },
+          "409": {
+            "description": "Badge label conflict. The badge label is already owned by a different organization, so the upsert was refused rather than overwriting another organization's badge.",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
           "500": {
             "description": "Internal server error",
             "content": {
@@ -879,6 +889,16 @@ const BadgeSchema: Record<string, unknown> = {
       },
       "500": {
         "description": "Internal server error",
+        "content": {
+          "text/plain": {
+            "schema": {
+              "type": "string"
+            }
+          }
+        }
+      },
+      "BadgeLabelConflict": {
+        "description": "Badge label conflict. The badge label is already owned by a different organization, so the upsert was refused rather than overwriting another organization's badge.",
         "content": {
           "text/plain": {
             "schema": {


### PR DESCRIPTION
## Symptom

`POST /api/organizations/badges` (`createOrUpdateBadge`) declared only `200`, `400`, `401` and `500`.
The server now returns `409` for a label owned by another organization, so the published contract was
behind the handler.

## Root cause

The badge upsert matched on `label` alone, unscoped by organization. Any org admin could POST an
existing label and silently rewrite another organization's public badge art and copy for every
profile on the platform. `layer5io/meshery-cloud` is landing the fix: the write is scoped by `org_id`
and a foreign-owned label is refused with `409` instead of the previous `500`.

Schema/Handler Parity is a hard contract in this ecosystem and this repo owns the contract, so the
contract catches up here rather than the server bending to the stale spec.

## Fix

- `createOrUpdateBadge` now declares `409` alongside its existing responses.
- The response reuses the same `text/plain` error shape every sibling error response on this
  operation already uses - no new error schema. It is declared as a named local response,
  `BadgeLabelConflict`, following the `AccountDeletionConflict` precedent in
  `schemas/constructs/v1beta2/user/api.yml`, because the shared core `409` carries an unrelated
  description ("Publish request already exists") and OpenAPI 3.0 ignores sibling keys next to a
  `$ref`.
- Artifacts regenerated with `make build`. No generated file was hand-edited.

## Consumer

Parity partner: **`layer5io/meshery-cloud`** - badge cross-tenant overwrite fix. This is landing in
parallel with, not after, the consumer: a live production security hole stays open until the consumer
ships, and the consumer PR declares the dependency explicitly.

## Generated output

Regeneration touched exactly two generated files, both badge-scoped and both purely additive:

- `typescript/generated/v1beta2/badge/Badge.ts`
- `typescript/generated/v1beta2/badge/BadgeSchema.ts`

Go models and the RTK Query clients are byte-identical, which is expected: neither encodes error
response codes. `node build/generate-rtk.js` was re-run on its own to confirm the no-op rather than
assume it. **No unrelated drift or churn appeared.**

## Testing

- `make validate-schemas` - no blocking violations
- `make build` - full regeneration, Go validation tests pass
- `go test ./...` - pass
- `make consumer-audit` - clean, 245 endpoints
- `npm run build` - distribution builds

## Scope

Deliberately limited to this one operation and its regeneration. No other operation gained a response
code, the badge schema was not restructured, and no unrelated drift was fixed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clear `409 Conflict` response when creating or updating a badge with a duplicate label.
  * Conflict responses now provide a plain-text explanation of the issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->