### PR TITLE
Fix CoreConnectionKinds export

### DIFF
--- a/typescript/constants/index.ts
+++ b/typescript/constants/index.ts
@@ -5,5 +5,12 @@
  * To change these values, edit the enum's `x-ts-const` schema in
  * schemas/constructs/ and re-run `make generate-enums-ts`.
  */
+import {
+  CoreConnectionKinds,
+  type CoreConnectionKind,
+} from "./v1beta3/connection";
 
-export * from "./v1beta3/connection";
+export {
+  CoreConnectionKinds,
+  type CoreConnectionKind,
+};

--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -99,10 +99,15 @@ import type * as core from "./generated/v1alpha1/core/Core";
 //
 // Includes CoreConnectionKinds - note that a connection's `kind` stays an
 // open-ended string; that enum only names the kinds with bespoke handling.
-export * from "./constants";
+import {
+  CoreConnectionKinds,
+  type CoreConnectionKind,
+} from "./constants";
 
 // Export schemas
 export {
+  CoreConnectionKinds,
+  type CoreConnectionKind,
   core,
   // v1beta1
   EnvironmentDefinitionV1Beta1OpenApiSchema,


### PR DESCRIPTION
**Notes for Reviewers**
The CoreConnectionKinds is currently imported into the meshery repository (within ui/utils/Enum.ts) for example, but it is neither defined nor accessible (was not defined from the schema generated dist).
The goal of this PR is to correct its export so that the CoreConnectionKinds will likewise be accessible when schemas are built.
This PR also adheres to the export pattern found in other schema components.

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.
 

<!--
Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined the public TypeScript exports to expose only the supported connection constants and type.
  * Reduced unintended access to other internal constants while preserving the documented connection-related exports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->