### PR TITLE
chore: ignore .superpowers/ plugin runtime state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .claude/worktrees/
 .claude/settings.local.json
 
+# Superpowers plugin runtime state
+/.superpowers/
+
 
 # api-audit local binary (built via `go build ./cmd/api-audit`)
 /api-audit


### PR DESCRIPTION
## Description

The Superpowers plugin writes per-developer runtime state into a `.superpowers/` directory at the repo root. It is not project content, but because it is untracked it leaves the working copy permanently dirty - which in turn blocks clones from refreshing (the clone this was found on had fallen 28 commits behind for exactly this reason).

`meshery-cloud` already ignores it. This repo was simply missing the rule.

**Symptom** - untracked `.superpowers/` keeps `git status` dirty forever, stalling clone refresh.
**Root cause** - no ignore rule for a known per-developer tooling path.
**Fix** - add `/.superpowers/`, grouped with the existing Claude Code local-state entries at the top of `.gitignore`.

```diff
 .claude/worktrees/
 .claude/settings.local.json
 
+# Superpowers plugin runtime state
+/.superpowers/
+
```

The pattern and comment wording match the precedent already in `meshery-cloud/.gitignore`, so the two repos stay consistent. The leading `/` anchors the rule to the repo root, matching that precedent and the directory's actual location.

Nothing under `.superpowers/` has ever been tracked (`git ls-files` and `git log -- .superpowers` are both empty), so no `git rm --cached` is required.

## Scope

Deliberately one entry. No existing lines reordered, no unrelated entries deduplicated, no speculative patterns added for tooling this repo does not use. The diff is a pure 3-line addition.

No schema, Go, or TypeScript surface is touched, so `make build` / `make validate-schemas` / `consumer-audit` outputs are unaffected by this change. No documentation update applies - this adds no behavior, contract, or workflow.

## Verification

```
$ git check-ignore -v .superpowers/x
.gitignore:7:/.superpowers/	.superpowers/x

$ git check-ignore -v .superpowers/sdd/probe        # real file, real dir
.gitignore:7:/.superpowers/	.superpowers/sdd/probe

$ git check-ignore -v .superpowers/
.gitignore:7:/.superpowers/	.superpowers/

$ git status --short                                # with .superpowers/ present on disk
 M .gitignore
```

Checked against a real `.superpowers/sdd/` tree created on disk, not just a hypothetical path - `git status` saw nothing but the intended `.gitignore` edit. The existing `.superpowers/` directory was left in place; ignoring it is the whole point.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ignore rules to exclude Superpowers plugin runtime files from version control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->