### PR TITLE
[schemas] Add DeleteModelsByRegistrant OpenAPI schema construct

### DIFF
--- a/schemas/constructs/v1beta1/registry/api.yml
+++ b/schemas/constructs/v1beta1/registry/api.yml
@@ -138,6 +138,47 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
+  /api/registry/registrants/{connectionID}/models:
+    delete:
+      x-internal: ["meshery"]
+      tags:
+        - Registry
+      operationId: deleteRegistryModelsByRegistrant
+      summary: Delete all registered models for a registrant
+      description: >-
+        Deletes all model definitions, components, relationships, and policies
+        belonging to a specific registrant connection ID.
+      parameters:
+        - name: connectionID
+          in: path
+          required: true
+          description: Connection ID of the registrant
+          schema:
+            type: string
+            format: uuid
+      responses:
+        "200":
+          description: Models successfully deleted.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  message:
+                    type: string
+                  count:
+                    type: integer
+                  connectionName:
+                    type: string
+        "400":
+          $ref: "#/components/responses/400"
+        "401":
+          $ref: "#/components/responses/401"
+        "404":
+          $ref: "#/components/responses/404"
+        "500":
+          $ref: "#/components/responses/500"
+
   /api/registry/models/{model}/components:
     get:
       x-internal: ["meshery"]

--- a/schemas/constructs/v1beta1/registry/api.yml
+++ b/schemas/constructs/v1beta1/registry/api.yml
@@ -138,7 +138,7 @@ paths:
         "500":
           $ref: "#/components/responses/500"
 
-  /api/registry/registrants/{connectionID}/models:
+  /api/registry/registrants/{connectionId}/models:
     delete:
       x-internal: ["meshery"]
       tags:
@@ -149,7 +149,7 @@ paths:
         Deletes all model definitions, components, relationships, and policies
         belonging to a specific registrant connection ID.
       parameters:
-        - name: connectionID
+        - name: connectionId
           in: path
           required: true
           description: Connection ID of the registrant
@@ -163,6 +163,10 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                  - message
+                  - count
+                  - connectionName
                 properties:
                   message:
                     type: string

--- a/schemas/constructs/v1beta1/registry/api.yml
+++ b/schemas/constructs/v1beta1/registry/api.yml
@@ -158,7 +158,7 @@ paths:
             format: uuid
       responses:
         "200":
-          description: Models successfully deleted.
+          description: Models deleted for registrant.
           content:
             application/json:
               schema:
@@ -170,10 +170,13 @@ paths:
                 properties:
                   message:
                     type: string
+                    example: Deleted 9 models for registrant "meshery"
                   count:
                     type: integer
+                    example: 9
                   connectionName:
                     type: string
+                    example: meshery
         "400":
           $ref: "#/components/responses/400"
         "401":


### PR DESCRIPTION
**Notes for Reviewers**

This PR defines the OpenAPI 3.0 schema construct for deleting all models associated with a registrant connection ID (`DELETE /api/registry/registrants/{connectionID}/models`). This enables schema-driven code generation of frontend RTK Query mutations and server endpoint definitions.
**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [✅] Yes, I signed my commits.

### Changes Made
- Added `DeleteModelsByRegistrant` operation definition under `/api/registry/registrants/{connectionID}/models` in `schemas/constructs/v1beta1/registry/api.yml`.
- Defined required path parameter `connectionID` (UUID format) and typed responses (`200 OK`, `404 Not Found`, `500 Internal Server Error`).

This PR fixes #https://github.com/meshery/meshery/issues/11025
<!--

Thank you for contributing to Meshery! 

Contributing Conventions:

1. Include descriptive PR titles with [<component-name>] prepended.
2. Build and test your changes before submitting a PR. 
3. Sign your commits

By following the community's contribution conventions upfront, the review process will 
be accelerated and your PR merged more quickly.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to delete all registered models and related components, relationships, and policies for a connection.
  * The operation returns deletion details and provides clear responses for invalid, unauthorized, missing, or server-error requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->