### PR TITLE
docs(openapi): document missing Academy 403 and 404 responses

### DIFF
--- a/schemas/constructs/v1beta2/academy/api.yml
+++ b/schemas/constructs/v1beta2/academy/api.yml
@@ -718,7 +718,11 @@ components:
     401:
       $ref: ../core/api.yml#/components/responses/401
     403:
-      $ref: ../../v1beta2/core/api.yml#/components/responses/403
+      description: The caller is not authorized to act on this resource
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'
     404:
       $ref: ../core/api.yml#/components/responses/404
     500:

--- a/schemas/constructs/v1beta2/academy/api.yml
+++ b/schemas/constructs/v1beta2/academy/api.yml
@@ -446,6 +446,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
         '500':
@@ -511,6 +513,8 @@ paths:
           description: Invalid request parameters
         '401':
           $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
         '404':
           description: Quiz not found
         '500':
@@ -585,6 +589,14 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          description: Test submission not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Server error
           content:
@@ -705,6 +717,8 @@ components:
       $ref: ../core/api.yml#/components/responses/400
     401:
       $ref: ../core/api.yml#/components/responses/401
+    403:
+      $ref: ../../v1beta2/core/api.yml#/components/responses/403
     404:
       $ref: ../core/api.yml#/components/responses/404
     500:

--- a/schemas/constructs/v1beta2/academy/api.yml
+++ b/schemas/constructs/v1beta2/academy/api.yml
@@ -516,7 +516,7 @@ paths:
         '403':
           $ref: '#/components/responses/403'
         '404':
-          description: Quiz not found
+          description: Quiz or registration not found
         '500':
           description: Server error
   /api/academy/registrations/{id}/test-sessions:

--- a/schemas/constructs/v1beta3/academy/api.yml
+++ b/schemas/constructs/v1beta3/academy/api.yml
@@ -522,7 +522,7 @@ paths:
         '403':
           $ref: '#/components/responses/403'
         '404':
-          description: Quiz not found
+          description: Quiz or registration not found
         '500':
           description: Server error
   /api/academy/registrations/{id}/test-sessions:

--- a/schemas/constructs/v1beta3/academy/api.yml
+++ b/schemas/constructs/v1beta3/academy/api.yml
@@ -734,7 +734,11 @@ components:
     401:
       $ref: ../../v1beta2/core/api.yml#/components/responses/401
     403:
-      $ref: ../../v1beta2/core/api.yml#/components/responses/403
+      description: The caller is not authorized to act on this resource
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ErrorResponse'  
     404:
       $ref: ../../v1beta2/core/api.yml#/components/responses/404
     500:

--- a/schemas/constructs/v1beta3/academy/api.yml
+++ b/schemas/constructs/v1beta3/academy/api.yml
@@ -452,6 +452,8 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
         '500':
@@ -517,6 +519,8 @@ paths:
           description: Invalid request parameters
         '401':
           $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
         '404':
           description: Quiz not found
         '500':
@@ -591,6 +595,14 @@ paths:
                 $ref: '#/components/schemas/ErrorResponse'
         '401':
           $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
+        '404':
+          description: Test submission not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ErrorResponse'
         '500':
           description: Server error
           content:
@@ -721,6 +733,8 @@ components:
       $ref: ../../v1beta2/core/api.yml#/components/responses/400
     401:
       $ref: ../../v1beta2/core/api.yml#/components/responses/401
+    403:
+      $ref: ../../v1beta2/core/api.yml#/components/responses/403
     404:
       $ref: ../../v1beta2/core/api.yml#/components/responses/404
     500:


### PR DESCRIPTION
## Summary

This PR updates the Academy OpenAPI specifications to match the documented handler behavior described in #1123.

### Changes
- Add missing `403` response to `startTestById`
- Add missing `403` response to `updateCurrentItemInProgressTracker`
- Add missing `403` and `404` responses to `submitQuiz`
- Register the shared `403` response under `components.responses`
- Apply the same updates to both `v1beta2` and `v1beta3`

Closes #1123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Academy API specifications to document `403 Forbidden` responses for progress updates, test-session starts, and quiz submissions.
  * Documented `404 Not Found` responses for quiz and registration lookups, including error details when a test submission cannot be found.
  * Added consistent authorization details and error response bodies across API versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->