### PR TITLE
[skills] iterate-pr 2.4.0: never report an unfetched PR as a clean one

### DIFF
--- a/.agents/skills/iterate-pr/SKILL.md
+++ b/.agents/skills/iterate-pr/SKILL.md
@@ -1,35 +1,123 @@
 ---
 name: iterate-pr
 description: Iterate on a PR until CI passes. Optionally merge or merge and publish a release of the repo. Automates the feedback-fix-push-wait cycle.
+argument-hint: "[--merge] [--release]"
 metadata:
   author: leecalcote
-  version: "2.0.0"
-  argument-hint: merge | merge-release
+  version: "2.4.0"
 ---
 
 # Iterate on PR Until CI Passes
+
+> **2.4.0** - `fetch_pr_feedback.py` no longer reports an empty result as a successful
+> fetch. Every path where a feedback channel could come back empty because the request
+> did not actually deliver now fails loudly, and a server-side count probe backstops any
+> path not yet known. See [Fetch Integrity](#fetch-integrity).
 
 Continuously iterate on the current branch until all CI checks pass and review feedback is addressed.
 
 **Requires**: GitHub CLI (`gh`) authenticated.
 
-**Requires**: The `uv` CLI for python package management, install guide at https://docs.astral.sh/uv/getting-started/installation/
+**Requires**: Python 3.9+.
 
-**Important**: All scripts must be run from the repository root directory (where `.git` is located), not from the skill directory. Use the full path to the script via `${HOME}/.agents/skills/iterate-pr`.
+**Important**: Run scripts from the repository root directory (where `.git` is located).
+
+### Running the Bundled Scripts
+
+Skills live in `.agents/skills/` - that is the canonical path, and the only one used in
+this document. Some repos also expose `.claude/skills` as a symlink to it, but that
+symlink is not guaranteed: it does not survive a Windows checkout with
+`core.symlinks=false`, and not every repo carries it. Always invoke via `.agents/`.
+
+Every script below accepts either runner - they only use the standard library, so no
+dependency installation is needed either way:
+
+- **Preferred**: [`uv`](https://docs.astral.sh/uv/getting-started/installation/) - `uv run <script>`. Faster startup, isolated from system Python.
+- **Fallback**: `python3 <script>` - used automatically when `uv` is not on `PATH`.
+
+Before running any script command shown in this skill, check for `uv` first and prefer it;
+fall back to `python3` only if `uv` is unavailable:
+
+```bash
+if command -v uv >/dev/null 2>&1; then
+  uv run .agents/skills/iterate-pr/scripts/<script>.py [args]
+else
+  python3 .agents/skills/iterate-pr/scripts/<script>.py [args]
+fi
+```
+
+The rest of this document shows invocations in the shorter `python3 <script>` form for
+readability - substitute `uv run` per the rule above whenever `uv` is available.
+
+### Reading Script Output - Mandatory Gate
+
+`fetch_pr_feedback.py` and `fetch_pr_checks.py` both emit a single JSON object with a
+top-level `status` field, and both exit non-zero on failure.
+
+| `status` | Meaning | What you must do |
+|---|---|---|
+| `"ok"` | The fetch completed. `summary` and `feedback`/`checks` are trustworthy. | Proceed. |
+| `"error"` | The fetch did **not** complete. `summary` and `feedback`/`checks` are `null`. | **Stop.** Surface `error` to the user. Never merge. |
+
+**Check `status` before reading any other field.** A failed lookup is not a clean PR.
+Do not pipe these scripts through anything that discards the exit status, and never infer
+"no feedback" or "checks passed" from an absent count - on failure the counts are `null`,
+not `0`, precisely so that the two cases cannot be confused.
+
+### Fetch Integrity
+
+The failure this skill guards against hardest is the *silent* one: reporting a clean PR
+because the feedback never arrived, rather than because there was none. A run that merges
+on that basis merges unreviewed code, and nothing in the output says so.
+
+`fetch_pr_feedback.py` reads three independent channels - inline review threads (GraphQL),
+PR conversation comments (REST), and review bodies (REST). Each is treated as a channel
+that must *deliver*, not merely return:
+
+- `gh` exiting non-zero is an error, never an empty channel.
+- `gh` exiting 0 while writing nothing is an error too. An undelivered response and an
+  empty one are indistinguishable downstream, so they are not allowed to look alike here.
+- A payload of unexpected shape is an error, not an absence.
+- **Count probe backstop:** if any channel does come back empty, the script asks GitHub how
+  many records that channel actually holds. If the server says there are records and the
+  fetch produced none, the script fails with the channel named and both numbers shown.
+
+The probe costs one small extra query and only runs when a channel is already empty, so a
+genuinely quiet PR reports `status: "ok"` with zero counts and no extra cost on the common
+path. A PR with real feedback can no longer report zero.
 
 ## Invocation and Modes
 
 Invoke as:
 
 - `/iterate-pr`
-- `/iterate-pr merge`
-- `/iterate-pr merge-release`
+- `/iterate-pr --merge` (alias: `full`)
+- `/iterate-pr --release`
+- `/iterate-pr --merge --release` (alias: `full-release`)
+
+In Claude Desktop, arguments are **hints**, not strict CLI parsing. Treat whatever follows `/iterate-pr` as a mode hint string.
+
+`full` and `full-release` are the positional spellings this skill used before 2.3.0 and are
+still what several callers' standing instructions say. They are exact synonyms for `--merge`
+and `--merge --release`. Both spellings are supported and must stay supported: a caller who
+types `full` is asking for an autonomous merge run, and silently giving them default mode
+means the PR they expected to be merged just sits there.
+
+### Argument Hint Interpretation (Claude Desktop)
+
+Use this deterministic precedence:
+
+1. If hints include `--release`, `full-release`, or terms like `release`, `publish`, `ship` → run **release mode**.
+2. Else if hints include `--merge`, `full`, or terms like `autonomous`, `merge` → run **merge mode**.
+3. Else run **default mode**.
+
+Do not fail because hints are missing or unrecognized; default safely.
 
 | Mode | Behavior |
 |---|---|
 | Default (`/iterate-pr`) | Iterates on CI + high/medium feedback, asks user about low-priority items, then exits without merging. |
-| `merge` | Fully autonomous: handles every non-resolved feedback item, replies to every item, re-requests review (Gemini or Copilot) after each push, iterates until no new feedback and CI is green, then merges the PR. |
-| `merge-release` | Does everything in `merge`, then cuts/publishes a release for the repository. |
+| `--merge` / `full` | Fully autonomous: handles every new feedback item and replies to each one once, re-requests review (Gemini or Copilot) after each push, iterates until no new feedback and CI is green, then administratively merges the PR without waiting for a required-approval status. |
+| `--release` / `full-release` | Does everything in `--merge`, then cuts/publishes a release for the repository. |
 
 ## Bundled Scripts
 
@@ -38,12 +126,13 @@ Invoke as:
 Fetches CI check status and extracts failure snippets from logs.
 
 ```bash
-uv run ${HOME}/.agents/skills/iterate-pr/scripts/fetch_pr_checks.py [--pr NUMBER]
+python3 .agents/skills/iterate-pr/scripts/fetch_pr_checks.py [--pr NUMBER]
 ```
 
 Returns JSON:
 ```json
 {
+  "status": "ok",
   "pr": {"number": 123, "branch": "feat/foo"},
   "summary": {"total": 5, "passed": 3, "failed": 2, "pending": 0},
   "checks": [
@@ -58,8 +147,13 @@ Returns JSON:
 Fetches and categorizes PR review feedback using the [LOGAF scale](https://develop.sentry.dev/engineering-practices/code-review/#logaf-scale).
 
 ```bash
-uv run ${HOME}/.agents/skills/iterate-pr/scripts/fetch_pr_feedback.py [--pr NUMBER]
+python3 .agents/skills/iterate-pr/scripts/fetch_pr_feedback.py [--pr NUMBER]
 ```
+
+Sources covered, all paginated: review bodies (**every** review state, not only
+`CHANGES_REQUESTED`), inline review threads, and PR conversation comments. Each is a
+channel that must deliver - see [Fetch Integrity](#fetch-integrity) - so a zero here means
+the PR really has nothing, never that a request quietly returned nothing.
 
 Returns JSON with feedback categorized as:
 - `high` - Must address before merge (`h:`, blocker, changes requested)
@@ -68,22 +162,54 @@ Returns JSON with feedback categorized as:
 - `bot` - Informational automated comments (Codecov, Dependabot, etc.)
 - `resolved` - Already resolved threads
 
-Review bot feedback (from Sentry, Warden, Cursor, Bugbot, CodeQL, etc.) appears in `high`/`medium`/`low` with `review_bot: true` — it is NOT placed in the `bot` bucket.
+Review bot feedback (CodeRabbit, Gemini Code Assist, Copilot, Sentry, Warden, Cursor,
+Bugbot, CodeQL, etc.) appears in `high`/`medium`/`low` with `review_bot: true` — it is NOT
+placed in the `bot` bucket. `REVIEW_BOT_PATTERNS` in `scripts/fetch_pr_feedback.py` owns
+the full roster; do not maintain a second copy of it here. Logins are matched with any
+trailing `[bot]` stripped, because REST reports `coderabbitai[bot]` where GraphQL reports
+`coderabbitai` for the same account; without that normalization the generic `[bot]` suffix
+rule files the fleet's main reviewer under `bot` and it gets skipped silently.
 
 Each feedback item may also include:
 - `thread_id` - GraphQL node ID for inline review comments (used for replies via `reply_to_thread.py`)
+- `replied` - the newest comment in that thread is yours, so you have already answered it
+
+Top-level fields:
+- `status` - see the mandatory gate above
+- `viewer` - the login `gh` is authenticated as
+- `summary.needs_attention` - open `high` + `medium` items, **excluding** those flagged `replied`
+- `summary.already_replied` - how many priority items were excluded on that basis
+
+**Self-authored feedback is never reported.** Comments and reviews written by the PR author
+or by `viewer` are dropped, and a thread whose newest comment is yours is flagged `replied`
+and leaves `needs_attention`. Without both rules a `--merge` run answers an item, sees its
+own answer as new feedback, and never converges.
+
+`replied` is decided per source, by the strongest evidence each one offers:
+
+| Source | `replied` when |
+|---|---|
+| Inline review thread | the newest comment in that thread is yours - exact |
+| Review body | never - a review body has no thread and no resolve button, so track in-session which you have answered |
+| PR conversation comment | never - GitHub gives these no resolution state, so track in-session which you have answered |
+
+Only the inline-thread signal is exact evidence, so it is the only one used. Anything
+weaker - "the review predates something else we said" - cannot tell answering a review
+apart from merely typing after it, and would silently dismiss a review that arrives
+mid-round. Re-reporting a review you already answered is visible to you; dropping one you
+never read is not.
 
 ### `scripts/reply_to_thread.py`
 
 Replies to PR review threads. Batches multiple replies into a single GraphQL call.
 
 ```bash
-uv run ${HOME}/.agents/skills/iterate-pr/scripts/reply_to_thread.py THREAD_ID "body" [THREAD_ID "body" ...]
+python3 .agents/skills/iterate-pr/scripts/reply_to_thread.py THREAD_ID "body" [THREAD_ID "body" ...]
 ```
 
 Arguments are alternating `(thread_id, body)` pairs. The script sends the reply body without adding signatures, attribution, or sign-off text. Example:
 ```bash
-uv run ${HOME}/.agents/skills/iterate-pr/scripts/reply_to_thread.py \
+python3 .agents/skills/iterate-pr/scripts/reply_to_thread.py \
   PRRT_abc "Fixed the null check." \
   PRRT_def "Replaced with path-segment counting."
 ```
@@ -100,11 +226,14 @@ Stop if no PR exists for the current branch.
 
 ### 2. Gather Review Feedback
 
-Run `${HOME}/.agents/skills/iterate-pr/scripts/fetch_pr_feedback.py` to get categorized feedback already posted on the PR.
+Run `python3 .agents/skills/iterate-pr/scripts/fetch_pr_feedback.py` to get categorized feedback already posted on the PR.
+
+Check `status` first. If it is not `"ok"`, stop and report the `error` — do not continue as
+though the PR had no feedback.
 
 ### 3. Handle Feedback by Priority and Mode
 
-Determine mode from invocation (`/iterate-pr`, `/iterate-pr merge`, `/iterate-pr merge-release`).
+Determine mode from invocation (`/iterate-pr`, `/iterate-pr --merge`, `/iterate-pr --release`).
 
 #### Default mode (`/iterate-pr`)
 
@@ -126,11 +255,18 @@ Which would you like to address? (e.g., "1,3" or "all" or "none")
 
 **Skip silently:**
 - `resolved` threads
+- items flagged `replied` (you already answered them; act only when a reviewer follows up)
 - `bot` comments (informational only — Codecov, Dependabot, etc.)
 
-#### Merge modes (`/iterate-pr merge`, `/iterate-pr merge-release`)
+#### Merge modes (`/iterate-pr --merge`, `/iterate-pr --merge --release`)
 
-Operate autonomously. Process every non-resolved feedback item returned by `fetch_pr_feedback.py` (`high`, `medium`, `low`, and `bot`).
+Operate autonomously. Process every **new** feedback item returned by `fetch_pr_feedback.py` (`high`, `medium`, `low`, and `bot`).
+
+An item is **new** when it is not `resolved`, not flagged `replied`, and not one you already
+answered in an earlier round of this same session. Only inline review threads carry `replied`;
+review bodies and PR conversation comments have no resolution state, so the fetcher re-returns
+them verbatim on every poll and cannot make that last distinction for you. Keep your own
+in-session record of which ones you have replied to and do not answer them twice.
 
 For each item:
 - Decide whether the feedback is justified
@@ -154,17 +290,17 @@ After processing feedback, reply to PR comments/threads to acknowledge the actio
 
 **Scope by mode:**
 - Default mode: reply to `high`/`medium`; reply to `low` only when fixed or declined by the user
-- Merge modes: reply to every non-resolved feedback item, including informational bot feedback
+- Merge modes: reply to every new feedback item, including informational bot feedback - one reply per item per session, not one per poll
 
 **How to reply:**
-- If `thread_id` exists (inline review thread), use `${HOME}/.agents/skills/iterate-pr/scripts/reply_to_thread.py`
+- If `thread_id` exists (inline review thread), use `python3 .agents/skills/iterate-pr/scripts/reply_to_thread.py`
 - If no `thread_id` exists, post a PR comment with `gh pr comment <PR_NUMBER> --body "..."`
-- In merge modes, a feedback round is incomplete until every item has a corresponding reply
+- In merge modes, a round is incomplete until every **new** item has a corresponding reply; an item you answered in an earlier round of this session already has one, so leave it alone rather than replying again
 
 Batch inline replies for a round into a single call:
 
 ```bash
-uv run ${HOME}/.agents/skills/iterate-pr/scripts/reply_to_thread.py \
+python3 .agents/skills/iterate-pr/scripts/reply_to_thread.py \
   PRRT_abc "Fixed — description of change." \
   PRRT_def "Not applicable — reason."
 ```
@@ -177,9 +313,11 @@ uv run ${HOME}/.agents/skills/iterate-pr/scripts/reply_to_thread.py \
 
 ### 4. Check CI Status
 
-Run `${HOME}/.agents/skills/iterate-pr/scripts/fetch_pr_checks.py` to get structured failure data.
+Run `python3 .agents/skills/iterate-pr/scripts/fetch_pr_checks.py` to get structured failure data.
+Check `status` first; if it is not `"ok"`, stop and report the `error` rather than treating
+the PR as green.
 
-**Wait if pending:** If review bot checks (sentry, warden, cursor, bugbot, seer, codeql) are still running, wait before proceeding—they post actionable feedback that must be evaluated. Informational bots (codecov) are not worth waiting for.
+**Wait if pending:** If review bot checks (sentry, warden, cursor, bugbot, seer, codeql, coderabbit, gemini) are still running, wait before proceeding—they post actionable feedback that must be evaluated. Informational bots (codecov) are not worth waiting for.
 
 ### 5. Fix CI Failures
 
@@ -213,22 +351,22 @@ Always add exactly one sign-off to each commit for the active authenticated GitH
 
 Poll CI status and review feedback in a loop instead of blocking:
 
-1. Run `uv run ${HOME}/.agents/skills/iterate-pr/scripts/fetch_pr_checks.py` to get current CI status
+1. Run `python3 .agents/skills/iterate-pr/scripts/fetch_pr_checks.py` to get current CI status
 2. If all checks passed → proceed to exit conditions
 3. If any checks failed (none pending) → return to step 5
 4. If checks are still pending:
-   a. Run `uv run ${HOME}/.agents/skills/iterate-pr/scripts/fetch_pr_feedback.py` for new review feedback
+   a. Run `python3 .agents/skills/iterate-pr/scripts/fetch_pr_feedback.py` for new review feedback
    b. Address feedback based on mode:
       - Default mode: new `high`/`medium`
-      - Merge modes: every new non-resolved item (`high`/`medium`/`low`/`bot`) and reply to each item
+      - Merge modes: every new item (`high`/`medium`/`low`/`bot`) and reply to each item - "new" as defined in step 3, so a review body or PR comment you already answered this session is skipped, not re-answered
    c. If changes were needed, commit and push (this restarts CI)
    d. In merge modes, after each push, explicitly re-request review:
       - Prefer Gemini review command (`/gemini review`) when available
       - Otherwise request Copilot review by commenting `@copilot review` on the PR
    e. Sleep 30 seconds (don't increase on subsequent iterations), then repeat from sub-step 1
-5. After all checks pass, do a final feedback check: `sleep 10`, then run `uv run ${HOME}/.agents/skills/iterate-pr/scripts/fetch_pr_feedback.py`.
+5. After all checks pass, do a final feedback check: `sleep 10`, then run `python3 .agents/skills/iterate-pr/scripts/fetch_pr_feedback.py`.
    - Default mode: address any new `high`/`medium` feedback; if changes are needed, return to step 6
-   - Merge modes: address any new non-resolved item; if changes are needed, return to step 6 and re-request review
+   - Merge modes: address any new item; if changes are needed, return to step 6 and re-request review
 
 ### 8. Repeat
 
@@ -236,46 +374,74 @@ If step 7 required code changes (from new feedback after CI passed), return to s
 
 In merge modes, continue looping until both conditions are true:
 - CI checks are green
-- No new non-resolved feedback is returned after the latest review request
+- No new feedback remains after the latest review request - that is, every item the fetcher
+  returned is `resolved`, flagged `replied`, or one you already answered this session. Do not
+  wait for the fetcher to return an empty list; it never will while an unresolved review body
+  or PR conversation comment exists.
 
 ### 9. Finish by Mode
 
 - Default mode: stop after success conditions are met (do not merge automatically)
-- `merge`: merge once CI is green and no new feedback remains:
+- `--merge`: once CI is green and no new feedback remains, merge administratively - do not wait for a required-approval status to clear:
 
 ```bash
-gh pr merge <PR_NUMBER> --auto --delete-branch
+gh pr merge <PR_NUMBER> --admin --delete-branch
 ```
 
-- `merge-release`: complete `merge` mode merge, then cut a release:
+`--admin` uses the authenticated account's admin/maintainer permissions to bypass the
+required-approving-review branch-protection rule; it does not bypass or skip the CI-green
+and feedback-resolved checks this skill already enforces in steps 4-7, and it never fabricates
+or requests an approving review from another account. If the command fails (e.g. the
+authenticated account lacks admin/maintainer rights on the repo, or a check can't be
+bypassed), stop and surface the `gh` error to the user - do not retry under a different
+identity and do not fall back silently.
+
+- `--release`: complete `--merge` mode merge, then cut a release.
+
+  **First check whether this repository ships its own release skill** (look for
+  `cut-release` or similar under `.agents/skills/`). If it does, use it instead of the
+  generic steps below - it knows this repo's drafter, tag and post-publish workflow
+  conventions, and the generic path does not.
+
+  Otherwise, resolve the repo from the checkout rather than hardcoding it:
+
+  ```bash
+  REPO=$(gh repo view --json nameWithOwner --jq .nameWithOwner)
+  ```
+
   1. Find the draft release tag:
      ```bash
-     gh release list --repo layer5io/meshery-cloud --json tagName,isDraft --jq '.[] | select(.isDraft) | .tagName'
+     gh release list --repo "$REPO" --json tagName,isDraft --jq '.[] | select(.isDraft) | .tagName'
      ```
   2. Review draft notes:
      ```bash
-     gh release view vX.Y.Z --repo layer5io/meshery-cloud
+     gh release view vX.Y.Z --repo "$REPO"
      ```
   3. Publish the release:
      ```bash
-     gh release edit vX.Y.Z --repo layer5io/meshery-cloud --draft=false --latest
+     gh release edit vX.Y.Z --repo "$REPO" --draft=false --latest
      ```
+
+  Publishing a GitHub release does not prove the artifact reached its registry. Verify at
+  the real surface - the package registry, the version endpoint - not the release page.
 
 ## Exit Conditions
 
 **Success (default):** All checks pass, post-CI feedback re-check is clean (no new unaddressed high/medium feedback including review bot findings), user has decided on low-priority items.
 
-**Success (`merge`):** All checks pass, no new non-resolved feedback remains after the latest review request, every feedback item has a reply, and the PR is merged.
+**Success (`--merge`):** All checks pass, no new feedback remains after the latest review request (step 8's definition - not an empty fetcher result), every new feedback item has a reply (one per item per session, not one per poll), and the PR is administratively merged (no wait on a required-approval status).
 
-**Success (`merge-release`):** `merge` success criteria are met and the draft GitHub release has been published.
+**Success (`--release`):** `--merge` success criteria are met and the draft GitHub release has been published.
 
-**Ask for help:** Same failure after 2 attempts, feedback needs clarification, infrastructure issues.
+**Ask for help:** Same failure after 2 attempts, feedback needs clarification, infrastructure issues, or `gh pr merge --admin` fails (insufficient permissions or an unbypassable check) - surface the error rather than retrying under a different identity or falling back silently.
 
-**Stop:** No PR exists, branch needs rebase.
+**Stop:** No PR exists, branch needs rebase, or either fetch script returned `status: "error"`.
+A `status: "error"` is never a success condition and never a reason to merge.
 
 ## Fallback
 
 If scripts fail, use `gh` CLI directly:
-- `gh pr checks name,state,bucket,link`
+- `gh pr checks --json name,state,bucket,link`
 - `gh run view <run-id> --log-failed`
 - `gh api repos/{owner}/{repo}/pulls/{number}/comments`
+- `gh api repos/{owner}/{repo}/pulls/{number}/reviews`

--- a/.agents/skills/iterate-pr/scripts/fetch_pr_checks.py
+++ b/.agents/skills/iterate-pr/scripts/fetch_pr_checks.py
@@ -3,15 +3,20 @@
 # requires-python = ">=3.9"
 # ///
 """
-Fetch PR CI checks and extract relevant failure snippets.
+Fetch PR CI checks and optional failure snippets.
 
 Usage:
-    python fetch_pr_checks.py [--pr PR_NUMBER]
+    uv run fetch_pr_checks.py [--pr PR_NUMBER]
+    python3 fetch_pr_checks.py [--pr PR_NUMBER]
 
 If --pr is not specified, uses the PR for the current branch.
 
-Output: JSON to stdout with structured check data.
+Output contract: a single JSON object on stdout carrying a top-level ``status``
+field, ``"ok"`` or ``"error"``. On error ``summary`` and ``checks`` are ``null``
+- never empty - so a caller reading only stdout cannot mistake a failed lookup
+for a green PR. Errors also exit non-zero.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -19,141 +24,144 @@ import json
 import re
 import subprocess
 import sys
-from typing import Any
+from typing import Any, NoReturn
+
+RUN_ID_PATTERN = re.compile(r"/actions/runs/(\d+)")
+FAILURE_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\berror[:\s]",
+        r"\bfailed[:\s]",
+        r"\bfailure[:\s]",
+        r"\btraceback\b",
+        r"\bexception\b",
+        r"\bpanic:",
+        r"\bfatal:",
+        r"\bnpm ERR!",
+        r"\bTypeError\b",
+        r"\bSyntaxError\b",
+        r"\bImportError\b",
+        r"\bModuleNotFoundError\b",
+        r"===.*FAILURES.*===",
+    )
+]
 
 
-def run_gh(args: list[str]) -> dict[str, Any] | list[Any] | None:
-    """Run a gh CLI command and return parsed JSON output."""
+def fail(message: str) -> NoReturn:
+    """Emit a machine-readable failure and exit non-zero."""
+    print(
+        json.dumps(
+            {
+                "status": "error",
+                "error": message,
+                "pr": None,
+                "summary": None,
+                "checks": None,
+                "action_required": (
+                    "STOP: CI status could not be fetched, so this PR's check state "
+                    "is unknown. Do not treat this as 'checks passed' and do not "
+                    f"merge. Cause: {message}"
+                ),
+            },
+            indent=2,
+        )
+    )
+    sys.exit(1)
+
+
+def run_gh_json(args: list[str], allowed_exit_codes: tuple[int, ...] = (0,)) -> Any:
     try:
         result = subprocess.run(
-            ["gh"] + args,
+            ["gh", *args],
             capture_output=True,
             text=True,
-            check=True,
         )
-        return json.loads(result.stdout) if result.stdout.strip() else None
-    except subprocess.CalledProcessError as e:
-        print(f"Error running gh {' '.join(args)}: {e.stderr}", file=sys.stderr)
+    except OSError as exc:
+        raise RuntimeError(f"failed to run gh CLI: {exc}") from exc
+
+    if result.returncode not in allowed_exit_codes:
+        stderr = (result.stderr or result.stdout).strip() or "unknown gh error"
+        raise RuntimeError(f"gh {' '.join(args)} failed: {stderr}")
+
+    stdout = result.stdout.strip()
+    if not stdout:
         return None
-    except json.JSONDecodeError:
-        return None
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh {' '.join(args)} returned non-JSON output") from exc
 
 
 def get_pr_info(pr_number: int | None = None) -> dict[str, Any] | None:
-    """Get PR info, optionally by number or for current branch."""
     args = ["pr", "view", "--json", "number,url,headRefName,baseRefName"]
-    if pr_number:
+    if pr_number is not None:
         args.insert(2, str(pr_number))
-    return run_gh(args)
+    result = run_gh_json(args)
+    if not isinstance(result, dict):
+        raise RuntimeError("unable to determine PR for current branch")
+    return result
 
 
 def get_checks(pr_number: int | None = None) -> list[dict[str, Any]]:
-    """Get all checks for a PR by parsing tab-separated gh output."""
-    args = ["gh", "pr", "checks"]
-    if pr_number:
-        args.append(str(pr_number))
-    try:
-        result = subprocess.run(
-            args,
-            capture_output=True,
-            text=True,
-        )
-        if not result.stdout.strip():
-            return []
-        checks = []
-        for line in result.stdout.strip().split("\n"):
-            if not line.strip():
-                continue
-            parts = line.split("\t")
-            if len(parts) >= 2:
-                checks.append({
-                    "name": parts[0].strip(),
-                    "bucket": parts[1].strip(),
-                    "link": parts[3].strip() if len(parts) > 3 else "",
-                    "workflow": "",
-                })
-        return checks
-    except Exception:
-        return []
+    args = ["pr", "checks", "--json", "name,bucket,state,link,workflow"]
+    if pr_number is not None:
+        args.insert(2, str(pr_number))
 
-
-def get_failed_runs(branch: str) -> list[dict[str, Any]]:
-    """Get recent failed workflow runs for a branch."""
-    result = run_gh([
-        "run", "list",
-        "--branch", branch,
-        "--limit", "10",
-        "--json", "databaseId,name,status,conclusion,headSha"
-    ])
+    result = run_gh_json(args, allowed_exit_codes=(0, 8))
     if not isinstance(result, list):
         return []
-    # Return runs that failed or are in progress
-    return [r for r in result if r.get("conclusion") == "failure"]
+
+    checks: list[dict[str, Any]] = []
+    for entry in result:
+        if not isinstance(entry, dict):
+            continue
+        checks.append(
+            {
+                "name": str(entry.get("name") or "unknown"),
+                "status": str(entry.get("bucket") or entry.get("state") or "unknown"),
+                "link": str(entry.get("link") or ""),
+                "workflow": str(entry.get("workflow") or ""),
+            }
+        )
+
+    checks.sort(key=lambda check: (check["name"].lower(), check["workflow"].lower(), check["status"], check["link"]))
+    return checks
+
+
+def get_run_id(check_link: str) -> int | None:
+    match = RUN_ID_PATTERN.search(check_link)
+    if not match:
+        return None
+    return int(match.group(1))
 
 
 def extract_failure_snippet(log_text: str, max_lines: int = 50) -> str:
-    """Extract relevant failure snippet from log text.
+    lines = log_text.splitlines()
+    if not lines:
+        return ""
 
-    Looks for common failure markers and extracts surrounding context.
-    """
-    lines = log_text.split("\n")
+    first_failure = None
+    for index, line in enumerate(lines):
+        if any(pattern.search(line) for pattern in FAILURE_PATTERNS):
+            first_failure = index
+            break
 
-    # Patterns that indicate failure points (case-insensitive via re.IGNORECASE)
-    failure_patterns = [
-        r"error[:\s]",
-        r"failed[:\s]",
-        r"failure[:\s]",
-        r"traceback",
-        r"exception",
-        r"assert(ion)?.*failed",
-        r"FAILED",
-        r"panic:",
-        r"fatal:",
-        r"npm ERR!",
-        r"yarn error",
-        r"ModuleNotFoundError",
-        r"ImportError",
-        r"SyntaxError",
-        r"TypeError",
-        r"ValueError",
-        r"KeyError",
-        r"AttributeError",
-        r"NameError",
-        r"IndentationError",
-        r"===.*FAILURES.*===",
-        r"___.*___",  # pytest failure separators
-    ]
-
-    combined_pattern = "|".join(failure_patterns)
-
-    # Find lines matching failure patterns
-    failure_indices = []
-    for i, line in enumerate(lines):
-        if re.search(combined_pattern, line, re.IGNORECASE):
-            failure_indices.append(i)
-
-    if not failure_indices:
-        # No clear failure point, return last N lines
+    if first_failure is None:
         return "\n".join(lines[-max_lines:])
 
-    # Extract context around first failure point
-    # Include some context before and after
-    first_failure = failure_indices[0]
     start = max(0, first_failure - 5)
-    end = min(len(lines), first_failure + max_lines - 5)
-
-    snippet_lines = lines[start:end]
-
-    # If there are more failures after our snippet, note it
-    remaining_failures = [i for i in failure_indices if i >= end]
-    if remaining_failures:
-        snippet_lines.append(f"\n... ({len(remaining_failures)} more error(s) follow)")
-
-    return "\n".join(snippet_lines)
+    end = min(len(lines), start + max_lines)
+    return "\n".join(lines[start:end])
 
 
 def get_run_logs(run_id: int) -> str | None:
-    """Get failed logs for a workflow run."""
+    """Failure logs for a run, or ``None`` when they cannot be read.
+
+    A log snippet is an enrichment, so every failure here degrades to no
+    snippet. Raising instead would abort an otherwise-complete checks fetch and
+    leave stdout empty, which is the one thing this script's contract forbids.
+    """
     try:
         result = subprocess.run(
             ["gh", "run", "view", str(run_id), "--log-failed"],
@@ -161,77 +169,66 @@ def get_run_logs(run_id: int) -> str | None:
             text=True,
             timeout=60,
         )
-        return result.stdout if result.stdout else result.stderr
-    except subprocess.TimeoutExpired:
+    except (subprocess.TimeoutExpired, OSError):
         return None
-    except subprocess.CalledProcessError:
+    if result.returncode != 0:
         return None
+    return result.stdout if result.stdout.strip() else None
 
 
-def main():
+def summarize(checks: list[dict[str, Any]]) -> dict[str, int]:
+    return {
+        "total": len(checks),
+        "passed": sum(1 for check in checks if check["status"] == "pass"),
+        "failed": sum(1 for check in checks if check["status"] == "fail"),
+        "pending": sum(1 for check in checks if check["status"] == "pending"),
+        "skipped": sum(1 for check in checks if check["status"] in {"skipping", "cancel"}),
+    }
+
+
+def main() -> None:
     parser = argparse.ArgumentParser(description="Fetch PR CI checks with failure snippets")
     parser.add_argument("--pr", type=int, help="PR number (defaults to current branch PR)")
     args = parser.parse_args()
 
-    # Get PR info
-    pr_info = get_pr_info(args.pr)
-    if not pr_info:
-        print(json.dumps({"error": "No PR found for current branch"}))
-        sys.exit(1)
+    try:
+        pr_info = get_pr_info(args.pr)
+        checks = get_checks(pr_info["number"])
+    except RuntimeError as error:
+        fail(str(error))
 
     pr_number = pr_info["number"]
     branch = pr_info["headRefName"]
 
-    # Get checks
-    checks = get_checks(pr_number)
-
-    # Process checks and add failure snippets
     processed_checks = []
-    failed_runs = None  # Lazy load
+    log_cache: dict[int, str | None] = {}
 
     for check in checks:
-        processed = {
-            "name": check.get("name", "unknown"),
-            "status": check.get("bucket", check.get("state", "unknown")),
-            "link": check.get("link", ""),
-            "workflow": check.get("workflow", ""),
-        }
+        processed = dict(check)
 
-        # For failures, try to get log snippet
         if processed["status"] == "fail":
-            if failed_runs is None:
-                failed_runs = get_failed_runs(branch)
-
-            # Find matching run by workflow name
-            workflow_name = processed["workflow"] or processed["name"]
-            matching_run = next(
-                (r for r in failed_runs if workflow_name in r.get("name", "")),
-                None
-            )
-
-            if matching_run:
-                logs = get_run_logs(matching_run["databaseId"])
+            run_id = get_run_id(processed.get("link", ""))
+            if run_id is not None:
+                processed["run_id"] = run_id
+                if run_id not in log_cache:
+                    log_cache[run_id] = get_run_logs(run_id)
+                logs = log_cache[run_id]
                 if logs:
-                    processed["log_snippet"] = extract_failure_snippet(logs)
-                    processed["run_id"] = matching_run["databaseId"]
+                    snippet = extract_failure_snippet(logs)
+                    if snippet:
+                        processed["log_snippet"] = snippet
 
         processed_checks.append(processed)
 
-    # Build output
     output = {
+        "status": "ok",
         "pr": {
             "number": pr_number,
             "url": pr_info.get("url", ""),
             "branch": branch,
             "base": pr_info.get("baseRefName", ""),
         },
-        "summary": {
-            "total": len(processed_checks),
-            "passed": sum(1 for c in processed_checks if c["status"] == "pass"),
-            "failed": sum(1 for c in processed_checks if c["status"] == "fail"),
-            "pending": sum(1 for c in processed_checks if c["status"] == "pending"),
-            "skipped": sum(1 for c in processed_checks if c["status"] in ("skipping", "cancel")),
-        },
+        "summary": summarize(processed_checks),
         "checks": processed_checks,
     }
 

--- a/.agents/skills/iterate-pr/scripts/fetch_pr_feedback.py
+++ b/.agents/skills/iterate-pr/scripts/fetch_pr_feedback.py
@@ -6,26 +6,18 @@
 Fetch and categorize PR review feedback.
 
 Usage:
-    python fetch_pr_feedback.py [--pr PR_NUMBER]
+    uv run fetch_pr_feedback.py [--pr PR_NUMBER]
+    python3 fetch_pr_feedback.py [--pr PR_NUMBER]
 
 If --pr is not specified, uses the PR for the current branch.
 
-Output: JSON to stdout with categorized feedback.
-
-Categories (using LOGAF scale - see https://develop.sentry.dev/engineering-practices/code-review/#logaf-scale):
-- high: Must address before merge (h:, blocker, changes requested)
-- medium: Should address (m:, standard feedback)
-- low: Optional suggestions (l:, nit, style)
-- bot: Informational automated comments (Codecov, Dependabot, etc.)
-- resolved: Already resolved threads
-
-Bot classification:
-- Review bots (Sentry, Warden, Cursor, Bugbot, etc.) provide actionable code
-  feedback. Their comments are categorized by content into high/medium/low with
-  a ``review_bot: true`` flag — they are NOT placed in the ``bot`` bucket.
-- Info bots (Codecov, Dependabot, Renovate, etc.) post status reports and are
-  placed in the ``bot`` bucket for silent skipping.
+Output contract: a single JSON object on stdout carrying a top-level ``status``
+field. ``status`` is ``"ok"`` when the fetch completed and ``"error"`` when it
+did not. On error the ``summary`` and ``feedback`` keys are ``null`` - never
+empty - so that "there is no feedback" and "the feedback was never fetched"
+cannot be confused by a caller reading only stdout. Errors also exit non-zero.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -33,11 +25,12 @@ import json
 import re
 import subprocess
 import sys
-from typing import Any
+from typing import Any, NoReturn
 
 
-# Bots that provide actionable code review feedback (security issues, lint
-# violations, bugs). Their comments are categorized by content, not skipped.
+# Bots whose comments are actionable code review. Matched against the login with
+# any trailing "[bot]" stripped, because the REST API reports "coderabbitai[bot]"
+# while GraphQL reports "coderabbitai" for the same account.
 REVIEW_BOT_PATTERNS = [
     r"(?i)^sentry",
     r"(?i)^warden",
@@ -48,10 +41,16 @@ REVIEW_BOT_PATTERNS = [
     r"(?i)^codex",
     r"(?i)^claude",
     r"(?i)^codeql",
+    r"(?i)^coderabbit",
+    r"(?i)^gemini-code-assist",
+    r"(?i)^greptile",
+    r"(?i)^sourcery",
+    r"(?i)^qodo",
+    r"(?i)^codium",
+    r"(?i)^ellipsis",
 ]
 
-# Bots that post informational status reports (coverage, dependency updates).
-# These are placed in the ``bot`` bucket and skipped silently.
+# Bots that post informational status reports rather than review findings.
 INFO_BOT_PATTERNS = [
     r"(?i)^codecov",
     r"(?i)^dependabot",
@@ -61,100 +60,245 @@ INFO_BOT_PATTERNS = [
     r"(?i)^semantic-release",
     r"(?i)^sonarcloud",
     r"(?i)^snyk",
+    r"(?i)^netlify",
+    r"(?i)^vercel",
     r"(?i)bot$",
     r"(?i)\[bot\]$",
 ]
 
+LOGAF_PATTERNS = [
+    (re.compile(r"^\s*(?:h:|h\s*:|high:|\[h\])", re.IGNORECASE), "high"),
+    (re.compile(r"^\s*(?:m:|m\s*:|medium:|\[m\])", re.IGNORECASE), "medium"),
+    (re.compile(r"^\s*(?:l:|l\s*:|low:|\[l\])", re.IGNORECASE), "low"),
+]
 
-def run_gh(args: list[str]) -> dict[str, Any] | list[Any] | None:
-    """Run a gh CLI command and return parsed JSON output."""
+HIGH_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"must\s+(fix|change|update|address)",
+        r"this\s+(is\s+)?(wrong|incorrect|broken|buggy)",
+        r"security\s+(issue|vulnerability|concern)",
+        r"will\s+(break|cause|fail)",
+        r"\bcritical\b",
+        r"\bblocker\b",
+    )
+]
+
+LOW_PATTERNS = [
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"nit[:\s]",
+        r"nitpick",
+        r"suggestion[:\s]",
+        r"consider\s+",
+        r"could\s+(also\s+)?",
+        r"might\s+(want\s+to|be\s+better)",
+        r"optional[:\s]",
+        r"minor[:\s]",
+        r"style[:\s]",
+        r"prefer\s+",
+        r"what\s+do\s+you\s+think",
+        r"up\s+to\s+you",
+        r"take\s+it\s+or\s+leave",
+        r"\bfwiw\b",
+    )
+]
+
+BOT_SUFFIX = re.compile(r"\[bot\]$", re.IGNORECASE)
+
+
+def fail(message: str) -> NoReturn:
+    """Emit a machine-readable failure and exit non-zero.
+
+    ``summary`` and ``feedback`` are explicitly null so a caller that reads only
+    stdout cannot mistake a failed lookup for a clean PR.
+    """
+    print(
+        json.dumps(
+            {
+                "status": "error",
+                "error": message,
+                "pr": None,
+                "summary": None,
+                "feedback": None,
+                "action_required": (
+                    "STOP: PR feedback could not be fetched, so this PR's review "
+                    "state is unknown. Do not treat this as 'no feedback' and do "
+                    f"not merge. Cause: {message}"
+                ),
+            },
+            indent=2,
+        )
+    )
+    sys.exit(1)
+
+
+def run_gh_json(args: list[str]) -> Any:
     try:
         result = subprocess.run(
-            ["gh"] + args,
+            ["gh", *args],
             capture_output=True,
             text=True,
-            check=True,
         )
-        return json.loads(result.stdout) if result.stdout.strip() else None
-    except subprocess.CalledProcessError as e:
-        print(f"Error running gh {' '.join(args)}: {e.stderr}", file=sys.stderr)
+    except OSError as exc:
+        raise RuntimeError(f"failed to run gh CLI: {exc}") from exc
+    if result.returncode != 0:
+        stderr = (result.stderr or result.stdout).strip() or "unknown gh error"
+        raise RuntimeError(f"gh {' '.join(args)} failed: {stderr}")
+
+    stdout = result.stdout.strip()
+    if not stdout:
         return None
-    except json.JSONDecodeError:
-        return None
+
+    try:
+        return json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh {' '.join(args)} returned non-JSON output") from exc
 
 
-def get_repo_info() -> tuple[str, str] | None:
-    """Get owner and repo name from current directory."""
-    result = run_gh(["repo", "view", "--json", "owner,name"])
-    if result:
-        return result.get("owner", {}).get("login"), result.get("name")
-    return None
+def run_gh_json_list(args: list[str]) -> list[dict[str, Any]]:
+    """Fetch a paginated REST list and flatten it, or raise.
+
+    Every caller of this needs a list. ``gh`` can exit 0 while writing nothing -
+    a truncated response, a proxy, a degraded endpoint - and the shape that
+    reaches us is then ``None``, not ``[]``. Returning ``[]`` for it is the
+    silent-empty inversion this whole script exists to prevent: a whole feedback
+    channel disappears and the run reports a clean PR. So anything that is not a
+    list is an error, not an absence.
+    """
+    result = run_gh_json(args)
+    if result is None:
+        raise RuntimeError(
+            f"gh {' '.join(args)} exited 0 but returned no output; "
+            "the response was not delivered, so the feedback it carries is unknown"
+        )
+    if not isinstance(result, list):
+        raise RuntimeError(
+            f"gh {' '.join(args)} returned {type(result).__name__}, expected a list of pages"
+        )
+    return flatten_pages(result)
 
 
-def get_pr_info(pr_number: int | None = None) -> dict[str, Any] | None:
-    """Get PR info, optionally by number or for current branch."""
-    args = ["pr", "view", "--json", "number,url,headRefName,author,reviews,reviewDecision"]
-    if pr_number:
+def get_repo_info() -> tuple[str, str]:
+    result = run_gh_json(["repo", "view", "--json", "owner,name"])
+    if not isinstance(result, dict):
+        raise RuntimeError("could not determine repository from current directory")
+    owner = result.get("owner", {}).get("login")
+    repo = result.get("name")
+    if not owner or not repo:
+        raise RuntimeError("could not determine repository owner/name")
+    return str(owner), str(repo)
+
+
+def get_current_user() -> str:
+    """Login of the account ``gh`` is authenticated as.
+
+    Required, not optional: without it the fetcher cannot tell the caller's own
+    replies apart from reviewer feedback, and reports them back as new work.
+    """
+    result = run_gh_json(["api", "user"])
+    if not isinstance(result, dict):
+        raise RuntimeError("could not determine the authenticated gh user")
+    login = result.get("login")
+    if not login:
+        raise RuntimeError("authenticated gh user has no login")
+    return str(login)
+
+
+def get_pr_info(pr_number: int | None = None) -> dict[str, Any]:
+    args = ["pr", "view", "--json", "number,url,headRefName,author,reviewDecision"]
+    if pr_number is not None:
         args.insert(2, str(pr_number))
-    return run_gh(args)
+    result = run_gh_json(args)
+    if not isinstance(result, dict):
+        raise RuntimeError("unable to determine PR for current branch")
+    return result
+
+
+def normalize_login(username: str) -> str:
+    """Strip the REST-only ``[bot]`` suffix so both APIs classify identically."""
+    return BOT_SUFFIX.sub("", username or "").strip()
 
 
 def is_review_bot(username: str) -> bool:
-    """Check if username matches a review bot that posts actionable feedback."""
-    return any(re.search(p, username) for p in REVIEW_BOT_PATTERNS)
+    login = normalize_login(username)
+    return any(re.search(p, login) for p in REVIEW_BOT_PATTERNS)
 
 
 def is_info_bot(username: str) -> bool:
-    """Check if username matches an informational bot (skip silently)."""
-    return any(re.search(p, username) for p in INFO_BOT_PATTERNS)
+    return any(re.search(p, username or "") for p in INFO_BOT_PATTERNS)
 
 
-def is_bot(username: str) -> bool:
-    """Check if username matches any known bot pattern."""
-    return is_review_bot(username) or is_info_bot(username)
+def flatten_pages(result: list[Any]) -> list[dict[str, Any]]:
+    """Flatten the list of pages ``gh api --paginate --slurp`` returns.
 
-
-def get_review_comments(owner: str, repo: str, pr_number: int) -> list[dict[str, Any]]:
-    """Get inline code review comments via API."""
-    result = run_gh([
-        "api",
-        f"repos/{owner}/{repo}/pulls/{pr_number}/comments",
-        "--paginate",
-    ])
-    return result if isinstance(result, list) else []
+    Shape validation belongs to ``run_gh_json_list``; by the time we get here the
+    payload is known to be a list of pages.
+    """
+    entries: list[dict[str, Any]] = []
+    for page in result:
+        if isinstance(page, list):
+            entries.extend(entry for entry in page if isinstance(entry, dict))
+        elif isinstance(page, dict):
+            entries.append(page)
+    return entries
 
 
 def get_issue_comments(owner: str, repo: str, pr_number: int) -> list[dict[str, Any]]:
-    """Get PR conversation comments (includes bot comments)."""
-    result = run_gh([
+    return run_gh_json_list([
         "api",
         f"repos/{owner}/{repo}/issues/{pr_number}/comments",
         "--paginate",
+        "--slurp",
     ])
-    return result if isinstance(result, list) else []
+
+
+def get_reviews(owner: str, repo: str, pr_number: int) -> list[dict[str, Any]]:
+    """Submitted reviews, read from REST because only REST carries ``html_url``.
+
+    ``gh pr view --json reviews`` exposes the review's GraphQL node id, while the
+    page anchor is keyed on the numeric database id, so a review body sourced
+    that way reaches the caller with no link back to the review it came from.
+    """
+    return run_gh_json_list([
+        "api",
+        f"repos/{owner}/{repo}/pulls/{pr_number}/reviews",
+        "--paginate",
+        "--slurp",
+    ])
 
 
 def get_review_threads(owner: str, repo: str, pr_number: int) -> list[dict[str, Any]]:
-    """Get review threads with resolution status via GraphQL."""
     query = """
-    query($owner: String!, $repo: String!, $pr: Int!) {
+    query($owner: String!, $repo: String!, $pr: Int!, $after: String) {
       repository(owner: $owner, name: $repo) {
         pullRequest(number: $pr) {
-          reviewThreads(first: 100) {
+          reviewThreads(first: 100, after: $after) {
+            pageInfo {
+              hasNextPage
+              endCursor
+            }
             nodes {
               id
               isResolved
               isOutdated
               path
               line
-              comments(first: 10) {
+              firstComment: comments(first: 1) {
                 nodes {
-                  id
                   body
+                  createdAt
                   author {
                     login
                   }
+                }
+              }
+              lastComment: comments(last: 1) {
+                nodes {
                   createdAt
+                  author {
+                    login
+                  }
                 }
               }
             }
@@ -163,113 +307,211 @@ def get_review_threads(owner: str, repo: str, pr_number: int) -> list[dict[str, 
       }
     }
     """
-    try:
-        result = subprocess.run(
-            [
-                "gh", "api", "graphql",
-                "-f", f"query={query}",
-                "-F", f"owner={owner}",
-                "-F", f"repo={repo}",
-                "-F", f"pr={pr_number}",
-            ],
-            capture_output=True,
-            text=True,
-            check=True,
+    threads: list[dict[str, Any]] = []
+    cursor: str | None = None
+    while True:
+        args = [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"repo={repo}",
+            "-F",
+            f"pr={pr_number}",
+        ]
+        if cursor is not None:
+            args.extend(["-F", f"after={cursor}"])
+
+        result = run_gh_json(args)
+        if not isinstance(result, dict):
+            raise RuntimeError("gh api graphql returned no review-thread payload")
+
+        pull_request = ((result.get("data") or {}).get("repository") or {}).get("pullRequest")
+        if not isinstance(pull_request, dict):
+            raise RuntimeError(
+                f"GraphQL returned no pull request {pr_number} for {owner}/{repo}"
+            )
+
+        review_threads = pull_request.get("reviewThreads") or {}
+        nodes = review_threads.get("nodes", [])
+        if isinstance(nodes, list):
+            threads.extend(nodes)
+
+        page_info = review_threads.get("pageInfo") or {}
+        if not page_info.get("hasNextPage"):
+            break
+        cursor = page_info.get("endCursor")
+        if not cursor:
+            break
+
+    return threads
+
+
+# Channel name -> the GraphQL connection on PullRequest that counts the same records.
+PROBE_CONNECTIONS = {
+    "review threads": "reviewThreads",
+    "PR conversation comments": "comments",
+    "reviews": "reviews",
+}
+
+
+def probe_counts(owner: str, repo: str, pr_number: int) -> dict[str, int]:
+    """Server-side record counts per feedback channel.
+
+    One small query, used only to sanity-check an empty channel. It asks GitHub
+    how many records it holds rather than trusting that an empty response means
+    an empty PR.
+    """
+    selections = "\n".join(
+        f"{alias}: {connection}(first: 1) {{ totalCount }}"
+        for alias, connection in enumerate_probe_aliases()
+    )
+    query = f"""
+    query($owner: String!, $repo: String!, $pr: Int!) {{
+      repository(owner: $owner, name: $repo) {{
+        pullRequest(number: $pr) {{
+          {selections}
+        }}
+      }}
+    }}
+    """
+    result = run_gh_json([
+        "api",
+        "graphql",
+        "-f",
+        f"query={query}",
+        "-F",
+        f"owner={owner}",
+        "-F",
+        f"repo={repo}",
+        "-F",
+        f"pr={pr_number}",
+    ])
+    if not isinstance(result, dict):
+        raise RuntimeError("gh api graphql returned no count-probe payload")
+
+    pull_request = ((result.get("data") or {}).get("repository") or {}).get("pullRequest")
+    if not isinstance(pull_request, dict):
+        raise RuntimeError(
+            f"count probe found no pull request {pr_number} for {owner}/{repo}"
         )
-        data = json.loads(result.stdout)
-        threads = data.get("data", {}).get("repository", {}).get("pullRequest", {}).get("reviewThreads", {}).get("nodes", [])
-        return threads
-    except (subprocess.CalledProcessError, json.JSONDecodeError):
-        return []
+
+    counts: dict[str, int] = {}
+    for channel, (alias, _connection) in zip(PROBE_CONNECTIONS, enumerate_probe_aliases()):
+        node = pull_request.get(alias)
+        total = node.get("totalCount") if isinstance(node, dict) else None
+        if not isinstance(total, int):
+            raise RuntimeError(f"count probe returned no total for {channel}")
+        counts[channel] = total
+    return counts
+
+
+def enumerate_probe_aliases() -> list[tuple[str, str]]:
+    """Stable ``(alias, connection)`` pairs for the probe query.
+
+    Aliases are positional (``c0``, ``c1``, ...) so the query never repeats a
+    field name, which GraphQL rejects when the same connection is selected twice.
+    """
+    return [(f"c{index}", connection) for index, connection in enumerate(PROBE_CONNECTIONS.values())]
+
+
+def assert_empty_channels_are_really_empty(
+    owner: str,
+    repo: str,
+    pr_number: int,
+    fetched: dict[str, list[Any]],
+) -> None:
+    """Fail loudly when a channel came back empty but GitHub says it has records.
+
+    This is the backstop for the defect class this script is built around: every
+    known silent-empty path is closed above, but a *new* one would again look
+    exactly like a clean PR. Probing only when something is already empty keeps
+    this to one extra query on the rare path and none on the common one.
+    """
+    empty = [channel for channel, records in fetched.items() if not records]
+    if not empty:
+        return
+
+    counts = probe_counts(owner, repo, pr_number)
+    missing = [
+        f"{channel} (fetched 0, GitHub reports {counts[channel]})"
+        for channel in empty
+        if counts.get(channel, 0) > 0
+    ]
+    if missing:
+        raise RuntimeError(
+            "feedback channels came back empty while GitHub reports records in them: "
+            + "; ".join(missing)
+            + ". The fetch was incomplete, so this PR's review state is unknown"
+        )
 
 
 def detect_logaf(body: str) -> str | None:
-    """Detect LOGAF scale markers in comment body.
-
-    LOGAF scale (https://develop.sentry.dev/engineering-practices/code-review/#logaf-scale):
-    - l: / [l] / low: → low priority (optional)
-    - m: / [m] / medium: → medium priority (should address)
-    - h: / [h] / high: → high priority (must address)
-
-    Returns 'high', 'medium', 'low', or None if no marker found.
-    """
-    # Check for LOGAF markers at start of comment (with optional whitespace)
-    logaf_patterns = [
-        # h: or [h] or high: patterns
-        (r"^\s*(?:h:|h\s*:|high:|\[h\])", "high"),
-        # m: or [m] or medium: patterns
-        (r"^\s*(?:m:|m\s*:|medium:|\[m\])", "medium"),
-        # l: or [l] or low: patterns
-        (r"^\s*(?:l:|l\s*:|low:|\[l\])", "low"),
-    ]
-
-    for pattern, level in logaf_patterns:
-        if re.search(pattern, body, re.IGNORECASE):
+    for pattern, level in LOGAF_PATTERNS:
+        if pattern.search(body):
             return level
-
     return None
 
 
-def categorize_comment(comment: dict[str, Any], body: str) -> str:
-    """Categorize a comment based on content and author.
-
-    Uses LOGAF scale: high (must fix), medium (should fix), low (optional).
-    """
-    author = comment.get("author", {}).get("login", "") or comment.get("user", {}).get("login", "")
-
-    # Info bots are skipped silently; review bots fall through to content
-    # categorization so their actionable feedback is not lost.
+def categorize_comment(author: str, body: str) -> str:
     if is_info_bot(author) and not is_review_bot(author):
         return "bot"
 
-    # Check for explicit LOGAF markers first
     logaf_level = detect_logaf(body)
     if logaf_level:
         return logaf_level
 
-    # Look for high-priority (blocking) indicators
-    high_patterns = [
-        r"(?i)must\s+(fix|change|update|address)",
-        r"(?i)this\s+(is\s+)?(wrong|incorrect|broken|buggy)",
-        r"(?i)security\s+(issue|vulnerability|concern)",
-        r"(?i)will\s+(break|cause|fail)",
-        r"(?i)critical",
-        r"(?i)blocker",
-    ]
-
-    for pattern in high_patterns:
-        if re.search(pattern, body):
-            return "high"
-
-    # Look for low-priority (suggestion) indicators
-    low_patterns = [
-        r"(?i)nit[:\s]",
-        r"(?i)nitpick",
-        r"(?i)suggestion[:\s]",
-        r"(?i)consider\s+",
-        r"(?i)could\s+(also\s+)?",
-        r"(?i)might\s+(want\s+to|be\s+better)",
-        r"(?i)optional[:\s]",
-        r"(?i)minor[:\s]",
-        r"(?i)style[:\s]",
-        r"(?i)prefer\s+",
-        r"(?i)what\s+do\s+you\s+think",
-        r"(?i)up\s+to\s+you",
-        r"(?i)take\s+it\s+or\s+leave",
-        r"(?i)fwiw",
-    ]
-
-    for pattern in low_patterns:
-        if re.search(pattern, body):
-            return "low"
-
-    # Default to medium for non-bot comments without clear indicators
+    if any(pattern.search(body) for pattern in HIGH_PATTERNS):
+        return "high"
+    if any(pattern.search(body) for pattern in LOW_PATTERNS):
+        return "low"
     return "medium"
+
+
+def item_sort_key(item: dict[str, Any]) -> str:
+    return item.get("_created_at", "")
+
+
+def first_node(container: Any) -> dict[str, Any]:
+    """Return the first node of a GraphQL connection, or an empty dict."""
+    nodes = container.get("nodes") if isinstance(container, dict) else None
+    if isinstance(nodes, list) and nodes and isinstance(nodes[0], dict):
+        return nodes[0]
+    return {}
+
+
+def author_login(node: Any) -> str:
+    """``author.login`` of a GraphQL node, tolerating a null ``author``.
+
+    A deleted account serializes as ``"author": null``, which an unguarded
+    ``.get("author", {}).get("login")`` turns into an AttributeError.
+    """
+    if not isinstance(node, dict):
+        return ""
+    author = node.get("author")
+    if not isinstance(author, dict):
+        return ""
+    return str(author.get("login") or "")
+
+
+def user_login(node: Any) -> str:
+    """``user.login`` of a REST node, tolerating a null ``user``."""
+    if not isinstance(node, dict):
+        return ""
+    user = node.get("user")
+    if not isinstance(user, dict):
+        return ""
+    return str(user.get("login") or "")
 
 
 def extract_feedback_item(
     body: str,
     author: str,
+    *,
+    created_at: str = "",
     path: str | None = None,
     line: int | None = None,
     url: str | None = None,
@@ -277,21 +519,21 @@ def extract_feedback_item(
     is_outdated: bool = False,
     review_bot: bool = False,
     thread_id: str | None = None,
+    replied: bool = False,
 ) -> dict[str, Any]:
-    """Create a standardized feedback item."""
-    # Truncate long bodies for summary
     summary = body[:200] + "..." if len(body) > 200 else body
     summary = summary.replace("\n", " ").strip()
 
-    item = {
+    item: dict[str, Any] = {
         "author": author,
         "body": summary,
         "full_body": body,
+        "_created_at": created_at,
     }
 
     if path:
         item["path"] = path
-    if line:
+    if line is not None:
         item["line"] = line
     if url:
         item["url"] = url
@@ -303,143 +545,171 @@ def extract_feedback_item(
         item["review_bot"] = True
     if thread_id:
         item["thread_id"] = thread_id
+    if replied:
+        item["replied"] = True
 
     return item
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Fetch and categorize PR feedback")
     parser.add_argument("--pr", type=int, help="PR number (defaults to current branch PR)")
     args = parser.parse_args()
 
-    # Get repo info
-    repo_info = get_repo_info()
-    if not repo_info:
-        print(json.dumps({"error": "Could not determine repository"}))
-        sys.exit(1)
-    owner, repo = repo_info
-
-    # Get PR info
-    pr_info = get_pr_info(args.pr)
-    if not pr_info:
-        print(json.dumps({"error": "No PR found for current branch"}))
-        sys.exit(1)
+    try:
+        owner, repo = get_repo_info()
+        viewer = get_current_user()
+        pr_info = get_pr_info(args.pr)
+    except RuntimeError as error:
+        fail(str(error))
 
     pr_number = pr_info["number"]
-    pr_author = pr_info.get("author", {}).get("login", "")
-
-    # Get review decision
+    pr_author = author_login(pr_info)
     review_decision = pr_info.get("reviewDecision", "")
 
-    # Categorized feedback using LOGAF scale
-    feedback = {
-        "high": [],      # Must address before merge
-        "medium": [],    # Should address
-        "low": [],       # Optional suggestions
+    self_logins = {
+        normalize_login(viewer).casefold(),
+        normalize_login(pr_author).casefold(),
+    } - {""}
+
+    def is_self(author: str) -> bool:
+        """What the caller wrote is not feedback for the caller."""
+        return normalize_login(author).casefold() in self_logins
+
+    feedback: dict[str, list[dict[str, Any]]] = {
+        "high": [],
+        "medium": [],
+        "low": [],
         "bot": [],
         "resolved": [],
     }
 
-    # Process reviews for overall status
-    reviews = pr_info.get("reviews", [])
-    for review in reviews:
-        if review.get("state") == "CHANGES_REQUESTED":
-            author = review.get("author", {}).get("login", "")
-            body = review.get("body", "")
-            if body and author != pr_author:
-                item = extract_feedback_item(body, author)
-                item["type"] = "changes_requested"
-                feedback["high"].append(item)
-
-    # Get review threads (inline comments with resolution status)
-    threads = get_review_threads(owner, repo, pr_number)
-    seen_thread_ids = set()
+    try:
+        threads = get_review_threads(owner, repo, pr_number)
+        issue_comments = get_issue_comments(owner, repo, pr_number)
+        reviews = get_reviews(owner, repo, pr_number)
+        assert_empty_channels_are_really_empty(
+            owner,
+            repo,
+            pr_number,
+            {
+                "review threads": threads,
+                "PR conversation comments": issue_comments,
+                "reviews": reviews,
+            },
+        )
+    except RuntimeError as error:
+        fail(str(error))
 
     for thread in threads:
-        if not thread.get("comments", {}).get("nodes"):
+        if not isinstance(thread, dict):
             continue
 
-        first_comment = thread["comments"]["nodes"][0]
-        author = first_comment.get("author", {}).get("login", "")
+        first_comment = first_node(thread.get("firstComment"))
+        author = author_login(first_comment)
         body = first_comment.get("body", "")
-
-        # Skip if author is PR author (self-comments)
-        if author == pr_author:
+        if not author or not body or is_self(author) or len(body.strip()) < 3:
             continue
 
-        # Skip empty or very short comments
-        if not body or len(body.strip()) < 3:
-            continue
-
-        is_resolved = thread.get("isResolved", False)
-        is_outdated = thread.get("isOutdated", False)
-
+        is_resolved = bool(thread.get("isResolved", False))
         thread_id = thread.get("id")
+
+        # A thread whose newest comment is ours has already been answered. Without
+        # this the caller replies, sees the same thread on the next poll, and
+        # replies again forever.
+        last_author = author_login(first_node(thread.get("lastComment")))
+        replied = bool(last_author) and is_self(last_author)
+
+        category = "resolved" if is_resolved else categorize_comment(author, body)
+
         item = extract_feedback_item(
             body=body,
             author=author,
+            created_at=str(first_comment.get("createdAt", "")),
             path=thread.get("path"),
             line=thread.get("line"),
             is_resolved=is_resolved,
-            is_outdated=is_outdated,
-            thread_id=thread_id,
+            is_outdated=bool(thread.get("isOutdated", False)),
+            thread_id=thread_id if isinstance(thread_id, str) else None,
+            review_bot=category in {"high", "medium", "low"} and is_review_bot(author),
+            replied=replied and not is_resolved,
         )
-
-        if thread_id:
-            seen_thread_ids.add(thread_id)
-
-        if is_resolved:
-            feedback["resolved"].append(item)
-        elif is_review_bot(author):
-            category = categorize_comment(first_comment, body)
-            item["review_bot"] = True
-            feedback[category].append(item)
-        elif is_info_bot(author):
-            feedback["bot"].append(item)
-        else:
-            category = categorize_comment(first_comment, body)
-            feedback[category].append(item)
-
-    # Get issue comments (general PR conversation)
-    issue_comments = get_issue_comments(owner, repo, pr_number)
+        feedback[category].append(item)
 
     for comment in issue_comments:
-        author = comment.get("user", {}).get("login", "")
+        if not isinstance(comment, dict):
+            continue
+        author = user_login(comment)
         body = comment.get("body", "")
-
-        # Skip if author is PR author
-        if author == pr_author:
+        if not author or not body or is_self(author) or len(body.strip()) < 3:
             continue
 
-        # Skip empty comments
-        if not body or len(body.strip()) < 3:
-            continue
-
+        category = categorize_comment(author, body)
         item = extract_feedback_item(
             body=body,
             author=author,
+            created_at=str(comment.get("created_at", "")),
             url=comment.get("html_url"),
+            review_bot=category in {"high", "medium", "low"} and is_review_bot(author),
         )
+        feedback[category].append(item)
 
-        if is_review_bot(author):
-            category = categorize_comment(comment, body)
-            item["review_bot"] = True
-            feedback[category].append(item)
-        elif is_info_bot(author):
-            feedback["bot"].append(item)
-        else:
-            category = categorize_comment(comment, body)
-            feedback[category].append(item)
+    # Review bodies. Bots that post their findings as one review (CodeRabbit,
+    # Copilot, Gemini) submit with state COMMENTED, so filtering on
+    # CHANGES_REQUESTED alone discards the entire finding list.
+    #
+    # A review body is never flagged `replied`. It carries no thread and no
+    # resolve button, so the only stateless signal available is "we said
+    # something later", which cannot tell answering a review apart from
+    # happening to type after it - and a review that lands mid-round would then
+    # be dismissed unread. Re-reporting an answered review is visible; dropping
+    # an unread one is not.
+    for review in reviews:
+        if not isinstance(review, dict):
+            continue
+        author = user_login(review)
+        body = review.get("body", "") or ""
+        if not author or not body.strip() or is_self(author):
+            continue
+        state = review.get("state", "")
+        changes_requested = state == "CHANGES_REQUESTED"
+        category = "high" if changes_requested else categorize_comment(author, body)
+        item = extract_feedback_item(
+            body=body,
+            author=author,
+            created_at=str(review.get("submitted_at", "")),
+            url=review.get("html_url"),
+            review_bot=category in {"high", "medium", "low"} and is_review_bot(author),
+        )
+        item["type"] = "changes_requested" if changes_requested else "review"
+        feedback[category].append(item)
 
-    # Count review bot items across priority buckets
+    for bucket in feedback.values():
+        bucket.sort(key=item_sort_key)
+        for item in bucket:
+            item.pop("_created_at", None)
+
+    priority_buckets = ("high", "medium", "low")
     review_bot_count = sum(
-        1 for bucket in ("high", "medium", "low")
+        1
+        for bucket in priority_buckets
         for item in feedback[bucket]
         if item.get("review_bot")
     )
+    already_replied = sum(
+        1
+        for bucket in priority_buckets
+        for item in feedback[bucket]
+        if item.get("replied")
+    )
 
-    # Build output
+    open_high = [item for item in feedback["high"] if not item.get("replied")]
+    open_medium = [item for item in feedback["medium"] if not item.get("replied")]
+    open_low = [item for item in feedback["low"] if not item.get("replied")]
+
     output = {
+        "status": "ok",
+        "viewer": viewer,
         "pr": {
             "number": pr_number,
             "url": pr_info.get("url", ""),
@@ -453,17 +723,17 @@ def main():
             "bot_comments": len(feedback["bot"]),
             "resolved": len(feedback["resolved"]),
             "review_bot_feedback": review_bot_count,
-            "needs_attention": len(feedback["high"]) + len(feedback["medium"]),
+            "already_replied": already_replied,
+            "needs_attention": len(open_high) + len(open_medium),
         },
         "feedback": feedback,
     }
 
-    # Add actionable summary based on LOGAF priorities
-    if feedback["high"]:
+    if open_high:
         output["action_required"] = "Address high-priority feedback before merge"
-    elif feedback["medium"]:
+    elif open_medium:
         output["action_required"] = "Address medium-priority feedback"
-    elif feedback["low"]:
+    elif open_low:
         output["action_required"] = "Review low-priority suggestions - ask user which to address"
     else:
         output["action_required"] = None


### PR DESCRIPTION
## Summary

Converges the two `iterate-pr` skill lineages into one copy at **version 2.4.0** and fixes a defect that let the skill report a PR as having no review feedback when it actually had plenty.

The skill content in this PR is **byte-identical across every repo receiving it** - meshery, meshery-cloud, meshery-extensions, meshkit, sistent, schemas. Same branch name, same four files, same SHA-256s (listed below).

## The defect

**Symptom** - `fetch_pr_feedback.py` returned `needs_attention: 0`, `action_required: null`, exit code `0`, on PRs holding real unaddressed review threads. A `--merge` run reading that output concluded "no feedback, CI green" and merged unreviewed code. Nothing in the output indicated anything had gone wrong.

**Root cause** - an *empty* response and an *undelivered* response were treated identically. In the 2.3.0 lineage, `get_review_threads()` ended its pagination loop with:

```python
result = run_gh_json(args)
if not isinstance(result, dict):
    break        # <- silently yields zero threads
```

`run_gh_json` returns `None` whenever `gh` exits 0 with empty stdout. That `break` then produced zero threads, and the script went on to assemble and print a perfectly well-formed "clean PR" summary. The REST channels carried the identical inversion through `flatten_pages`, which returned `[]` for any non-list payload.

This is the whole defect class: **absence of data was inferred from absence of a response.**

**Fix** - fixed at the transport layer, not the call sites. Each of the three feedback channels (inline review threads via GraphQL, PR conversation comments via REST, review bodies via REST) must now *deliver*, not merely return. A non-zero exit, an exit-0-with-no-output, or an unexpected payload shape is an error, never an absence. On error the script exits non-zero and emits `status: "error"` with `summary` and `feedback` explicitly `null` - never `0`, never `[]` - so a caller reading only stdout cannot mistake a failed lookup for a clean PR.

**Regression guard** - a future silent-empty path would look exactly like a clean PR all over again, so a cheap count probe backstops the whole class: when any channel comes back empty, the script asks GitHub how many records that channel actually holds, and fails with the channel named and both numbers shown if the server disagrees. It runs *only* when a channel is already empty, so a genuinely quiet PR costs no extra query and still reports `status: "ok"`.

## Evidence

Validated against six `meshery/meshery` PRs holding **20 review threads** between them. Ground truth established by direct API enumeration (`reviewThreads.totalCount` per PR).

```
OK  PR 21146  threads_found=10/10 needs_attention=5 high=1 med=4 low=2 bot=5 resolved=9 replied=0
OK  PR 21145  threads_found= 3/3  needs_attention=3 high=0 med=3 low=2 bot=3 resolved=2 replied=1
OK  PR 21168  threads_found= 2/2  needs_attention=2 high=0 med=2 low=1 bot=1 resolved=2 replied=0
OK  PR 21144  threads_found= 2/2  needs_attention=2 high=0 med=2 low=1 bot=4 resolved=2 replied=0
OK  PR 21140  threads_found= 2/2  needs_attention=3 high=0 med=3 low=1 bot=3 resolved=1 replied=0
OK  PR 21147  threads_found= 1/1  needs_attention=2 high=0 med=2 low=1 bot=1 resolved=0 replied=0
TOTAL threads_found=20/20  PASS
```

**20/20, per-PR counts exact.**

Failure modes, exercised with a stub `gh` that exits 0 but delivers nothing:

| Scenario | 2.3.0 | 2.3.1 | 2.4.0 |
|---|---|---|---|
| GraphQL delivers nothing | `status` absent, `needs_attention: 0`, **exit 0** | exits 1, `status: "error"` | exits 1, `status: "error"` |
| REST delivers nothing | drops channel silently | `status: "ok"`, channel dropped silently | exits 1, names the channel |
| REST returns well-formed but empty pages | `status: "ok"`, silent | `status: "ok"`, silent | exits 1: `PR conversation comments (fetched 0, GitHub reports 6); reviews (fetched 0, GitHub reports 25)` |

That last row is the one only the count probe can catch - the payload is valid in every structural sense.

**No false positives:** eight PRs with genuinely empty channels (#21165, #21161, #21132, #21124, #21123, #21122, #21115, #21112) all report `status: "ok"`, exit 0, no alarm.

## What each lineage contributed

The converged copy starts from **meshery-cloud's 2.3.1**, which I verified - rather than assumed - to be the proven-fix lineage: it had already closed the GraphQL silent-empty path (`break` → `raise`), introduced the `status`/null-summary output contract with its explicit "STOP, do not merge" message, added `coderabbit`/`gemini`/`greptile`/`sourcery` and friends to the review-bot roster, normalized the `[bot]` login suffix so REST's `coderabbitai[bot]` and GraphQL's `coderabbitai` classify alike, switched review bodies to REST so they carry `html_url` and are read for *every* review state rather than only `CHANGES_REQUESTED`, and added `replied` thread tracking so a merge run stops answering its own replies forever. **2.3.0 contributed no code the 2.3.1 rewrite had dropped** - I diffed both directions to confirm nothing was lost. What 2.3.0/the fleet did contribute was the requirement set the converged copy had to satisfy: the correct `.agents/` script paths (2.3.1 had these right, 2.3.0 had 11 stale `.claude/` references), repo-neutral release steps in place of 2.3.1's hardcoded `layer5io/meshery-cloud`, and the pre-2.3.0 `full` / `full-release` mode vocabulary that several callers' standing instructions still use. On top of both, this PR adds the REST-side transport fix and the count-probe guard, neither of which existed in either lineage.

## Also fixed in convergence

- **Stale script paths** - 11 references corrected from `.claude/skills/iterate-pr/scripts/` to `.agents/skills/iterate-pr/scripts/`. `.claude/skills` is a symlink in some repos, but it does not survive a Windows checkout with `core.symlinks=false`, so `.agents/` is canonical. (sistent had already fixed this independently in layer5io/sistent#1757.)
- **`full` silently did nothing** - the mode-hint precedence matched `--merge`, `merge`, `autonomous`, and `release`, but not `full`. `/iterate-pr full` therefore matched no rule and fell through to non-merging **default** mode, while the caller believed they had asked for an autonomous merge run. `full` and `full-release` are now documented and honored as exact synonyms for `--merge` and `--merge --release`.
- **Repo-specific release steps** - `gh release ...` commands no longer hardcode a repo; they resolve it from the checkout, and a repository's own release skill (e.g. meshery-cloud's `cut-release`) takes precedence when one ships.

## Scope

Content only. **Nothing outside `.agents/skills/iterate-pr/` is touched** - no `.claude/skills` symlink changes in any layout, no `skills-lock.json` changes.

```
.agents/skills/iterate-pr/SKILL.md
.agents/skills/iterate-pr/scripts/fetch_pr_feedback.py
.agents/skills/iterate-pr/scripts/fetch_pr_checks.py
```

`scripts/reply_to_thread.py` was already identical in both lineages and is unchanged.

SHA-256 of the distributed content, identical in every repo:

```
32792d46a4a2e39b5c8ac8c28695f8c0f865e591e4458646e26e32d5cc8069cc  SKILL.md
f7d9340517f4646e4cc349817a95dbd02ace0fa6b9d8ba6f52c97a7e96c0222d  scripts/fetch_pr_checks.py
01bb85b4377c461a11123be4c07cdf4f26df8c1535d984024daf2d47f47e4e0a  scripts/fetch_pr_feedback.py
a92060302b935fac3aa636a5093b31bffb50e6e5cf33fac41eeee8925a351324  scripts/reply_to_thread.py
```

## CI expectations

This diff is **tooling-only**: files under `.agents/skills/iterate-pr/`, nothing the build compiles, lints, or ships. The Python scripts are stdlib-only (verified with `python3 -m py_compile`).

Expected checks on this repo: schema validation and generation lanes. No schema, model, or generated client is touched - this PR moves the repo's skill copy from 2.0.0 straight to the converged 2.4.0.

A green result here confirms the change is inert to the build - it is not evidence about the fetcher, which is what the oracle run above is for.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expanded pull request feedback collection across review threads, comments, and reviews, including pagination.
  * Added filtering for self-authored and already-replied feedback, with improved bot recognition and review metadata.
  * Added structured check summaries and direct failure-log snippets.
  * Added merge and release workflow modes with repository-aware publishing support.

* **Bug Fixes**
  * Improved validation, error reporting, and non-zero failure handling for unavailable or malformed data.
  * Added safeguards to verify empty feedback channels and fetch integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->