### PR TITLE
fix: add avatarUrl to v1beta3 EventResult

### DIFF
--- a/models/v1beta3/event/event.go
+++ b/models/v1beta3/event/event.go
@@ -66,6 +66,9 @@ type EventResult struct {
 	// Action The action of the event.
 	Action string `json:"action" yaml:"action"`
 
+	// AvatarUrl URL to the avatar image of the user associated with the event.
+	AvatarUrl *string `json:"avatarUrl,omitempty" yaml:"avatarUrl,omitempty"`
+
 	// Category The category of the event.
 	Category string `json:"category" yaml:"category"`
 

--- a/schemas/constructs/v1beta3/event/event.yaml
+++ b/schemas/constructs/v1beta3/event/event.yaml
@@ -42,6 +42,11 @@ properties:
     type: string
     description: The last name of the user associated with the event.
     maxLength: 500
+  avatarUrl:
+    type: string
+    format: uri
+    maxLength: 500
+    description: URL to the avatar image of the user associated with the event.
   email:
     $ref: ../../v1beta2/core/api.yml#/components/schemas/Email
     description: Email address of the user associated with the event.

--- a/typescript/generated/v1beta3/event/Event.ts
+++ b/typescript/generated/v1beta3/event/Event.ts
@@ -246,6 +246,11 @@ export interface components {
             /** @description The last name of the user associated with the event. */
             lastName?: string;
             /**
+             * Format: uri
+             * @description URL to the avatar image of the user associated with the event.
+             */
+            avatarUrl?: string;
+            /**
              * Format: email
              * @description Email address of the user associated with the event.
              */
@@ -285,6 +290,11 @@ export interface components {
                 firstName?: string;
                 /** @description The last name of the user associated with the event. */
                 lastName?: string;
+                /**
+                 * Format: uri
+                 * @description URL to the avatar image of the user associated with the event.
+                 */
+                avatarUrl?: string;
                 /**
                  * Format: email
                  * @description Email address of the user associated with the event.
@@ -721,6 +731,11 @@ export interface operations {
                             /** @description The last name of the user associated with the event. */
                             lastName?: string;
                             /**
+                             * Format: uri
+                             * @description URL to the avatar image of the user associated with the event.
+                             */
+                            avatarUrl?: string;
+                            /**
                              * Format: email
                              * @description Email address of the user associated with the event.
                              */
@@ -935,6 +950,11 @@ export interface operations {
                             firstName?: string;
                             /** @description The last name of the user associated with the event. */
                             lastName?: string;
+                            /**
+                             * Format: uri
+                             * @description URL to the avatar image of the user associated with the event.
+                             */
+                            avatarUrl?: string;
                             /**
                              * Format: email
                              * @description Email address of the user associated with the event.

--- a/typescript/generated/v1beta3/event/EventSchema.ts
+++ b/typescript/generated/v1beta3/event/EventSchema.ts
@@ -583,6 +583,12 @@ const EventSchema: Record<string, unknown> = {
                             "description": "The last name of the user associated with the event.",
                             "maxLength": 500
                           },
+                          "avatarUrl": {
+                            "type": "string",
+                            "format": "uri",
+                            "maxLength": 500,
+                            "description": "URL to the avatar image of the user associated with the event."
+                          },
                           "email": {
                             "description": "Email address of the user associated with the event.",
                             "type": "string",
@@ -932,6 +938,12 @@ const EventSchema: Record<string, unknown> = {
                             "type": "string",
                             "description": "The last name of the user associated with the event.",
                             "maxLength": 500
+                          },
+                          "avatarUrl": {
+                            "type": "string",
+                            "format": "uri",
+                            "maxLength": 500,
+                            "description": "URL to the avatar image of the user associated with the event."
                           },
                           "email": {
                             "description": "Email address of the user associated with the event.",
@@ -1537,6 +1549,12 @@ const EventSchema: Record<string, unknown> = {
             "description": "The last name of the user associated with the event.",
             "maxLength": 500
           },
+          "avatarUrl": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 500,
+            "description": "URL to the avatar image of the user associated with the event."
+          },
           "email": {
             "description": "Email address of the user associated with the event.",
             "type": "string",
@@ -1649,6 +1667,12 @@ const EventSchema: Record<string, unknown> = {
                   "type": "string",
                   "description": "The last name of the user associated with the event.",
                   "maxLength": 500
+                },
+                "avatarUrl": {
+                  "type": "string",
+                  "format": "uri",
+                  "maxLength": 500,
+                  "description": "URL to the avatar image of the user associated with the event."
                 },
                 "email": {
                   "description": "Email address of the user associated with the event.",

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -11768,6 +11768,8 @@ export type GetEventsOfWorkspaceApiResponse = /** status 200 Workspace events */
     firstName?: string;
     /** The last name of the user associated with the event. */
     lastName?: string;
+    /** URL to the avatar image of the user associated with the event. */
+    avatarUrl?: string;
     /** Email address of the user associated with the event. */
     email?: string;
     /** Authentication provider of the user associated with the event. */
@@ -11836,6 +11838,8 @@ export type GetEventsApiResponse = /** status 200 Events page */ {
     firstName?: string;
     /** The last name of the user associated with the event. */
     lastName?: string;
+    /** URL to the avatar image of the user associated with the event. */
+    avatarUrl?: string;
     /** Email address of the user associated with the event. */
     email?: string;
     /** Authentication provider of the user associated with the event. */


### PR DESCRIPTION
## Notes for Reviewers

This PR fixes #1145.

### What changed

- Adds the missing optional `avatarUrl` field to the v1beta3 `EventResult` schema.
- Defines `avatarUrl` as a `string` with `format: uri`.
- Regenerates the affected Go and TypeScript models.
- Regenerates the RTK Cloud client.

### Why

Meshery Cloud emits `avatarUrl` alongside the existing joined user fields (`firstName`, `lastName`, `email`, and `provider`), but the canonical v1beta3 `EventResult` schema did not expose this field.

This caused schema consumers to maintain a local extension when rendering user avatars.

### Validation

- `make build` 
- Schema validation 
- RTK generation tests 
- `git diff --check` 

---

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**

- [x] Yes, I signed my commits.