### PR TITLE
feat(relationship): add optional via intermediary selector field

### DIFF
--- a/models/v1beta3/relationship/relationship.go
+++ b/models/v1beta3/relationship/relationship.go
@@ -379,6 +379,9 @@ type Selector struct {
 
 	// To Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.
 	To []SelectorItem `json:"to" yaml:"to"`
+
+	// Via Optional. Describes the intermediary component(s) which are involved in the relationship.
+	Via []SelectorItem `json:"via,omitempty" yaml:"via,omitempty"`
 }
 
 // SelectorItem Optional fields that are a part of the selector. Absence of a field has an implied * meaning.

--- a/schemas/constructs/v1beta3/relationship/api.yml
+++ b/schemas/constructs/v1beta3/relationship/api.yml
@@ -188,6 +188,15 @@ components:
             x-go-type: SelectorItem
           x-oapi-codegen-extra-tags:
             json: "from"
+        via:
+          description: Optional. Describes the intermediary component(s) which are involved in the relationship.
+          type: array
+          x-go-type-skip-optional-pointer: true
+          items:
+            $ref: "#/components/schemas/SelectorItem"
+            x-go-type: SelectorItem
+          x-oapi-codegen-extra-tags:
+            json: "via,omitempty"
         to:
           description: Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.
           type: array


### PR DESCRIPTION
### Description
This PR addresses meshery/meshery#10736 by introducing an optional `via` field inside the relationship selector schema definition. This enables modeling explicit intermediary components in binding relationships (for example: `from: Role` -> `via: RoleBinding` -> `to: ServiceAccount`) rather than relying on implicit behaviors.

### Changes
* **Schemas Specs:**
  * Updated OpenAPI specs in `v1beta2` and `v1beta3` `api.yml` relation definitions to include the `via` array properties.
* **Go Models:**
  * Re-generated Go types inside `models/v1beta2/relationship/` and `models/v1beta3/relationship/` to include the `Via` slice.
* **TypeScript Types:**
  * Re-generated TypeScript definitions and schemas inside `typescript/generated/` to support the new `via` property field.

### Associated Issue
This is Phase 1 of resolving [meshery/meshery#10736](https://github.com/meshery/meshery/issues/10736).

I Validated schema and generated code changes locally

https://github.com/user-attachments/assets/5377ebe4-5923-461d-b9c0-94c6e4af1589



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Selectors now support an optional `via` field for representing intermediary components.
  * The new field is available consistently across relationship API versions and JSON/YAML formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->