### PR TITLE
fix(schemas): point ComponentDefinition.Model and ModelDefinition.Registrant at canonical schema versions

### DIFF
--- a/schemas/constructs/v1beta2/component/component.yaml
+++ b/schemas/constructs/v1beta2/component/component.yaml
@@ -55,11 +55,11 @@ properties:
       yaml: format
       json: format
   model:
-    $ref: ../../v1beta1/model/api.yml#/components/schemas/ModelDefinition
-    x-go-type: '*modelv1beta1.ModelDefinition'
+    $ref: ../model/api.yml#/components/schemas/ModelDefinition
+    x-go-type: '*modelv1beta2.ModelDefinition'
     x-go-type-import:
-      path: github.com/meshery/schemas/models/v1beta1/model
-      name: modelv1beta1
+      path: github.com/meshery/schemas/models/v1beta2/model
+      name: modelv1beta2
     x-order: 7
     description: Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models
     x-oapi-codegen-extra-tags:
@@ -67,11 +67,11 @@ properties:
       json: model
       yaml: model
   modelReference:
-    $ref: ../../v1beta1/model/api.yml#/components/schemas/ModelReference
-    x-go-type: modelv1beta1.ModelReference
+    $ref: ../model/api.yml#/components/schemas/ModelReference
+    x-go-type: modelv1beta2.ModelReference
     x-go-type-import:
-      path: github.com/meshery/schemas/models/v1beta1/model
-      name: modelv1beta1
+      path: github.com/meshery/schemas/models/v1beta2/model
+      name: modelv1beta2
     x-order: 8
     description: Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models
     x-oapi-codegen-extra-tags:

--- a/schemas/constructs/v1beta2/model/model.yaml
+++ b/schemas/constructs/v1beta2/model/model.yaml
@@ -79,11 +79,11 @@ properties:
       json: registrant
       gorm: foreignKey:RegistrantId;references:ID
     x-order: 8
-    x-go-type: connectionv1beta1.Connection
+    x-go-type: connectionv1beta3.Connection
     x-go-type-import:
-      path: github.com/meshery/schemas/models/v1beta1/connection
-      name: connectionv1beta1
-    $ref: ../../v1beta1/connection/api.yml#/components/schemas/Connection
+      path: github.com/meshery/schemas/models/v1beta3/connection
+      name: connectionv1beta3
+    $ref: ../../v1beta3/connection/api.yml#/components/schemas/Connection
   registrantId:
     description: ID of the registrant.
     $ref: ../core/api.yml#/components/schemas/Uuid

--- a/schemas/constructs/v1beta3/component/component.yaml
+++ b/schemas/constructs/v1beta3/component/component.yaml
@@ -55,11 +55,11 @@ properties:
       yaml: format
       json: format
   model:
-    $ref: ../../v1beta1/model/api.yml#/components/schemas/ModelDefinition
-    x-go-type: '*modelv1beta1.ModelDefinition'
+    $ref: ../../v1beta2/model/api.yml#/components/schemas/ModelDefinition
+    x-go-type: '*modelv1beta2.ModelDefinition'
     x-go-type-import:
-      path: github.com/meshery/schemas/models/v1beta1/model
-      name: modelv1beta1
+      path: github.com/meshery/schemas/models/v1beta2/model
+      name: modelv1beta2
     x-order: 7
     description: Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models
     x-oapi-codegen-extra-tags:
@@ -67,11 +67,11 @@ properties:
       json: model
       yaml: model
   modelReference:
-    $ref: ../../v1beta1/model/api.yml#/components/schemas/ModelReference
-    x-go-type: modelv1beta1.ModelReference
+    $ref: ../../v1beta2/model/api.yml#/components/schemas/ModelReference
+    x-go-type: modelv1beta2.ModelReference
     x-go-type-import:
-      path: github.com/meshery/schemas/models/v1beta1/model
-      name: modelv1beta1
+      path: github.com/meshery/schemas/models/v1beta2/model
+      name: modelv1beta2
     x-order: 8
     description: Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models
     x-oapi-codegen-extra-tags:


### PR DESCRIPTION
## What this fixes

`ComponentDefinition.Model`/`ModelReference` and `ModelDefinition.Registrant` were referencing stale, older schema versions instead of the latest ones that already exist in this repo, causing mismatched embedded types across schema versions.

- `schemas/constructs/v1beta2/component/component.yaml` — `model` and `modelReference` referenced `v1beta1/model`, even though `v1beta2/model/model.yaml` already exists. Updated both `$ref` targets and their `x-go-type`/`x-go-type-import` annotations to point at `v1beta2/model`.
- `schemas/constructs/v1beta3/component/component.yaml` — same issue: `model` and `modelReference` still referenced `v1beta1/model` instead of the latest existing model schema (`v1beta2/model`). Updated accordingly.
- `schemas/constructs/v1beta2/model/model.yaml` — `registrant` referenced `v1beta1/connection` instead of the latest existing connection schema (`v1beta3/connection`). Updated the `$ref` and Go type annotations.

No database migration is required — only `$ref` targets and their associated `x-go-type`/`x-go-type-import` annotations changed. `gorm` tags and DB-facing column names were left untouched.

## Acceptance criteria

- [x] `ModelDefinition.Registrant` references the canonical connection schema version
- [x] `ComponentDefinition.Model` references the canonical model schema version in all component versions
- [ ] `ComponentSchemaVersion` constant correctly reflects the actual component schema version — see note below
- [x] No database migration required

## Note on `ComponentSchemaVersion` (out of scope for this PR)

While investigating, I found `models/v1beta3/const.go` declares `ComponentSchemaVersion = "components.meshery.io/v1beta2"`, with an explicit comment stating this is intentional: it mirrors the current Go import graph, since `v1beta3/design.PatternFile.Components` still imports `v1beta2/component`, not `v1beta3/component`.

Correcting this constant would require also updating the `v1beta3/design` construct's Go imports to reference `v1beta3/component`, which is a larger, separate change outside the scope of this fix. Flagging it here for a maintainer to weigh in on whether it warrants its own issue.

Refs meshery/meshery#21398

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated component definitions to use the appropriate model schema versions for more consistent validation and compatibility.
  * Updated model registrant definitions to use the current connection schema version.
  * Applied these schema alignment updates across the v1beta2 and v1beta3 APIs.
  * Existing required fields remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->