### PR TITLE
Document canonical relationship kind/type/subType on v1beta3 schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -174,6 +174,7 @@ Long-form reference material lives in `docs/` to keep this file concise. Consult
 - **[`docs/release-procedure.md`](docs/release-procedure.md)** - full release flow, What NOT to Do, and versioning policy.
 - **[`docs/release-procedure-skill.md`](docs/release-procedure-skill.md)** - using the `meshery-schemas-release` skill, verification commands, troubleshooting.
 - **[`docs/relationship-evaluation-engine-contract.md`](docs/relationship-evaluation-engine-contract.md)** - the authoritative relationship-evaluation wire contract for downstream evaluators.
+- **[`docs/relationship-definition-taxonomy.md`](docs/relationship-definition-taxonomy.md)** - canonical kind/type/subType combinations and mutator vs mutated patch paths for relationship definitions.
 
 ## Questions?
 

--- a/docs/relationship-definition-taxonomy.md
+++ b/docs/relationship-definition-taxonomy.md
@@ -1,0 +1,45 @@
+# Relationship definition taxonomy
+
+Canonical `kind` / `type` / `subType` combinations for Meshery relationship definitions. The schema is `schemas/constructs/v1beta3/relationship/` (`relationships.meshery.io/v1beta3`).
+
+`kind` is an enum: `hierarchical` | `edge` | `sibling`. `type` and `subType` are **open strings**. Do not enum-lock them; copy an established combination. A new `subType` needs a visual paradigm and usually an OPA `evaluationQuery`.
+
+Contributor skill and pedagogical JSON: `meshery/meshery` `.agents/skills/gen-relationship/`. Human docs: https://docs.meshery.io/concepts/logical/relationships and https://docs.meshery.io/project/contributing/contributing-relationships.
+
+## Canonical combinations
+
+| kind | type | subType | Meaning |
+|---|---|---|---|
+| `edge` | `non-binding` | `reference` | Logical name/id pointer (Deployment → ConfigMap) |
+| `edge` | `non-binding` | `network` | Documented L3/L4/L7 selection (Service → Deployment) |
+| `edge` | `non-binding` | `firewall` | Policy that allows or denies traffic (NetworkPolicy → Pod) |
+| `edge` | `non-binding` | `permission` | Mentions a role or identity without binding it |
+| `edge` | `non-binding` | `alias` | Named stand-in, not nested ownership |
+| `edge` | `non-binding` | `annotation` | Designer-only line; `metadata.isAnnotation: true`; no patch |
+| `edge` | `non-binding` | `inventory` | Rare peer index; prefer hierarchical parent inventory for containment |
+| `edge` | `binding` | `permission` | Assigns identities (Role → ServiceAccount) |
+| `edge` | `binding` | `mount` | Storage or device attachment (PVC → Pod) |
+| `edge` | `binding` | `network` | Connecting provisions or rewrites network identity (rare) |
+| `hierarchical` | `parent` | `inventory` | Parent contains/scopes children; parent identity patched onto child |
+| `hierarchical` | `parent` | `alias` | Child is a nested object inside the parent (Container → Pod) |
+| `hierarchical` | `parent` | `wallet` | Child configuration is held/patched into the parent (WASMFilter → EnvoyFilter) |
+| `hierarchical` | `sibling` | `matchlabels` | **In-tree tagsets encoding.** Shared labels; no patch |
+| `sibling` | `matchlabels` | `tagsets` | **Schema-native tagsets.** Do not mix with the in-tree encoding in one model |
+
+`badge` is a visual-paradigm name only. There is no in-tree `kind`/`type`/`subType` encoding. Do not invent `subType: badge` without a visualization and evaluation policy.
+
+## Hierarchical from / to
+
+`from` is the child. `to` is the parent.
+
+| subType | Data flow |
+|---|---|
+| `inventory` | Parent **mutates** the child |
+| `alias` | Child **mutates** the parent |
+| `wallet` | Child **mutates** the parent |
+
+## Actions
+
+`mutatorRef` is the **source** (value to read). `mutatedRef` is the **sink** (field to patch). Both are `string[][]`. Sequence lengths must match: index `i` of `mutatorRef` copies onto index `i` of `mutatedRef`.
+
+Omit `patch` when the relationship only matches (tagsets, annotation).

--- a/models/v1beta3/relationship/relationship.go
+++ b/models/v1beta3/relationship/relationship.go
@@ -149,17 +149,31 @@ type MatchSelectorItem struct {
 	ID *core.Uuid `json:"id" yaml:"id,omitempty"`
 
 	// Kind Kind of the resource.
-	Kind       string      `json:"kind" yaml:"kind"`
+	Kind string `json:"kind" yaml:"kind"`
+
+	// MutatedRef Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+	//
+	// mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
 	MutatedRef *MutatedRef `json:"mutatedRef,omitempty" yaml:"mutatedRef,omitempty"`
 
-	// MutatorRef JSON ref to value from where patch should be applied.
+	// MutatorRef Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+	//
+	// The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+	//
+	// Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
 	MutatorRef *MutatorRef `json:"mutatorRef,omitempty" yaml:"mutatorRef,omitempty"`
 }
 
-// MutatedRef defines model for MutatedRef.
+// MutatedRef Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+//
+// mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
 type MutatedRef = [][]string
 
-// MutatorRef JSON ref to value from where patch should be applied.
+// MutatorRef Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+//
+// The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+//
+// Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
 type MutatorRef = [][]string
 
 // RelationshipDefinition Relationships define the nature of interaction between interconnected components in Meshery. The combination of relationship properties kind, type, and subtype characterize various genealogical relations among and between components. Relationships have selectors, selector sets, metadata, and optional parameters. Learn more at https://docs.meshery.io/concepts/logical/relationships.
@@ -173,7 +187,13 @@ type RelationshipDefinition struct {
 	// EvaluationQuery Optional. Assigns the policy to be used for the evaluation of the relationship. Deprecation Notice: In the future, this property is either to be removed or to it is to be an array of optional policy $refs.
 	EvaluationQuery *string `json:"evaluationQuery" yaml:"evaluationQuery"`
 
-	// Kind Kind of the Relationship. Learn more about relationships - https://docs.meshery.io/concepts/logical/relationships.
+	// Kind Kind of the Relationship. Enum: hierarchical, edge, sibling.
+	//
+	// hierarchical: parent-child containment, nesting, or inheritance. from is the child; to is the parent.
+	// edge: a connection between peers (network, mount, permission, reference, and similar).
+	// sibling: schema-native encoding for peer grouping such as tagsets. In-tree Kubernetes models instead encode tagsets as kind=hierarchical, type=sibling, subType=matchlabels. Do not mix the two encodings in one model.
+	//
+	// Learn more at https://docs.meshery.io/concepts/logical/relationships.
 	Kind RelationshipDefinitionKind `json:"kind" yaml:"kind"`
 
 	// RelationshipMetadata Metadata contains additional information associated with the Relationship.
@@ -191,20 +211,34 @@ type RelationshipDefinition struct {
 	// Selectors Selectors are organized as an array, with each item containing a distinct set of selectors that share a common functionality. This structure allows for flexibility in defining relationships, even when different components are involved.
 	Selectors *SelectorSet `gorm:"type:bytes;serializer:json" json:"selectors,omitempty" yaml:"selectors,omitempty"`
 
-	// SubType Most granular unit of relationship classification. The combination of Kind, Type and SubType together uniquely identify a Relationship.
+	// SubType Most granular unit of relationship classification. Open string. Combined with kind and type, uniquely identifies the visual paradigm.
+	//
+	// Canonical values: inventory, alias, wallet, matchlabels, tagsets, reference, network, firewall, permission, mount, annotation.
+	//
+	// badge is a visual-paradigm name only; there is no in-tree encoding. Do not invent subType=badge without a visualization and evaluation policy. See docs/relationship-definition-taxonomy.md.
 	SubType string `json:"subType" yaml:"subType"`
 
 	// Status Status of the relationship.
 	Status *RelationshipDefinitionStatus `json:"status" yaml:"status"`
 
-	// RelationshipType Classification of relationships. Used to group relationships similar in nature.
+	// RelationshipType Classification of relationships. Open string (not an enum). Used with kind and subType to select the visual paradigm and evaluation policy.
+	//
+	// Canonical values: parent (with kind=hierarchical); binding (assigns, mounts, or entitles); non-binding (real link that does not provision the attachment); sibling (in-tree tagsets with kind=hierarchical); matchlabels (schema-native tagsets with kind=sibling).
+	//
+	// Copy an established kind/type/subType combination rather than inventing a type. See docs/relationship-definition-taxonomy.md.
 	RelationshipType string `gorm:"column:type" json:"type" yaml:"type"`
 
 	// Version A valid semantic version string between 5 and 100 characters. The pattern allows for a major.minor.patch version followed by an optional pre-release tag like '-alpha' or '-beta.2' and an optional build metadata tag like '+build.1'.
 	Version core.SemverString `json:"version" yaml:"version"`
 }
 
-// RelationshipDefinitionKind Kind of the Relationship. Learn more about relationships - https://docs.meshery.io/concepts/logical/relationships.
+// RelationshipDefinitionKind Kind of the Relationship. Enum: hierarchical, edge, sibling.
+//
+// hierarchical: parent-child containment, nesting, or inheritance. from is the child; to is the parent.
+// edge: a connection between peers (network, mount, permission, reference, and similar).
+// sibling: schema-native encoding for peer grouping such as tagsets. In-tree Kubernetes models instead encode tagsets as kind=hierarchical, type=sibling, subType=matchlabels. Do not mix the two encodings in one model.
+//
+// Learn more at https://docs.meshery.io/concepts/logical/relationships.
 type RelationshipDefinitionKind string
 
 // RelationshipDefinitionStatus Status of the relationship.
@@ -330,11 +364,18 @@ type RelationshipDefinitionMetadataStylesTargetArrowShape string
 // RelationshipDefinitionMetadataStylesTextTransform A transformation to apply to the label text
 type RelationshipDefinitionMetadataStylesTextTransform string
 
-// RelationshipDefinitionSelectorsPatch Patch configuration for the selector
+// RelationshipDefinitionSelectorsPatch Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.
 type RelationshipDefinitionSelectorsPatch struct {
+	// MutatedRef Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+	//
+	// mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
 	MutatedRef *MutatedRef `json:"mutatedRef,omitempty" yaml:"mutatedRef,omitempty"`
 
-	// MutatorRef JSON ref to value from where patch should be applied.
+	// MutatorRef Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+	//
+	// The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+	//
+	// Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
 	MutatorRef *MutatorRef `json:"mutatorRef,omitempty" yaml:"mutatorRef,omitempty"`
 
 	// PatchStrategy patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -377,10 +418,10 @@ type RelationshipMetadata struct {
 
 // Selector Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.
 type Selector struct {
-	// From Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.
+	// From Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many).
 	From []SelectorItem `json:"from" yaml:"from"`
 
-	// To Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.
+	// To Destination side of the selector. For kind=hierarchical, to is the parent.
 	To []SelectorItem `json:"to" yaml:"to"`
 }
 
@@ -401,7 +442,7 @@ type SelectorItem struct {
 	// Model Reference to the specific registered model to which the component belongs and from which model version, category, and other properties may be referenced. Learn more at https://docs.meshery.io/concepts/models
 	Model *modelv1beta1.ModelReference `json:"model,omitempty" yaml:"model,omitempty"`
 
-	// RelationshipDefinitionSelectorsPatch Patch configuration for the selector
+	// RelationshipDefinitionSelectorsPatch Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.
 	RelationshipDefinitionSelectorsPatch *RelationshipDefinitionSelectorsPatch `json:"patch" yaml:"patch,omitempty"`
 }
 

--- a/schemas/constructs/v1beta3/relationship/api.yml
+++ b/schemas/constructs/v1beta3/relationship/api.yml
@@ -22,6 +22,8 @@ components:
       description: |
         Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
 
+        The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+
         Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
       items:
         type: array
@@ -32,7 +34,7 @@ components:
     MutatedRef:
       type: array
       description: |
-        Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length.
+        Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
 
         mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
       items:
@@ -67,7 +69,7 @@ components:
     RelationshipDefinitionSelectorsPatch:
       type: object
       description: |
-        Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match. Omit this object when the relationship only matches.
+        Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.
       x-go-name: RelationshipDefinitionSelectorsPatch
       properties:
         patchStrategy:

--- a/schemas/constructs/v1beta3/relationship/api.yml
+++ b/schemas/constructs/v1beta3/relationship/api.yml
@@ -19,20 +19,27 @@ components:
     # Reusable schema components from selector definitions
     MutatorRef:
       type: array
-      description: JSON ref to value from where patch should be applied.
+      description: |
+        Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+
+        Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
       items:
         type: array
         items:
           type: string
-        description: "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+        description: One path as an array of string segments, e.g. [configuration, metadata, name].
 
     MutatedRef:
       type: array
+      description: |
+        Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length.
+
+        mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
       items:
         type: array
         items:
           type: string
-        description: "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+        description: One path as an array of string segments, e.g. [configuration, spec, containers, _, name].
 
     RelationshipDefinitionSelectorsPatchStrategy:
       type: string
@@ -59,7 +66,8 @@ components:
 
     RelationshipDefinitionSelectorsPatch:
       type: object
-      description: Patch configuration for the selector
+      description: |
+        Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match. Omit this object when the relationship only matches.
       x-go-name: RelationshipDefinitionSelectorsPatch
       properties:
         patchStrategy:
@@ -183,7 +191,7 @@ components:
         - to
       properties:
         from:
-          description: Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.
+          description: Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many).
           type: array
           items:
             $ref: "#/components/schemas/SelectorItem"
@@ -191,7 +199,7 @@ components:
           x-oapi-codegen-extra-tags:
             json: "from"
         to:
-          description: Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.
+          description: Destination side of the selector. For kind=hierarchical, to is the parent.
           type: array
           items:
             $ref: "#/components/schemas/SelectorItem"

--- a/schemas/constructs/v1beta3/relationship/relationship.yaml
+++ b/schemas/constructs/v1beta3/relationship/relationship.yaml
@@ -35,7 +35,14 @@ properties:
       yaml: "version"
       json: "version"
   kind:
-    description: "Kind of the Relationship. Learn more about relationships - https://docs.meshery.io/concepts/logical/relationships."
+    description: |
+      Kind of the Relationship. Enum: hierarchical, edge, sibling.
+
+      hierarchical: parent-child containment, nesting, or inheritance. from is the child; to is the parent.
+      edge: a connection between peers (network, mount, permission, reference, and similar).
+      sibling: schema-native encoding for peer grouping such as tagsets. In-tree Kubernetes models instead encode tagsets as kind=hierarchical, type=sibling, subType=matchlabels. Do not mix the two encodings in one model.
+
+      Learn more at https://docs.meshery.io/concepts/logical/relationships.
     type: string
     enum:
       - hierarchical
@@ -47,7 +54,12 @@ properties:
       json: "kind"
 
   type:
-    description: Classification of relationships. Used to group relationships similar in nature.
+    description: |
+      Classification of relationships. Open string (not an enum). Used with kind and subType to select the visual paradigm and evaluation policy.
+
+      Canonical values: parent (with kind=hierarchical); binding (assigns, mounts, or entitles); non-binding (real link that does not provision the attachment); sibling (in-tree tagsets with kind=hierarchical); matchlabels (schema-native tagsets with kind=sibling).
+
+      Copy an established kind/type/subType combination rather than inventing a type. See docs/relationship-definition-taxonomy.md.
     type: string
     x-go-name: RelationshipType
     x-go-type-skip-optional-pointer: true
@@ -60,7 +72,12 @@ properties:
 
   # Canonical v1beta3 wire: camelCase. Not DB-backed in this construct.
   subType:
-    description: Most granular unit of relationship classification. The combination of Kind, Type and SubType together uniquely identify a Relationship.
+    description: |
+      Most granular unit of relationship classification. Open string. Combined with kind and type, uniquely identifies the visual paradigm.
+
+      Canonical values: inventory, alias, wallet, matchlabels, tagsets, reference, network, firewall, permission, mount, annotation.
+
+      badge is a visual-paradigm name only; there is no in-tree encoding. Do not invent subType=badge without a visualization and evaluation policy. See docs/relationship-definition-taxonomy.md.
     type: string
     x-go-type-skip-optional-pointer: true
     x-order: 10

--- a/typescript/generated/v1beta3/relationship/Relationship.ts
+++ b/typescript/generated/v1beta3/relationship/Relationship.ts
@@ -29,13 +29,31 @@ export interface components {
             /** @description Specifies the version of the relationship definition. */
             version: string;
             /**
-             * @description Kind of the Relationship. Learn more about relationships - https://docs.meshery.io/concepts/logical/relationships.
+             * @description Kind of the Relationship. Enum: hierarchical, edge, sibling.
+             *
+             *     hierarchical: parent-child containment, nesting, or inheritance. from is the child; to is the parent.
+             *     edge: a connection between peers (network, mount, permission, reference, and similar).
+             *     sibling: schema-native encoding for peer grouping such as tagsets. In-tree Kubernetes models instead encode tagsets as kind=hierarchical, type=sibling, subType=matchlabels. Do not mix the two encodings in one model.
+             *
+             *     Learn more at https://docs.meshery.io/concepts/logical/relationships.
              * @enum {string}
              */
             kind: "hierarchical" | "edge" | "sibling";
-            /** @description Classification of relationships. Used to group relationships similar in nature. */
+            /**
+             * @description Classification of relationships. Open string (not an enum). Used with kind and subType to select the visual paradigm and evaluation policy.
+             *
+             *     Canonical values: parent (with kind=hierarchical); binding (assigns, mounts, or entitles); non-binding (real link that does not provision the attachment); sibling (in-tree tagsets with kind=hierarchical); matchlabels (schema-native tagsets with kind=sibling).
+             *
+             *     Copy an established kind/type/subType combination rather than inventing a type. See docs/relationship-definition-taxonomy.md.
+             */
             type: string;
-            /** @description Most granular unit of relationship classification. The combination of Kind, Type and SubType together uniquely identify a Relationship. */
+            /**
+             * @description Most granular unit of relationship classification. Open string. Combined with kind and type, uniquely identifies the visual paradigm.
+             *
+             *     Canonical values: inventory, alias, wallet, matchlabels, tagsets, reference, network, firewall, permission, mount, annotation.
+             *
+             *     badge is a visual-paradigm name only; there is no in-tree encoding. Do not invent subType=badge without a visualization and evaluation policy. See docs/relationship-definition-taxonomy.md.
+             */
             subType: string;
             /**
              * @description Status of the relationship.
@@ -231,7 +249,7 @@ export interface components {
             selectors?: {
                 /** @description Selectors used to define relationships which are allowed. */
                 allow: {
-                    /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+                    /** @description Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many). */
                     from: {
                         /**
                          * Format: uuid
@@ -253,8 +271,19 @@ export interface components {
                                 id?: string;
                                 /** @description Kind of the resource. */
                                 kind: string;
-                                /** @description JSON ref to value from where patch should be applied. */
+                                /**
+                                 * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                                 *
+                                 *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                                 */
                                 mutatorRef?: string[][];
+                                /**
+                                 * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                                 */
                                 mutatedRef?: string[][];
                             }[];
                             /** @description The to of the matchselector. */
@@ -266,8 +295,19 @@ export interface components {
                                 id?: string;
                                 /** @description Kind of the resource. */
                                 kind: string;
-                                /** @description JSON ref to value from where patch should be applied. */
+                                /**
+                                 * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                                 *
+                                 *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                                 */
                                 mutatorRef?: string[][];
+                                /**
+                                 * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                                 */
                                 mutatedRef?: string[][];
                             }[];
                         };
@@ -302,7 +342,7 @@ export interface components {
                                 kind: string;
                             };
                         };
-                        /** @description Patch configuration for the selector */
+                        /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                         patch?: {
                             /**
                              * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -318,12 +358,23 @@ export interface components {
                              * @enum {string}
                              */
                             patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         };
                     }[];
-                    /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+                    /** @description Destination side of the selector. For kind=hierarchical, to is the parent. */
                     to: {
                         /**
                          * Format: uuid
@@ -345,8 +396,19 @@ export interface components {
                                 id?: string;
                                 /** @description Kind of the resource. */
                                 kind: string;
-                                /** @description JSON ref to value from where patch should be applied. */
+                                /**
+                                 * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                                 *
+                                 *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                                 */
                                 mutatorRef?: string[][];
+                                /**
+                                 * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                                 */
                                 mutatedRef?: string[][];
                             }[];
                             /** @description The to of the matchselector. */
@@ -358,8 +420,19 @@ export interface components {
                                 id?: string;
                                 /** @description Kind of the resource. */
                                 kind: string;
-                                /** @description JSON ref to value from where patch should be applied. */
+                                /**
+                                 * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                                 *
+                                 *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                                 */
                                 mutatorRef?: string[][];
+                                /**
+                                 * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                                 */
                                 mutatedRef?: string[][];
                             }[];
                         };
@@ -394,7 +467,7 @@ export interface components {
                                 kind: string;
                             };
                         };
-                        /** @description Patch configuration for the selector */
+                        /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                         patch?: {
                             /**
                              * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -410,15 +483,26 @@ export interface components {
                              * @enum {string}
                              */
                             patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         };
                     }[];
                 };
                 /** @description Optional selectors used to define relationships which should not be created / is restricted. */
                 deny?: {
-                    /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+                    /** @description Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many). */
                     from: {
                         /**
                          * Format: uuid
@@ -440,8 +524,19 @@ export interface components {
                                 id?: string;
                                 /** @description Kind of the resource. */
                                 kind: string;
-                                /** @description JSON ref to value from where patch should be applied. */
+                                /**
+                                 * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                                 *
+                                 *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                                 */
                                 mutatorRef?: string[][];
+                                /**
+                                 * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                                 */
                                 mutatedRef?: string[][];
                             }[];
                             /** @description The to of the matchselector. */
@@ -453,8 +548,19 @@ export interface components {
                                 id?: string;
                                 /** @description Kind of the resource. */
                                 kind: string;
-                                /** @description JSON ref to value from where patch should be applied. */
+                                /**
+                                 * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                                 *
+                                 *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                                 */
                                 mutatorRef?: string[][];
+                                /**
+                                 * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                                 */
                                 mutatedRef?: string[][];
                             }[];
                         };
@@ -489,7 +595,7 @@ export interface components {
                                 kind: string;
                             };
                         };
-                        /** @description Patch configuration for the selector */
+                        /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                         patch?: {
                             /**
                              * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -505,12 +611,23 @@ export interface components {
                              * @enum {string}
                              */
                             patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         };
                     }[];
-                    /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+                    /** @description Destination side of the selector. For kind=hierarchical, to is the parent. */
                     to: {
                         /**
                          * Format: uuid
@@ -532,8 +649,19 @@ export interface components {
                                 id?: string;
                                 /** @description Kind of the resource. */
                                 kind: string;
-                                /** @description JSON ref to value from where patch should be applied. */
+                                /**
+                                 * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                                 *
+                                 *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                                 */
                                 mutatorRef?: string[][];
+                                /**
+                                 * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                                 */
                                 mutatedRef?: string[][];
                             }[];
                             /** @description The to of the matchselector. */
@@ -545,8 +673,19 @@ export interface components {
                                 id?: string;
                                 /** @description Kind of the resource. */
                                 kind: string;
-                                /** @description JSON ref to value from where patch should be applied. */
+                                /**
+                                 * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                                 *
+                                 *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                                 */
                                 mutatorRef?: string[][];
+                                /**
+                                 * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                                 *
+                                 *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                                 */
                                 mutatedRef?: string[][];
                             }[];
                         };
@@ -581,7 +720,7 @@ export interface components {
                                 kind: string;
                             };
                         };
-                        /** @description Patch configuration for the selector */
+                        /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                         patch?: {
                             /**
                              * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -597,16 +736,38 @@ export interface components {
                              * @enum {string}
                              */
                             patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         };
                     }[];
                 };
             }[];
         };
-        /** @description JSON ref to value from where patch should be applied. */
+        /**
+         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+         *
+         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+         *
+         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+         */
         MutatorRef: string[][];
+        /**
+         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+         *
+         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+         */
         MutatedRef: string[][];
         /**
          * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -622,7 +783,7 @@ export interface components {
          * @enum {string}
          */
         RelationshipDefinitionSelectorsPatchStrategy: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-        /** @description Patch configuration for the selector */
+        /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
         RelationshipDefinitionSelectorsPatch: {
             /**
              * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -638,8 +799,19 @@ export interface components {
              * @enum {string}
              */
             patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-            /** @description JSON ref to value from where patch should be applied. */
+            /**
+             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+             *
+             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+             *
+             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+             */
             mutatorRef?: string[][];
+            /**
+             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+             *
+             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+             */
             mutatedRef?: string[][];
         };
         /** @description Match selector item for binding between nodes */
@@ -651,8 +823,19 @@ export interface components {
             id?: string;
             /** @description Kind of the resource. */
             kind: string;
-            /** @description JSON ref to value from where patch should be applied. */
+            /**
+             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+             *
+             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+             *
+             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+             */
             mutatorRef?: string[][];
+            /**
+             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+             *
+             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+             */
             mutatedRef?: string[][];
         };
         /** @description Match configuration for selector */
@@ -668,8 +851,19 @@ export interface components {
                 id?: string;
                 /** @description Kind of the resource. */
                 kind: string;
-                /** @description JSON ref to value from where patch should be applied. */
+                /**
+                 * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                 *
+                 *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                 *
+                 *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                 */
                 mutatorRef?: string[][];
+                /**
+                 * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                 *
+                 *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                 */
                 mutatedRef?: string[][];
             }[];
             /** @description The to of the matchselector. */
@@ -681,8 +875,19 @@ export interface components {
                 id?: string;
                 /** @description Kind of the resource. */
                 kind: string;
-                /** @description JSON ref to value from where patch should be applied. */
+                /**
+                 * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                 *
+                 *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                 *
+                 *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                 */
                 mutatorRef?: string[][];
+                /**
+                 * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                 *
+                 *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                 */
                 mutatedRef?: string[][];
             }[];
         };
@@ -708,8 +913,19 @@ export interface components {
                     id?: string;
                     /** @description Kind of the resource. */
                     kind: string;
-                    /** @description JSON ref to value from where patch should be applied. */
+                    /**
+                     * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                     *
+                     *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                     *
+                     *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                     */
                     mutatorRef?: string[][];
+                    /**
+                     * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                     *
+                     *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                     */
                     mutatedRef?: string[][];
                 }[];
                 /** @description The to of the matchselector. */
@@ -721,8 +937,19 @@ export interface components {
                     id?: string;
                     /** @description Kind of the resource. */
                     kind: string;
-                    /** @description JSON ref to value from where patch should be applied. */
+                    /**
+                     * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                     *
+                     *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                     *
+                     *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                     */
                     mutatorRef?: string[][];
+                    /**
+                     * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                     *
+                     *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                     */
                     mutatedRef?: string[][];
                 }[];
             };
@@ -757,7 +984,7 @@ export interface components {
                     kind: string;
                 };
             };
-            /** @description Patch configuration for the selector */
+            /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
             patch?: {
                 /**
                  * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -773,14 +1000,25 @@ export interface components {
                  * @enum {string}
                  */
                 patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                /** @description JSON ref to value from where patch should be applied. */
+                /**
+                 * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                 *
+                 *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                 *
+                 *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                 */
                 mutatorRef?: string[][];
+                /**
+                 * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                 *
+                 *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                 */
                 mutatedRef?: string[][];
             };
         };
         /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
         Selector: {
-            /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+            /** @description Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many). */
             from: {
                 /**
                  * Format: uuid
@@ -802,8 +1040,19 @@ export interface components {
                         id?: string;
                         /** @description Kind of the resource. */
                         kind: string;
-                        /** @description JSON ref to value from where patch should be applied. */
+                        /**
+                         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                         *
+                         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                         *
+                         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                         */
                         mutatorRef?: string[][];
+                        /**
+                         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                         *
+                         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                         */
                         mutatedRef?: string[][];
                     }[];
                     /** @description The to of the matchselector. */
@@ -815,8 +1064,19 @@ export interface components {
                         id?: string;
                         /** @description Kind of the resource. */
                         kind: string;
-                        /** @description JSON ref to value from where patch should be applied. */
+                        /**
+                         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                         *
+                         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                         *
+                         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                         */
                         mutatorRef?: string[][];
+                        /**
+                         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                         *
+                         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                         */
                         mutatedRef?: string[][];
                     }[];
                 };
@@ -851,7 +1111,7 @@ export interface components {
                         kind: string;
                     };
                 };
-                /** @description Patch configuration for the selector */
+                /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                 patch?: {
                     /**
                      * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -867,12 +1127,23 @@ export interface components {
                      * @enum {string}
                      */
                     patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                    /** @description JSON ref to value from where patch should be applied. */
+                    /**
+                     * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                     *
+                     *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                     *
+                     *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                     */
                     mutatorRef?: string[][];
+                    /**
+                     * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                     *
+                     *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                     */
                     mutatedRef?: string[][];
                 };
             }[];
-            /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+            /** @description Destination side of the selector. For kind=hierarchical, to is the parent. */
             to: {
                 /**
                  * Format: uuid
@@ -894,8 +1165,19 @@ export interface components {
                         id?: string;
                         /** @description Kind of the resource. */
                         kind: string;
-                        /** @description JSON ref to value from where patch should be applied. */
+                        /**
+                         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                         *
+                         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                         *
+                         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                         */
                         mutatorRef?: string[][];
+                        /**
+                         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                         *
+                         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                         */
                         mutatedRef?: string[][];
                     }[];
                     /** @description The to of the matchselector. */
@@ -907,8 +1189,19 @@ export interface components {
                         id?: string;
                         /** @description Kind of the resource. */
                         kind: string;
-                        /** @description JSON ref to value from where patch should be applied. */
+                        /**
+                         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                         *
+                         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                         *
+                         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                         */
                         mutatorRef?: string[][];
+                        /**
+                         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                         *
+                         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                         */
                         mutatedRef?: string[][];
                     }[];
                 };
@@ -943,7 +1236,7 @@ export interface components {
                         kind: string;
                     };
                 };
-                /** @description Patch configuration for the selector */
+                /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                 patch?: {
                     /**
                      * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -959,8 +1252,19 @@ export interface components {
                      * @enum {string}
                      */
                     patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                    /** @description JSON ref to value from where patch should be applied. */
+                    /**
+                     * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                     *
+                     *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                     *
+                     *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                     */
                     mutatorRef?: string[][];
+                    /**
+                     * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                     *
+                     *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                     */
                     mutatedRef?: string[][];
                 };
             }[];
@@ -969,7 +1273,7 @@ export interface components {
         SelectorSetItem: {
             /** @description Selectors used to define relationships which are allowed. */
             allow: {
-                /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+                /** @description Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many). */
                 from: {
                     /**
                      * Format: uuid
@@ -991,8 +1295,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                         /** @description The to of the matchselector. */
@@ -1004,8 +1319,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                     };
@@ -1040,7 +1366,7 @@ export interface components {
                             kind: string;
                         };
                     };
-                    /** @description Patch configuration for the selector */
+                    /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                     patch?: {
                         /**
                          * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -1056,12 +1382,23 @@ export interface components {
                          * @enum {string}
                          */
                         patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                        /** @description JSON ref to value from where patch should be applied. */
+                        /**
+                         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                         *
+                         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                         *
+                         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                         */
                         mutatorRef?: string[][];
+                        /**
+                         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                         *
+                         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                         */
                         mutatedRef?: string[][];
                     };
                 }[];
-                /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+                /** @description Destination side of the selector. For kind=hierarchical, to is the parent. */
                 to: {
                     /**
                      * Format: uuid
@@ -1083,8 +1420,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                         /** @description The to of the matchselector. */
@@ -1096,8 +1444,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                     };
@@ -1132,7 +1491,7 @@ export interface components {
                             kind: string;
                         };
                     };
-                    /** @description Patch configuration for the selector */
+                    /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                     patch?: {
                         /**
                          * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -1148,15 +1507,26 @@ export interface components {
                          * @enum {string}
                          */
                         patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                        /** @description JSON ref to value from where patch should be applied. */
+                        /**
+                         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                         *
+                         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                         *
+                         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                         */
                         mutatorRef?: string[][];
+                        /**
+                         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                         *
+                         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                         */
                         mutatedRef?: string[][];
                     };
                 }[];
             };
             /** @description Optional selectors used to define relationships which should not be created / is restricted. */
             deny?: {
-                /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+                /** @description Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many). */
                 from: {
                     /**
                      * Format: uuid
@@ -1178,8 +1548,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                         /** @description The to of the matchselector. */
@@ -1191,8 +1572,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                     };
@@ -1227,7 +1619,7 @@ export interface components {
                             kind: string;
                         };
                     };
-                    /** @description Patch configuration for the selector */
+                    /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                     patch?: {
                         /**
                          * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -1243,12 +1635,23 @@ export interface components {
                          * @enum {string}
                          */
                         patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                        /** @description JSON ref to value from where patch should be applied. */
+                        /**
+                         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                         *
+                         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                         *
+                         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                         */
                         mutatorRef?: string[][];
+                        /**
+                         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                         *
+                         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                         */
                         mutatedRef?: string[][];
                     };
                 }[];
-                /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+                /** @description Destination side of the selector. For kind=hierarchical, to is the parent. */
                 to: {
                     /**
                      * Format: uuid
@@ -1270,8 +1673,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                         /** @description The to of the matchselector. */
@@ -1283,8 +1697,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                     };
@@ -1319,7 +1744,7 @@ export interface components {
                             kind: string;
                         };
                     };
-                    /** @description Patch configuration for the selector */
+                    /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                     patch?: {
                         /**
                          * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -1335,8 +1760,19 @@ export interface components {
                          * @enum {string}
                          */
                         patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                        /** @description JSON ref to value from where patch should be applied. */
+                        /**
+                         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                         *
+                         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                         *
+                         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                         */
                         mutatorRef?: string[][];
+                        /**
+                         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                         *
+                         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                         */
                         mutatedRef?: string[][];
                     };
                 }[];
@@ -1346,7 +1782,7 @@ export interface components {
         SelectorSet: {
             /** @description Selectors used to define relationships which are allowed. */
             allow: {
-                /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+                /** @description Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many). */
                 from: {
                     /**
                      * Format: uuid
@@ -1368,8 +1804,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                         /** @description The to of the matchselector. */
@@ -1381,8 +1828,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                     };
@@ -1417,7 +1875,7 @@ export interface components {
                             kind: string;
                         };
                     };
-                    /** @description Patch configuration for the selector */
+                    /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                     patch?: {
                         /**
                          * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -1433,12 +1891,23 @@ export interface components {
                          * @enum {string}
                          */
                         patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                        /** @description JSON ref to value from where patch should be applied. */
+                        /**
+                         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                         *
+                         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                         *
+                         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                         */
                         mutatorRef?: string[][];
+                        /**
+                         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                         *
+                         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                         */
                         mutatedRef?: string[][];
                     };
                 }[];
-                /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+                /** @description Destination side of the selector. For kind=hierarchical, to is the parent. */
                 to: {
                     /**
                      * Format: uuid
@@ -1460,8 +1929,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                         /** @description The to of the matchselector. */
@@ -1473,8 +1953,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                     };
@@ -1509,7 +2000,7 @@ export interface components {
                             kind: string;
                         };
                     };
-                    /** @description Patch configuration for the selector */
+                    /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                     patch?: {
                         /**
                          * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -1525,15 +2016,26 @@ export interface components {
                          * @enum {string}
                          */
                         patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                        /** @description JSON ref to value from where patch should be applied. */
+                        /**
+                         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                         *
+                         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                         *
+                         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                         */
                         mutatorRef?: string[][];
+                        /**
+                         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                         *
+                         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                         */
                         mutatedRef?: string[][];
                     };
                 }[];
             };
             /** @description Optional selectors used to define relationships which should not be created / is restricted. */
             deny?: {
-                /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+                /** @description Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many). */
                 from: {
                     /**
                      * Format: uuid
@@ -1555,8 +2057,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                         /** @description The to of the matchselector. */
@@ -1568,8 +2081,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                     };
@@ -1604,7 +2128,7 @@ export interface components {
                             kind: string;
                         };
                     };
-                    /** @description Patch configuration for the selector */
+                    /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                     patch?: {
                         /**
                          * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -1620,12 +2144,23 @@ export interface components {
                          * @enum {string}
                          */
                         patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                        /** @description JSON ref to value from where patch should be applied. */
+                        /**
+                         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                         *
+                         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                         *
+                         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                         */
                         mutatorRef?: string[][];
+                        /**
+                         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                         *
+                         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                         */
                         mutatedRef?: string[][];
                     };
                 }[];
-                /** @description Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match. */
+                /** @description Destination side of the selector. For kind=hierarchical, to is the parent. */
                 to: {
                     /**
                      * Format: uuid
@@ -1647,8 +2182,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                         /** @description The to of the matchselector. */
@@ -1660,8 +2206,19 @@ export interface components {
                             id?: string;
                             /** @description Kind of the resource. */
                             kind: string;
-                            /** @description JSON ref to value from where patch should be applied. */
+                            /**
+                             * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                             *
+                             *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                             *
+                             *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                             */
                             mutatorRef?: string[][];
+                            /**
+                             * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                             *
+                             *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                             */
                             mutatedRef?: string[][];
                         }[];
                     };
@@ -1696,7 +2253,7 @@ export interface components {
                             kind: string;
                         };
                     };
-                    /** @description Patch configuration for the selector */
+                    /** @description Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches. */
                     patch?: {
                         /**
                          * @description patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).
@@ -1712,8 +2269,19 @@ export interface components {
                          * @enum {string}
                          */
                         patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
-                        /** @description JSON ref to value from where patch should be applied. */
+                        /**
+                         * @description Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.
+                         *
+                         *     The pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.
+                         *
+                         *     Example: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. "_" may mark only the first array position in a path.
+                         */
                         mutatorRef?: string[][];
+                        /**
+                         * @description Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.
+                         *
+                         *     mutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).
+                         */
                         mutatedRef?: string[][];
                     };
                 }[];

--- a/typescript/generated/v1beta3/relationship/RelationshipSchema.ts
+++ b/typescript/generated/v1beta3/relationship/RelationshipSchema.ts
@@ -84,7 +84,7 @@ const RelationshipSchema: Record<string, unknown> = {
             "pattern": "^[a-z0-9]+.[0-9]+.[0-9]+(-[0-9A-Za-z-]+(.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
           },
           "kind": {
-            "description": "Kind of the Relationship. Learn more about relationships - https://docs.meshery.io/concepts/logical/relationships.",
+            "description": "Kind of the Relationship. Enum: hierarchical, edge, sibling.\n\nhierarchical: parent-child containment, nesting, or inheritance. from is the child; to is the parent.\nedge: a connection between peers (network, mount, permission, reference, and similar).\nsibling: schema-native encoding for peer grouping such as tagsets. In-tree Kubernetes models instead encode tagsets as kind=hierarchical, type=sibling, subType=matchlabels. Do not mix the two encodings in one model.\n\nLearn more at https://docs.meshery.io/concepts/logical/relationships.\n",
             "type": "string",
             "enum": [
               "hierarchical",
@@ -98,7 +98,7 @@ const RelationshipSchema: Record<string, unknown> = {
             }
           },
           "type": {
-            "description": "Classification of relationships. Used to group relationships similar in nature.",
+            "description": "Classification of relationships. Open string (not an enum). Used with kind and subType to select the visual paradigm and evaluation policy.\n\nCanonical values: parent (with kind=hierarchical); binding (assigns, mounts, or entitles); non-binding (real link that does not provision the attachment); sibling (in-tree tagsets with kind=hierarchical); matchlabels (schema-native tagsets with kind=sibling).\n\nCopy an established kind/type/subType combination rather than inventing a type. See docs/relationship-definition-taxonomy.md.\n",
             "type": "string",
             "x-go-name": "RelationshipType",
             "x-go-type-skip-optional-pointer": true,
@@ -111,7 +111,7 @@ const RelationshipSchema: Record<string, unknown> = {
             "maxLength": 255
           },
           "subType": {
-            "description": "Most granular unit of relationship classification. The combination of Kind, Type and SubType together uniquely identify a Relationship.",
+            "description": "Most granular unit of relationship classification. Open string. Combined with kind and type, uniquely identifies the visual paradigm.\n\nCanonical values: inventory, alias, wallet, matchlabels, tagsets, reference, network, firewall, permission, mount, annotation.\n\nbadge is a visual-paradigm name only; there is no in-tree encoding. Do not invent subType=badge without a visualization and evaluation policy. See docs/relationship-definition-taxonomy.md.\n",
             "type": "string",
             "x-go-type-skip-optional-pointer": true,
             "x-order": 10,
@@ -854,7 +854,7 @@ const RelationshipSchema: Record<string, unknown> = {
                   ],
                   "properties": {
                     "from": {
-                      "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+                      "description": "Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many).",
                       "type": "array",
                       "items": {
                         "x-go-type": "SelectorItem",
@@ -937,13 +937,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatorRef,omitempty"
                                       },
                                       "type": "array",
-                                      "description": "JSON ref to value from where patch should be applied.",
+                                      "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                        "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                       }
                                     },
                                     "mutatedRef": {
@@ -951,12 +951,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatedRef,omitempty"
                                       },
                                       "type": "array",
+                                      "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                        "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                       }
                                     }
                                   }
@@ -1001,13 +1002,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatorRef,omitempty"
                                       },
                                       "type": "array",
-                                      "description": "JSON ref to value from where patch should be applied.",
+                                      "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                        "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                       }
                                     },
                                     "mutatedRef": {
@@ -1015,12 +1016,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatedRef,omitempty"
                                       },
                                       "type": "array",
+                                      "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                        "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                       }
                                     }
                                   }
@@ -1145,7 +1147,7 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "patch"
                             },
                             "type": "object",
-                            "description": "Patch configuration for the selector",
+                            "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                             "x-go-name": "RelationshipDefinitionSelectorsPatch",
                             "properties": {
                               "patchStrategy": {
@@ -1170,13 +1172,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatorRef,omitempty"
                                 },
                                 "type": "array",
-                                "description": "JSON ref to value from where patch should be applied.",
+                                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                 }
                               },
                               "mutatedRef": {
@@ -1184,12 +1186,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatedRef,omitempty"
                                 },
                                 "type": "array",
+                                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                 }
                               }
                             }
@@ -1201,7 +1204,7 @@ const RelationshipSchema: Record<string, unknown> = {
                       }
                     },
                     "to": {
-                      "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+                      "description": "Destination side of the selector. For kind=hierarchical, to is the parent.",
                       "type": "array",
                       "items": {
                         "x-go-type": "SelectorItem",
@@ -1284,13 +1287,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatorRef,omitempty"
                                       },
                                       "type": "array",
-                                      "description": "JSON ref to value from where patch should be applied.",
+                                      "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                        "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                       }
                                     },
                                     "mutatedRef": {
@@ -1298,12 +1301,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatedRef,omitempty"
                                       },
                                       "type": "array",
+                                      "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                        "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                       }
                                     }
                                   }
@@ -1348,13 +1352,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatorRef,omitempty"
                                       },
                                       "type": "array",
-                                      "description": "JSON ref to value from where patch should be applied.",
+                                      "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                        "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                       }
                                     },
                                     "mutatedRef": {
@@ -1362,12 +1366,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatedRef,omitempty"
                                       },
                                       "type": "array",
+                                      "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                        "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                       }
                                     }
                                   }
@@ -1492,7 +1497,7 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "patch"
                             },
                             "type": "object",
-                            "description": "Patch configuration for the selector",
+                            "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                             "x-go-name": "RelationshipDefinitionSelectorsPatch",
                             "properties": {
                               "patchStrategy": {
@@ -1517,13 +1522,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatorRef,omitempty"
                                 },
                                 "type": "array",
-                                "description": "JSON ref to value from where patch should be applied.",
+                                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                 }
                               },
                               "mutatedRef": {
@@ -1531,12 +1536,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatedRef,omitempty"
                                 },
                                 "type": "array",
+                                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                 }
                               }
                             }
@@ -1562,7 +1568,7 @@ const RelationshipSchema: Record<string, unknown> = {
                   ],
                   "properties": {
                     "from": {
-                      "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+                      "description": "Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many).",
                       "type": "array",
                       "items": {
                         "x-go-type": "SelectorItem",
@@ -1645,13 +1651,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatorRef,omitempty"
                                       },
                                       "type": "array",
-                                      "description": "JSON ref to value from where patch should be applied.",
+                                      "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                        "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                       }
                                     },
                                     "mutatedRef": {
@@ -1659,12 +1665,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatedRef,omitempty"
                                       },
                                       "type": "array",
+                                      "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                        "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                       }
                                     }
                                   }
@@ -1709,13 +1716,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatorRef,omitempty"
                                       },
                                       "type": "array",
-                                      "description": "JSON ref to value from where patch should be applied.",
+                                      "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                        "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                       }
                                     },
                                     "mutatedRef": {
@@ -1723,12 +1730,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatedRef,omitempty"
                                       },
                                       "type": "array",
+                                      "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                        "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                       }
                                     }
                                   }
@@ -1853,7 +1861,7 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "patch"
                             },
                             "type": "object",
-                            "description": "Patch configuration for the selector",
+                            "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                             "x-go-name": "RelationshipDefinitionSelectorsPatch",
                             "properties": {
                               "patchStrategy": {
@@ -1878,13 +1886,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatorRef,omitempty"
                                 },
                                 "type": "array",
-                                "description": "JSON ref to value from where patch should be applied.",
+                                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                 }
                               },
                               "mutatedRef": {
@@ -1892,12 +1900,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatedRef,omitempty"
                                 },
                                 "type": "array",
+                                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                 }
                               }
                             }
@@ -1909,7 +1918,7 @@ const RelationshipSchema: Record<string, unknown> = {
                       }
                     },
                     "to": {
-                      "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+                      "description": "Destination side of the selector. For kind=hierarchical, to is the parent.",
                       "type": "array",
                       "items": {
                         "x-go-type": "SelectorItem",
@@ -1992,13 +2001,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatorRef,omitempty"
                                       },
                                       "type": "array",
-                                      "description": "JSON ref to value from where patch should be applied.",
+                                      "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                        "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                       }
                                     },
                                     "mutatedRef": {
@@ -2006,12 +2015,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatedRef,omitempty"
                                       },
                                       "type": "array",
+                                      "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                        "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                       }
                                     }
                                   }
@@ -2056,13 +2066,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatorRef,omitempty"
                                       },
                                       "type": "array",
-                                      "description": "JSON ref to value from where patch should be applied.",
+                                      "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                        "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                       }
                                     },
                                     "mutatedRef": {
@@ -2070,12 +2080,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                         "json": "mutatedRef,omitempty"
                                       },
                                       "type": "array",
+                                      "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                       "items": {
                                         "type": "array",
                                         "items": {
                                           "type": "string"
                                         },
-                                        "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                        "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                       }
                                     }
                                   }
@@ -2200,7 +2211,7 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "patch"
                             },
                             "type": "object",
-                            "description": "Patch configuration for the selector",
+                            "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                             "x-go-name": "RelationshipDefinitionSelectorsPatch",
                             "properties": {
                               "patchStrategy": {
@@ -2225,13 +2236,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatorRef,omitempty"
                                 },
                                 "type": "array",
-                                "description": "JSON ref to value from where patch should be applied.",
+                                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                 }
                               },
                               "mutatedRef": {
@@ -2239,12 +2250,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatedRef,omitempty"
                                 },
                                 "type": "array",
+                                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                 }
                               }
                             }
@@ -2264,23 +2276,24 @@ const RelationshipSchema: Record<string, unknown> = {
       },
       "MutatorRef": {
         "type": "array",
-        "description": "JSON ref to value from where patch should be applied.",
+        "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
         "items": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+          "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
         }
       },
       "MutatedRef": {
         "type": "array",
+        "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
         "items": {
           "type": "array",
           "items": {
             "type": "string"
           },
-          "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+          "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
         }
       },
       "RelationshipDefinitionSelectorsPatchStrategy": {
@@ -2299,7 +2312,7 @@ const RelationshipSchema: Record<string, unknown> = {
       },
       "RelationshipDefinitionSelectorsPatch": {
         "type": "object",
-        "description": "Patch configuration for the selector",
+        "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
         "x-go-name": "RelationshipDefinitionSelectorsPatch",
         "properties": {
           "patchStrategy": {
@@ -2324,13 +2337,13 @@ const RelationshipSchema: Record<string, unknown> = {
               "json": "mutatorRef,omitempty"
             },
             "type": "array",
-            "description": "JSON ref to value from where patch should be applied.",
+            "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
             "items": {
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+              "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
             }
           },
           "mutatedRef": {
@@ -2338,12 +2351,13 @@ const RelationshipSchema: Record<string, unknown> = {
               "json": "mutatedRef,omitempty"
             },
             "type": "array",
+            "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
             "items": {
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+              "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
             }
           }
         }
@@ -2380,13 +2394,13 @@ const RelationshipSchema: Record<string, unknown> = {
               "json": "mutatorRef,omitempty"
             },
             "type": "array",
-            "description": "JSON ref to value from where patch should be applied.",
+            "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
             "items": {
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+              "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
             }
           },
           "mutatedRef": {
@@ -2394,12 +2408,13 @@ const RelationshipSchema: Record<string, unknown> = {
               "json": "mutatedRef,omitempty"
             },
             "type": "array",
+            "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
             "items": {
               "type": "array",
               "items": {
                 "type": "string"
               },
-              "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+              "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
             }
           }
         }
@@ -2456,13 +2471,13 @@ const RelationshipSchema: Record<string, unknown> = {
                     "json": "mutatorRef,omitempty"
                   },
                   "type": "array",
-                  "description": "JSON ref to value from where patch should be applied.",
+                  "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                   "items": {
                     "type": "array",
                     "items": {
                       "type": "string"
                     },
-                    "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                    "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                   }
                 },
                 "mutatedRef": {
@@ -2470,12 +2485,13 @@ const RelationshipSchema: Record<string, unknown> = {
                     "json": "mutatedRef,omitempty"
                   },
                   "type": "array",
+                  "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                   "items": {
                     "type": "array",
                     "items": {
                       "type": "string"
                     },
-                    "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                    "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                   }
                 }
               }
@@ -2520,13 +2536,13 @@ const RelationshipSchema: Record<string, unknown> = {
                     "json": "mutatorRef,omitempty"
                   },
                   "type": "array",
-                  "description": "JSON ref to value from where patch should be applied.",
+                  "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                   "items": {
                     "type": "array",
                     "items": {
                       "type": "string"
                     },
-                    "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                    "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                   }
                 },
                 "mutatedRef": {
@@ -2534,12 +2550,13 @@ const RelationshipSchema: Record<string, unknown> = {
                     "json": "mutatedRef,omitempty"
                   },
                   "type": "array",
+                  "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                   "items": {
                     "type": "array",
                     "items": {
                       "type": "string"
                     },
-                    "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                    "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                   }
                 }
               }
@@ -2634,13 +2651,13 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "mutatorRef,omitempty"
                       },
                       "type": "array",
-                      "description": "JSON ref to value from where patch should be applied.",
+                      "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                       "items": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         },
-                        "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                        "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                       }
                     },
                     "mutatedRef": {
@@ -2648,12 +2665,13 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "mutatedRef,omitempty"
                       },
                       "type": "array",
+                      "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                       "items": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         },
-                        "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                        "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                       }
                     }
                   }
@@ -2698,13 +2716,13 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "mutatorRef,omitempty"
                       },
                       "type": "array",
-                      "description": "JSON ref to value from where patch should be applied.",
+                      "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                       "items": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         },
-                        "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                        "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                       }
                     },
                     "mutatedRef": {
@@ -2712,12 +2730,13 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "mutatedRef,omitempty"
                       },
                       "type": "array",
+                      "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                       "items": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         },
-                        "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                        "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                       }
                     }
                   }
@@ -2842,7 +2861,7 @@ const RelationshipSchema: Record<string, unknown> = {
               "json": "patch"
             },
             "type": "object",
-            "description": "Patch configuration for the selector",
+            "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
             "x-go-name": "RelationshipDefinitionSelectorsPatch",
             "properties": {
               "patchStrategy": {
@@ -2867,13 +2886,13 @@ const RelationshipSchema: Record<string, unknown> = {
                   "json": "mutatorRef,omitempty"
                 },
                 "type": "array",
-                "description": "JSON ref to value from where patch should be applied.",
+                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                 "items": {
                   "type": "array",
                   "items": {
                     "type": "string"
                   },
-                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                 }
               },
               "mutatedRef": {
@@ -2881,12 +2900,13 @@ const RelationshipSchema: Record<string, unknown> = {
                   "json": "mutatedRef,omitempty"
                 },
                 "type": "array",
+                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                 "items": {
                   "type": "array",
                   "items": {
                     "type": "string"
                   },
-                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                 }
               }
             }
@@ -2902,7 +2922,7 @@ const RelationshipSchema: Record<string, unknown> = {
         ],
         "properties": {
           "from": {
-            "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+            "description": "Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many).",
             "type": "array",
             "items": {
               "x-go-type": "SelectorItem",
@@ -2985,13 +3005,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatorRef,omitempty"
                             },
                             "type": "array",
-                            "description": "JSON ref to value from where patch should be applied.",
+                            "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                              "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                             }
                           },
                           "mutatedRef": {
@@ -2999,12 +3019,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatedRef,omitempty"
                             },
                             "type": "array",
+                            "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                              "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                             }
                           }
                         }
@@ -3049,13 +3070,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatorRef,omitempty"
                             },
                             "type": "array",
-                            "description": "JSON ref to value from where patch should be applied.",
+                            "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                              "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                             }
                           },
                           "mutatedRef": {
@@ -3063,12 +3084,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatedRef,omitempty"
                             },
                             "type": "array",
+                            "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                              "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                             }
                           }
                         }
@@ -3193,7 +3215,7 @@ const RelationshipSchema: Record<string, unknown> = {
                     "json": "patch"
                   },
                   "type": "object",
-                  "description": "Patch configuration for the selector",
+                  "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                   "x-go-name": "RelationshipDefinitionSelectorsPatch",
                   "properties": {
                     "patchStrategy": {
@@ -3218,13 +3240,13 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "mutatorRef,omitempty"
                       },
                       "type": "array",
-                      "description": "JSON ref to value from where patch should be applied.",
+                      "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                       "items": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         },
-                        "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                        "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                       }
                     },
                     "mutatedRef": {
@@ -3232,12 +3254,13 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "mutatedRef,omitempty"
                       },
                       "type": "array",
+                      "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                       "items": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         },
-                        "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                        "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                       }
                     }
                   }
@@ -3249,7 +3272,7 @@ const RelationshipSchema: Record<string, unknown> = {
             }
           },
           "to": {
-            "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+            "description": "Destination side of the selector. For kind=hierarchical, to is the parent.",
             "type": "array",
             "items": {
               "x-go-type": "SelectorItem",
@@ -3332,13 +3355,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatorRef,omitempty"
                             },
                             "type": "array",
-                            "description": "JSON ref to value from where patch should be applied.",
+                            "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                              "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                             }
                           },
                           "mutatedRef": {
@@ -3346,12 +3369,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatedRef,omitempty"
                             },
                             "type": "array",
+                            "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                              "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                             }
                           }
                         }
@@ -3396,13 +3420,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatorRef,omitempty"
                             },
                             "type": "array",
-                            "description": "JSON ref to value from where patch should be applied.",
+                            "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                              "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                             }
                           },
                           "mutatedRef": {
@@ -3410,12 +3434,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatedRef,omitempty"
                             },
                             "type": "array",
+                            "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                              "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                             }
                           }
                         }
@@ -3540,7 +3565,7 @@ const RelationshipSchema: Record<string, unknown> = {
                     "json": "patch"
                   },
                   "type": "object",
-                  "description": "Patch configuration for the selector",
+                  "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                   "x-go-name": "RelationshipDefinitionSelectorsPatch",
                   "properties": {
                     "patchStrategy": {
@@ -3565,13 +3590,13 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "mutatorRef,omitempty"
                       },
                       "type": "array",
-                      "description": "JSON ref to value from where patch should be applied.",
+                      "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                       "items": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         },
-                        "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                        "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                       }
                     },
                     "mutatedRef": {
@@ -3579,12 +3604,13 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "mutatedRef,omitempty"
                       },
                       "type": "array",
+                      "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                       "items": {
                         "type": "array",
                         "items": {
                           "type": "string"
                         },
-                        "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                        "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                       }
                     }
                   }
@@ -3617,7 +3643,7 @@ const RelationshipSchema: Record<string, unknown> = {
             ],
             "properties": {
               "from": {
-                "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+                "description": "Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many).",
                 "type": "array",
                 "items": {
                   "x-go-type": "SelectorItem",
@@ -3700,13 +3726,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatorRef,omitempty"
                                 },
                                 "type": "array",
-                                "description": "JSON ref to value from where patch should be applied.",
+                                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                 }
                               },
                               "mutatedRef": {
@@ -3714,12 +3740,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatedRef,omitempty"
                                 },
                                 "type": "array",
+                                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                 }
                               }
                             }
@@ -3764,13 +3791,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatorRef,omitempty"
                                 },
                                 "type": "array",
-                                "description": "JSON ref to value from where patch should be applied.",
+                                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                 }
                               },
                               "mutatedRef": {
@@ -3778,12 +3805,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatedRef,omitempty"
                                 },
                                 "type": "array",
+                                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                 }
                               }
                             }
@@ -3908,7 +3936,7 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "patch"
                       },
                       "type": "object",
-                      "description": "Patch configuration for the selector",
+                      "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                       "x-go-name": "RelationshipDefinitionSelectorsPatch",
                       "properties": {
                         "patchStrategy": {
@@ -3933,13 +3961,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "mutatorRef,omitempty"
                           },
                           "type": "array",
-                          "description": "JSON ref to value from where patch should be applied.",
+                          "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                           "items": {
                             "type": "array",
                             "items": {
                               "type": "string"
                             },
-                            "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                            "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                           }
                         },
                         "mutatedRef": {
@@ -3947,12 +3975,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "mutatedRef,omitempty"
                           },
                           "type": "array",
+                          "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                           "items": {
                             "type": "array",
                             "items": {
                               "type": "string"
                             },
-                            "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                            "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                           }
                         }
                       }
@@ -3964,7 +3993,7 @@ const RelationshipSchema: Record<string, unknown> = {
                 }
               },
               "to": {
-                "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+                "description": "Destination side of the selector. For kind=hierarchical, to is the parent.",
                 "type": "array",
                 "items": {
                   "x-go-type": "SelectorItem",
@@ -4047,13 +4076,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatorRef,omitempty"
                                 },
                                 "type": "array",
-                                "description": "JSON ref to value from where patch should be applied.",
+                                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                 }
                               },
                               "mutatedRef": {
@@ -4061,12 +4090,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatedRef,omitempty"
                                 },
                                 "type": "array",
+                                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                 }
                               }
                             }
@@ -4111,13 +4141,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatorRef,omitempty"
                                 },
                                 "type": "array",
-                                "description": "JSON ref to value from where patch should be applied.",
+                                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                 }
                               },
                               "mutatedRef": {
@@ -4125,12 +4155,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatedRef,omitempty"
                                 },
                                 "type": "array",
+                                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                 }
                               }
                             }
@@ -4255,7 +4286,7 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "patch"
                       },
                       "type": "object",
-                      "description": "Patch configuration for the selector",
+                      "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                       "x-go-name": "RelationshipDefinitionSelectorsPatch",
                       "properties": {
                         "patchStrategy": {
@@ -4280,13 +4311,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "mutatorRef,omitempty"
                           },
                           "type": "array",
-                          "description": "JSON ref to value from where patch should be applied.",
+                          "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                           "items": {
                             "type": "array",
                             "items": {
                               "type": "string"
                             },
-                            "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                            "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                           }
                         },
                         "mutatedRef": {
@@ -4294,12 +4325,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "mutatedRef,omitempty"
                           },
                           "type": "array",
+                          "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                           "items": {
                             "type": "array",
                             "items": {
                               "type": "string"
                             },
-                            "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                            "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                           }
                         }
                       }
@@ -4325,7 +4357,7 @@ const RelationshipSchema: Record<string, unknown> = {
             ],
             "properties": {
               "from": {
-                "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+                "description": "Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many).",
                 "type": "array",
                 "items": {
                   "x-go-type": "SelectorItem",
@@ -4408,13 +4440,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatorRef,omitempty"
                                 },
                                 "type": "array",
-                                "description": "JSON ref to value from where patch should be applied.",
+                                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                 }
                               },
                               "mutatedRef": {
@@ -4422,12 +4454,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatedRef,omitempty"
                                 },
                                 "type": "array",
+                                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                 }
                               }
                             }
@@ -4472,13 +4505,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatorRef,omitempty"
                                 },
                                 "type": "array",
-                                "description": "JSON ref to value from where patch should be applied.",
+                                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                 }
                               },
                               "mutatedRef": {
@@ -4486,12 +4519,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatedRef,omitempty"
                                 },
                                 "type": "array",
+                                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                 }
                               }
                             }
@@ -4616,7 +4650,7 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "patch"
                       },
                       "type": "object",
-                      "description": "Patch configuration for the selector",
+                      "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                       "x-go-name": "RelationshipDefinitionSelectorsPatch",
                       "properties": {
                         "patchStrategy": {
@@ -4641,13 +4675,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "mutatorRef,omitempty"
                           },
                           "type": "array",
-                          "description": "JSON ref to value from where patch should be applied.",
+                          "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                           "items": {
                             "type": "array",
                             "items": {
                               "type": "string"
                             },
-                            "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                            "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                           }
                         },
                         "mutatedRef": {
@@ -4655,12 +4689,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "mutatedRef,omitempty"
                           },
                           "type": "array",
+                          "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                           "items": {
                             "type": "array",
                             "items": {
                               "type": "string"
                             },
-                            "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                            "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                           }
                         }
                       }
@@ -4672,7 +4707,7 @@ const RelationshipSchema: Record<string, unknown> = {
                 }
               },
               "to": {
-                "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+                "description": "Destination side of the selector. For kind=hierarchical, to is the parent.",
                 "type": "array",
                 "items": {
                   "x-go-type": "SelectorItem",
@@ -4755,13 +4790,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatorRef,omitempty"
                                 },
                                 "type": "array",
-                                "description": "JSON ref to value from where patch should be applied.",
+                                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                 }
                               },
                               "mutatedRef": {
@@ -4769,12 +4804,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatedRef,omitempty"
                                 },
                                 "type": "array",
+                                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                 }
                               }
                             }
@@ -4819,13 +4855,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatorRef,omitempty"
                                 },
                                 "type": "array",
-                                "description": "JSON ref to value from where patch should be applied.",
+                                "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                  "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                 }
                               },
                               "mutatedRef": {
@@ -4833,12 +4869,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "mutatedRef,omitempty"
                                 },
                                 "type": "array",
+                                "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                 "items": {
                                   "type": "array",
                                   "items": {
                                     "type": "string"
                                   },
-                                  "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                  "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                 }
                               }
                             }
@@ -4963,7 +5000,7 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "patch"
                       },
                       "type": "object",
-                      "description": "Patch configuration for the selector",
+                      "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                       "x-go-name": "RelationshipDefinitionSelectorsPatch",
                       "properties": {
                         "patchStrategy": {
@@ -4988,13 +5025,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "mutatorRef,omitempty"
                           },
                           "type": "array",
-                          "description": "JSON ref to value from where patch should be applied.",
+                          "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                           "items": {
                             "type": "array",
                             "items": {
                               "type": "string"
                             },
-                            "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                            "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                           }
                         },
                         "mutatedRef": {
@@ -5002,12 +5039,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "mutatedRef,omitempty"
                           },
                           "type": "array",
+                          "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                           "items": {
                             "type": "array",
                             "items": {
                               "type": "string"
                             },
-                            "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                            "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                           }
                         }
                       }
@@ -5049,7 +5087,7 @@ const RelationshipSchema: Record<string, unknown> = {
               ],
               "properties": {
                 "from": {
-                  "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+                  "description": "Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many).",
                   "type": "array",
                   "items": {
                     "x-go-type": "SelectorItem",
@@ -5132,13 +5170,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatorRef,omitempty"
                                   },
                                   "type": "array",
-                                  "description": "JSON ref to value from where patch should be applied.",
+                                  "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                    "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                   }
                                 },
                                 "mutatedRef": {
@@ -5146,12 +5184,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatedRef,omitempty"
                                   },
                                   "type": "array",
+                                  "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                    "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                   }
                                 }
                               }
@@ -5196,13 +5235,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatorRef,omitempty"
                                   },
                                   "type": "array",
-                                  "description": "JSON ref to value from where patch should be applied.",
+                                  "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                    "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                   }
                                 },
                                 "mutatedRef": {
@@ -5210,12 +5249,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatedRef,omitempty"
                                   },
                                   "type": "array",
+                                  "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                    "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                   }
                                 }
                               }
@@ -5340,7 +5380,7 @@ const RelationshipSchema: Record<string, unknown> = {
                           "json": "patch"
                         },
                         "type": "object",
-                        "description": "Patch configuration for the selector",
+                        "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                         "x-go-name": "RelationshipDefinitionSelectorsPatch",
                         "properties": {
                           "patchStrategy": {
@@ -5365,13 +5405,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatorRef,omitempty"
                             },
                             "type": "array",
-                            "description": "JSON ref to value from where patch should be applied.",
+                            "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                              "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                             }
                           },
                           "mutatedRef": {
@@ -5379,12 +5419,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatedRef,omitempty"
                             },
                             "type": "array",
+                            "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                              "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                             }
                           }
                         }
@@ -5396,7 +5437,7 @@ const RelationshipSchema: Record<string, unknown> = {
                   }
                 },
                 "to": {
-                  "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+                  "description": "Destination side of the selector. For kind=hierarchical, to is the parent.",
                   "type": "array",
                   "items": {
                     "x-go-type": "SelectorItem",
@@ -5479,13 +5520,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatorRef,omitempty"
                                   },
                                   "type": "array",
-                                  "description": "JSON ref to value from where patch should be applied.",
+                                  "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                    "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                   }
                                 },
                                 "mutatedRef": {
@@ -5493,12 +5534,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatedRef,omitempty"
                                   },
                                   "type": "array",
+                                  "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                    "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                   }
                                 }
                               }
@@ -5543,13 +5585,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatorRef,omitempty"
                                   },
                                   "type": "array",
-                                  "description": "JSON ref to value from where patch should be applied.",
+                                  "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                    "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                   }
                                 },
                                 "mutatedRef": {
@@ -5557,12 +5599,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatedRef,omitempty"
                                   },
                                   "type": "array",
+                                  "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                    "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                   }
                                 }
                               }
@@ -5687,7 +5730,7 @@ const RelationshipSchema: Record<string, unknown> = {
                           "json": "patch"
                         },
                         "type": "object",
-                        "description": "Patch configuration for the selector",
+                        "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                         "x-go-name": "RelationshipDefinitionSelectorsPatch",
                         "properties": {
                           "patchStrategy": {
@@ -5712,13 +5755,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatorRef,omitempty"
                             },
                             "type": "array",
-                            "description": "JSON ref to value from where patch should be applied.",
+                            "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                              "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                             }
                           },
                           "mutatedRef": {
@@ -5726,12 +5769,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatedRef,omitempty"
                             },
                             "type": "array",
+                            "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                              "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                             }
                           }
                         }
@@ -5757,7 +5801,7 @@ const RelationshipSchema: Record<string, unknown> = {
               ],
               "properties": {
                 "from": {
-                  "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+                  "description": "Originator side of the selector. For kind=hierarchical, from is the child. Each from item relates to each to item in the same selector (1:many).",
                   "type": "array",
                   "items": {
                     "x-go-type": "SelectorItem",
@@ -5840,13 +5884,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatorRef,omitempty"
                                   },
                                   "type": "array",
-                                  "description": "JSON ref to value from where patch should be applied.",
+                                  "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                    "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                   }
                                 },
                                 "mutatedRef": {
@@ -5854,12 +5898,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatedRef,omitempty"
                                   },
                                   "type": "array",
+                                  "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                    "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                   }
                                 }
                               }
@@ -5904,13 +5949,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatorRef,omitempty"
                                   },
                                   "type": "array",
-                                  "description": "JSON ref to value from where patch should be applied.",
+                                  "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                    "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                   }
                                 },
                                 "mutatedRef": {
@@ -5918,12 +5963,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatedRef,omitempty"
                                   },
                                   "type": "array",
+                                  "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                    "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                   }
                                 }
                               }
@@ -6048,7 +6094,7 @@ const RelationshipSchema: Record<string, unknown> = {
                           "json": "patch"
                         },
                         "type": "object",
-                        "description": "Patch configuration for the selector",
+                        "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                         "x-go-name": "RelationshipDefinitionSelectorsPatch",
                         "properties": {
                           "patchStrategy": {
@@ -6073,13 +6119,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatorRef,omitempty"
                             },
                             "type": "array",
-                            "description": "JSON ref to value from where patch should be applied.",
+                            "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                              "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                             }
                           },
                           "mutatedRef": {
@@ -6087,12 +6133,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatedRef,omitempty"
                             },
                             "type": "array",
+                            "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                              "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                             }
                           }
                         }
@@ -6104,7 +6151,7 @@ const RelationshipSchema: Record<string, unknown> = {
                   }
                 },
                 "to": {
-                  "description": "Describes the component(s) which are involved in the relationship along with a set of actions to perform upon selection match.",
+                  "description": "Destination side of the selector. For kind=hierarchical, to is the parent.",
                   "type": "array",
                   "items": {
                     "x-go-type": "SelectorItem",
@@ -6187,13 +6234,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatorRef,omitempty"
                                   },
                                   "type": "array",
-                                  "description": "JSON ref to value from where patch should be applied.",
+                                  "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                    "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                   }
                                 },
                                 "mutatedRef": {
@@ -6201,12 +6248,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatedRef,omitempty"
                                   },
                                   "type": "array",
+                                  "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                    "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                   }
                                 }
                               }
@@ -6251,13 +6299,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatorRef,omitempty"
                                   },
                                   "type": "array",
-                                  "description": "JSON ref to value from where patch should be applied.",
+                                  "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                                    "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                                   }
                                 },
                                 "mutatedRef": {
@@ -6265,12 +6313,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                     "json": "mutatedRef,omitempty"
                                   },
                                   "type": "array",
+                                  "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                                   "items": {
                                     "type": "array",
                                     "items": {
                                       "type": "string"
                                     },
-                                    "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                                    "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                                   }
                                 }
                               }
@@ -6395,7 +6444,7 @@ const RelationshipSchema: Record<string, unknown> = {
                           "json": "patch"
                         },
                         "type": "object",
-                        "description": "Patch configuration for the selector",
+                        "description": "Patch configuration for a matched selector. mutatorRef is the value source; mutatedRef is the value sink. Sequence lengths must match, and the two sequences pair across the related selector items - the source paths on one item feed the sink paths on the related item of the other side, index by index. Omit this object when the relationship only matches.\n",
                         "x-go-name": "RelationshipDefinitionSelectorsPatch",
                         "properties": {
                           "patchStrategy": {
@@ -6420,13 +6469,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatorRef,omitempty"
                             },
                             "type": "array",
-                            "description": "JSON ref to value from where patch should be applied.",
+                            "description": "Source of a patch: nested JSON path segments of the value to read. Pair with mutatedRef; sequences must be the same length. Index i of mutatorRef is copied onto index i of mutatedRef.\n\nThe pairing spans the two related selector items: a mutatorRef on one side (commonly the `from` item) supplies values to the mutatedRef on the related item of the other side, entry by entry, by index. Each path resolves relative to its own selector item's component document.\n\nExample: mutatorRef [[config, url], [config, name]] patches onto mutatedRef [[configPatch, value], [name]]. Paths are relative to the Meshery component document (configuration, displayName, component.kind), not raw Kubernetes YAML. \"_\" may mark only the first array position in a path.\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "The sequence of mutatorRef and mutatedRef must match. eg: mutatorRef: [[config, url], [config, name]], mutatedRef: [[configPatch, value], [name]]. The value [config, url] will be patched at [configPatch, value]. Similarly [config,name] will be patched at [name]."
+                              "description": "One path as an array of string segments, e.g. [configuration, metadata, name]."
                             }
                           },
                           "mutatedRef": {
@@ -6434,12 +6483,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "mutatedRef,omitempty"
                             },
                             "type": "array",
+                            "description": "Sink of a patch: nested JSON path segments (JSONPath) of the field to write. Pair with mutatorRef; sequences must be the same length. The mutatorRef it pairs with lives on the related selector item of the other side, and each path resolves relative to its own selector item's component document.\n\nmutatedRef currently does not support patching an array value itself. Omit patch entirely when the relationship only matches (tagsets, annotation).\n",
                             "items": {
                               "type": "array",
                               "items": {
                                 "type": "string"
                               },
-                              "description": "JSONPath (https://en.wikipedia.org/wiki/JSONPath) to property to be patched."
+                              "description": "One path as an array of string segments, e.g. [configuration, spec, containers, _, name]."
                             }
                           }
                         }


### PR DESCRIPTION
## Summary

- Documents canonical `kind` / `type` / `subType` combinations on the v1beta3 relationship construct (`schemas/constructs/v1beta3/relationship/`).
- Clarifies `mutatorRef` (source) vs `mutatedRef` (sink), paired sequences, and hierarchical `from`=child / `to`=parent.
- Adds [`docs/relationship-definition-taxonomy.md`](docs/relationship-definition-taxonomy.md). `type` and `subType` stay open strings (not enums).

Companion: meshery/meshery#21479 (contributor skill + docs).

## Test plan

- [x] `make validate-schemas`
- [x] `make build` (generated comments updated locally; not committed — master automation regenerates `models/` and `typescript/generated/`)
- [ ] Confirm published OpenAPI/docs pick up the new descriptions after generate-on-master.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a relationship-definition taxonomy covering canonical kinds, types, subtypes, hierarchy, data flow, and action semantics.
  * Expanded guidance for relationship references, selector direction, path pairing, JSONPath usage, patches, and match-only configurations.
  * Clarified schema documentation with canonical values, encoding rules, examples, and contributor resources.
  * No validation or structural behavior changes were introduced.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->