### PR TITLE
fix(relationship): add 'replace' to v1beta3 patchStrategy enum

### DIFF
--- a/models/v1beta2/relationship/relationship.go
+++ b/models/v1beta2/relationship/relationship.go
@@ -126,6 +126,7 @@ const (
 	Merge     RelationshipDefinitionSelectorsPatchStrategy = "merge"
 	Move      RelationshipDefinitionSelectorsPatchStrategy = "move"
 	Remove    RelationshipDefinitionSelectorsPatchStrategy = "remove"
+	Replace   RelationshipDefinitionSelectorsPatchStrategy = "replace"
 	Strategic RelationshipDefinitionSelectorsPatchStrategy = "strategic"
 	Test      RelationshipDefinitionSelectorsPatchStrategy = "test"
 )
@@ -342,6 +343,7 @@ type RelationshipDefinitionSelectorsPatch struct {
 	// merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
 	// strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
 	// remove: Removes a value.
+	// replace: Replaces the value at the target location.
 	// copy: Copies a value from one location to another.
 	// move: Moves a value from one location to another.
 	// test: Tests that a value at the target location is equal to a specified value.
@@ -354,6 +356,7 @@ type RelationshipDefinitionSelectorsPatch struct {
 // merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
 // strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
 // remove: Removes a value.
+// replace: Replaces the value at the target location.
 // copy: Copies a value from one location to another.
 // move: Moves a value from one location to another.
 // test: Tests that a value at the target location is equal to a specified value.

--- a/models/v1beta3/relationship/relationship.go
+++ b/models/v1beta3/relationship/relationship.go
@@ -126,6 +126,7 @@ const (
 	Merge     RelationshipDefinitionSelectorsPatchStrategy = "merge"
 	Move      RelationshipDefinitionSelectorsPatchStrategy = "move"
 	Remove    RelationshipDefinitionSelectorsPatchStrategy = "remove"
+	Replace   RelationshipDefinitionSelectorsPatchStrategy = "replace"
 	Strategic RelationshipDefinitionSelectorsPatchStrategy = "strategic"
 	Test      RelationshipDefinitionSelectorsPatchStrategy = "test"
 )
@@ -342,6 +343,7 @@ type RelationshipDefinitionSelectorsPatch struct {
 	// merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
 	// strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
 	// remove: Removes a value.
+	// replace: Replaces the value at the target location.
 	// copy: Copies a value from one location to another.
 	// move: Moves a value from one location to another.
 	// test: Tests that a value at the target location is equal to a specified value.
@@ -354,6 +356,7 @@ type RelationshipDefinitionSelectorsPatch struct {
 // merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
 // strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
 // remove: Removes a value.
+// replace: Replaces the value at the target location.
 // copy: Copies a value from one location to another.
 // move: Moves a value from one location to another.
 // test: Tests that a value at the target location is equal to a specified value.

--- a/schemas/constructs/v1beta2/relationship/api.yml
+++ b/schemas/constructs/v1beta2/relationship/api.yml
@@ -43,6 +43,7 @@ components:
         merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
         strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
         remove: Removes a value.
+        replace: Replaces the value at the target location.
         copy: Copies a value from one location to another.
         move: Moves a value from one location to another.
         test: Tests that a value at the target location is equal to a specified value.
@@ -51,6 +52,7 @@ components:
         - strategic
         - add
         - remove
+        - replace
         - copy
         - move
         - test

--- a/schemas/constructs/v1beta3/relationship/api.yml
+++ b/schemas/constructs/v1beta3/relationship/api.yml
@@ -43,6 +43,7 @@ components:
         merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
         strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
         remove: Removes a value.
+        replace: Replaces the value at the target location.
         copy: Copies a value from one location to another.
         move: Moves a value from one location to another.
         test: Tests that a value at the target location is equal to a specified value.
@@ -51,6 +52,7 @@ components:
         - strategic
         - add
         - remove
+        - replace
         - copy
         - move
         - test

--- a/typescript/generated/v1beta2/design/Design.ts
+++ b/typescript/generated/v1beta2/design/Design.ts
@@ -1527,12 +1527,13 @@ export interface components {
                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                  *     remove: Removes a value.
+                                 *     replace: Replaces the value at the target location.
                                  *     copy: Copies a value from one location to another.
                                  *     move: Moves a value from one location to another.
                                  *     test: Tests that a value at the target location is equal to a specified value.
                                  * @enum {string}
                                  */
-                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                 /** @description JSON ref to value from where patch should be applied. */
                                 mutatorRef?: string[][];
                                 mutatedRef?: string[][];
@@ -1618,12 +1619,13 @@ export interface components {
                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                  *     remove: Removes a value.
+                                 *     replace: Replaces the value at the target location.
                                  *     copy: Copies a value from one location to another.
                                  *     move: Moves a value from one location to another.
                                  *     test: Tests that a value at the target location is equal to a specified value.
                                  * @enum {string}
                                  */
-                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                 /** @description JSON ref to value from where patch should be applied. */
                                 mutatorRef?: string[][];
                                 mutatedRef?: string[][];
@@ -1712,12 +1714,13 @@ export interface components {
                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                  *     remove: Removes a value.
+                                 *     replace: Replaces the value at the target location.
                                  *     copy: Copies a value from one location to another.
                                  *     move: Moves a value from one location to another.
                                  *     test: Tests that a value at the target location is equal to a specified value.
                                  * @enum {string}
                                  */
-                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                 /** @description JSON ref to value from where patch should be applied. */
                                 mutatorRef?: string[][];
                                 mutatedRef?: string[][];
@@ -1803,12 +1806,13 @@ export interface components {
                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                  *     remove: Removes a value.
+                                 *     replace: Replaces the value at the target location.
                                  *     copy: Copies a value from one location to another.
                                  *     move: Moves a value from one location to another.
                                  *     test: Tests that a value at the target location is equal to a specified value.
                                  * @enum {string}
                                  */
-                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                 /** @description JSON ref to value from where patch should be applied. */
                                 mutatorRef?: string[][];
                                 mutatedRef?: string[][];
@@ -2986,12 +2990,13 @@ export interface components {
                                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                      *     remove: Removes a value.
+                                     *     replace: Replaces the value at the target location.
                                      *     copy: Copies a value from one location to another.
                                      *     move: Moves a value from one location to another.
                                      *     test: Tests that a value at the target location is equal to a specified value.
                                      * @enum {string}
                                      */
-                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                     /** @description JSON ref to value from where patch should be applied. */
                                     mutatorRef?: string[][];
                                     mutatedRef?: string[][];
@@ -3077,12 +3082,13 @@ export interface components {
                                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                      *     remove: Removes a value.
+                                     *     replace: Replaces the value at the target location.
                                      *     copy: Copies a value from one location to another.
                                      *     move: Moves a value from one location to another.
                                      *     test: Tests that a value at the target location is equal to a specified value.
                                      * @enum {string}
                                      */
-                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                     /** @description JSON ref to value from where patch should be applied. */
                                     mutatorRef?: string[][];
                                     mutatedRef?: string[][];
@@ -3171,12 +3177,13 @@ export interface components {
                                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                      *     remove: Removes a value.
+                                     *     replace: Replaces the value at the target location.
                                      *     copy: Copies a value from one location to another.
                                      *     move: Moves a value from one location to another.
                                      *     test: Tests that a value at the target location is equal to a specified value.
                                      * @enum {string}
                                      */
-                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                     /** @description JSON ref to value from where patch should be applied. */
                                     mutatorRef?: string[][];
                                     mutatedRef?: string[][];
@@ -3262,12 +3269,13 @@ export interface components {
                                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                      *     remove: Removes a value.
+                                     *     replace: Replaces the value at the target location.
                                      *     copy: Copies a value from one location to another.
                                      *     move: Moves a value from one location to another.
                                      *     test: Tests that a value at the target location is equal to a specified value.
                                      * @enum {string}
                                      */
-                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                     /** @description JSON ref to value from where patch should be applied. */
                                     mutatorRef?: string[][];
                                     mutatedRef?: string[][];
@@ -4457,12 +4465,13 @@ export interface components {
                                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                          *     remove: Removes a value.
+                                         *     replace: Replaces the value at the target location.
                                          *     copy: Copies a value from one location to another.
                                          *     move: Moves a value from one location to another.
                                          *     test: Tests that a value at the target location is equal to a specified value.
                                          * @enum {string}
                                          */
-                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                         /** @description JSON ref to value from where patch should be applied. */
                                         mutatorRef?: string[][];
                                         mutatedRef?: string[][];
@@ -4548,12 +4557,13 @@ export interface components {
                                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                          *     remove: Removes a value.
+                                         *     replace: Replaces the value at the target location.
                                          *     copy: Copies a value from one location to another.
                                          *     move: Moves a value from one location to another.
                                          *     test: Tests that a value at the target location is equal to a specified value.
                                          * @enum {string}
                                          */
-                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                         /** @description JSON ref to value from where patch should be applied. */
                                         mutatorRef?: string[][];
                                         mutatedRef?: string[][];
@@ -4642,12 +4652,13 @@ export interface components {
                                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                          *     remove: Removes a value.
+                                         *     replace: Replaces the value at the target location.
                                          *     copy: Copies a value from one location to another.
                                          *     move: Moves a value from one location to another.
                                          *     test: Tests that a value at the target location is equal to a specified value.
                                          * @enum {string}
                                          */
-                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                         /** @description JSON ref to value from where patch should be applied. */
                                         mutatorRef?: string[][];
                                         mutatedRef?: string[][];
@@ -4733,12 +4744,13 @@ export interface components {
                                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                          *     remove: Removes a value.
+                                         *     replace: Replaces the value at the target location.
                                          *     copy: Copies a value from one location to another.
                                          *     move: Moves a value from one location to another.
                                          *     test: Tests that a value at the target location is equal to a specified value.
                                          * @enum {string}
                                          */
-                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                         /** @description JSON ref to value from where patch should be applied. */
                                         mutatorRef?: string[][];
                                         mutatedRef?: string[][];
@@ -5937,12 +5949,13 @@ export interface components {
                                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                          *     remove: Removes a value.
+                                         *     replace: Replaces the value at the target location.
                                          *     copy: Copies a value from one location to another.
                                          *     move: Moves a value from one location to another.
                                          *     test: Tests that a value at the target location is equal to a specified value.
                                          * @enum {string}
                                          */
-                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                         /** @description JSON ref to value from where patch should be applied. */
                                         mutatorRef?: string[][];
                                         mutatedRef?: string[][];
@@ -6028,12 +6041,13 @@ export interface components {
                                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                          *     remove: Removes a value.
+                                         *     replace: Replaces the value at the target location.
                                          *     copy: Copies a value from one location to another.
                                          *     move: Moves a value from one location to another.
                                          *     test: Tests that a value at the target location is equal to a specified value.
                                          * @enum {string}
                                          */
-                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                         /** @description JSON ref to value from where patch should be applied. */
                                         mutatorRef?: string[][];
                                         mutatedRef?: string[][];
@@ -6122,12 +6136,13 @@ export interface components {
                                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                          *     remove: Removes a value.
+                                         *     replace: Replaces the value at the target location.
                                          *     copy: Copies a value from one location to another.
                                          *     move: Moves a value from one location to another.
                                          *     test: Tests that a value at the target location is equal to a specified value.
                                          * @enum {string}
                                          */
-                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                         /** @description JSON ref to value from where patch should be applied. */
                                         mutatorRef?: string[][];
                                         mutatedRef?: string[][];
@@ -6213,12 +6228,13 @@ export interface components {
                                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                          *     remove: Removes a value.
+                                         *     replace: Replaces the value at the target location.
                                          *     copy: Copies a value from one location to another.
                                          *     move: Moves a value from one location to another.
                                          *     test: Tests that a value at the target location is equal to a specified value.
                                          * @enum {string}
                                          */
-                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                         /** @description JSON ref to value from where patch should be applied. */
                                         mutatorRef?: string[][];
                                         mutatedRef?: string[][];
@@ -7488,12 +7504,13 @@ export interface components {
                                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                          *     remove: Removes a value.
+                                         *     replace: Replaces the value at the target location.
                                          *     copy: Copies a value from one location to another.
                                          *     move: Moves a value from one location to another.
                                          *     test: Tests that a value at the target location is equal to a specified value.
                                          * @enum {string}
                                          */
-                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                         /** @description JSON ref to value from where patch should be applied. */
                                         mutatorRef?: string[][];
                                         mutatedRef?: string[][];
@@ -7579,12 +7596,13 @@ export interface components {
                                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                          *     remove: Removes a value.
+                                         *     replace: Replaces the value at the target location.
                                          *     copy: Copies a value from one location to another.
                                          *     move: Moves a value from one location to another.
                                          *     test: Tests that a value at the target location is equal to a specified value.
                                          * @enum {string}
                                          */
-                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                         /** @description JSON ref to value from where patch should be applied. */
                                         mutatorRef?: string[][];
                                         mutatedRef?: string[][];
@@ -7673,12 +7691,13 @@ export interface components {
                                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                          *     remove: Removes a value.
+                                         *     replace: Replaces the value at the target location.
                                          *     copy: Copies a value from one location to another.
                                          *     move: Moves a value from one location to another.
                                          *     test: Tests that a value at the target location is equal to a specified value.
                                          * @enum {string}
                                          */
-                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                         /** @description JSON ref to value from where patch should be applied. */
                                         mutatorRef?: string[][];
                                         mutatedRef?: string[][];
@@ -7764,12 +7783,13 @@ export interface components {
                                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                          *     remove: Removes a value.
+                                         *     replace: Replaces the value at the target location.
                                          *     copy: Copies a value from one location to another.
                                          *     move: Moves a value from one location to another.
                                          *     test: Tests that a value at the target location is equal to a specified value.
                                          * @enum {string}
                                          */
-                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                         /** @description JSON ref to value from where patch should be applied. */
                                         mutatorRef?: string[][];
                                         mutatedRef?: string[][];
@@ -9166,12 +9186,13 @@ export interface operations {
                                                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                      *     remove: Removes a value.
+                                                     *     replace: Replaces the value at the target location.
                                                      *     copy: Copies a value from one location to another.
                                                      *     move: Moves a value from one location to another.
                                                      *     test: Tests that a value at the target location is equal to a specified value.
                                                      * @enum {string}
                                                      */
-                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                     /** @description JSON ref to value from where patch should be applied. */
                                                     mutatorRef?: string[][];
                                                     mutatedRef?: string[][];
@@ -9257,12 +9278,13 @@ export interface operations {
                                                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                      *     remove: Removes a value.
+                                                     *     replace: Replaces the value at the target location.
                                                      *     copy: Copies a value from one location to another.
                                                      *     move: Moves a value from one location to another.
                                                      *     test: Tests that a value at the target location is equal to a specified value.
                                                      * @enum {string}
                                                      */
-                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                     /** @description JSON ref to value from where patch should be applied. */
                                                     mutatorRef?: string[][];
                                                     mutatedRef?: string[][];
@@ -9351,12 +9373,13 @@ export interface operations {
                                                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                      *     remove: Removes a value.
+                                                     *     replace: Replaces the value at the target location.
                                                      *     copy: Copies a value from one location to another.
                                                      *     move: Moves a value from one location to another.
                                                      *     test: Tests that a value at the target location is equal to a specified value.
                                                      * @enum {string}
                                                      */
-                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                     /** @description JSON ref to value from where patch should be applied. */
                                                     mutatorRef?: string[][];
                                                     mutatedRef?: string[][];
@@ -9442,12 +9465,13 @@ export interface operations {
                                                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                      *     remove: Removes a value.
+                                                     *     replace: Replaces the value at the target location.
                                                      *     copy: Copies a value from one location to another.
                                                      *     move: Moves a value from one location to another.
                                                      *     test: Tests that a value at the target location is equal to a specified value.
                                                      * @enum {string}
                                                      */
-                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                     /** @description JSON ref to value from where patch should be applied. */
                                                     mutatorRef?: string[][];
                                                     mutatedRef?: string[][];
@@ -10669,12 +10693,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -10760,12 +10785,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -10854,12 +10880,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -10945,12 +10972,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -12153,12 +12181,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -12244,12 +12273,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -12338,12 +12368,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -12429,12 +12460,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -13909,12 +13941,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -14000,12 +14033,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -14094,12 +14128,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -14185,12 +14220,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -15471,12 +15507,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -15562,12 +15599,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -15656,12 +15694,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -15747,12 +15786,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -17130,12 +17170,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -17221,12 +17262,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -17315,12 +17357,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -17406,12 +17449,13 @@ export interface operations {
                                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                  *     remove: Removes a value.
+                                                 *     replace: Replaces the value at the target location.
                                                  *     copy: Copies a value from one location to another.
                                                  *     move: Moves a value from one location to another.
                                                  *     test: Tests that a value at the target location is equal to a specified value.
                                                  * @enum {string}
                                                  */
-                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                 /** @description JSON ref to value from where patch should be applied. */
                                                 mutatorRef?: string[][];
                                                 mutatedRef?: string[][];
@@ -18665,12 +18709,13 @@ export interface operations {
                                                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                      *     remove: Removes a value.
+                                                     *     replace: Replaces the value at the target location.
                                                      *     copy: Copies a value from one location to another.
                                                      *     move: Moves a value from one location to another.
                                                      *     test: Tests that a value at the target location is equal to a specified value.
                                                      * @enum {string}
                                                      */
-                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                     /** @description JSON ref to value from where patch should be applied. */
                                                     mutatorRef?: string[][];
                                                     mutatedRef?: string[][];
@@ -18756,12 +18801,13 @@ export interface operations {
                                                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                      *     remove: Removes a value.
+                                                     *     replace: Replaces the value at the target location.
                                                      *     copy: Copies a value from one location to another.
                                                      *     move: Moves a value from one location to another.
                                                      *     test: Tests that a value at the target location is equal to a specified value.
                                                      * @enum {string}
                                                      */
-                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                     /** @description JSON ref to value from where patch should be applied. */
                                                     mutatorRef?: string[][];
                                                     mutatedRef?: string[][];
@@ -18850,12 +18896,13 @@ export interface operations {
                                                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                      *     remove: Removes a value.
+                                                     *     replace: Replaces the value at the target location.
                                                      *     copy: Copies a value from one location to another.
                                                      *     move: Moves a value from one location to another.
                                                      *     test: Tests that a value at the target location is equal to a specified value.
                                                      * @enum {string}
                                                      */
-                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                     /** @description JSON ref to value from where patch should be applied. */
                                                     mutatorRef?: string[][];
                                                     mutatedRef?: string[][];
@@ -18941,12 +18988,13 @@ export interface operations {
                                                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                                      *     remove: Removes a value.
+                                                     *     replace: Replaces the value at the target location.
                                                      *     copy: Copies a value from one location to another.
                                                      *     move: Moves a value from one location to another.
                                                      *     test: Tests that a value at the target location is equal to a specified value.
                                                      * @enum {string}
                                                      */
-                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                                     /** @description JSON ref to value from where patch should be applied. */
                                                     mutatorRef?: string[][];
                                                     mutatedRef?: string[][];

--- a/typescript/generated/v1beta2/design/DesignSchema.ts
+++ b/typescript/generated/v1beta2/design/DesignSchema.ts
@@ -3821,12 +3821,13 @@ const DesignSchema: Record<string, unknown> = {
                                                                 "json": "patchStrategy,omitempty"
                                                               },
                                                               "type": "string",
-                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                               "enum": [
                                                                 "merge",
                                                                 "strategic",
                                                                 "add",
                                                                 "remove",
+                                                                "replace",
                                                                 "copy",
                                                                 "move",
                                                                 "test"
@@ -4167,12 +4168,13 @@ const DesignSchema: Record<string, unknown> = {
                                                                 "json": "patchStrategy,omitempty"
                                                               },
                                                               "type": "string",
-                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                               "enum": [
                                                                 "merge",
                                                                 "strategic",
                                                                 "add",
                                                                 "remove",
+                                                                "replace",
                                                                 "copy",
                                                                 "move",
                                                                 "test"
@@ -4527,12 +4529,13 @@ const DesignSchema: Record<string, unknown> = {
                                                                 "json": "patchStrategy,omitempty"
                                                               },
                                                               "type": "string",
-                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                               "enum": [
                                                                 "merge",
                                                                 "strategic",
                                                                 "add",
                                                                 "remove",
+                                                                "replace",
                                                                 "copy",
                                                                 "move",
                                                                 "test"
@@ -4873,12 +4876,13 @@ const DesignSchema: Record<string, unknown> = {
                                                                 "json": "patchStrategy,omitempty"
                                                               },
                                                               "type": "string",
-                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                               "enum": [
                                                                 "merge",
                                                                 "strategic",
                                                                 "add",
                                                                 "remove",
+                                                                "replace",
                                                                 "copy",
                                                                 "move",
                                                                 "test"
@@ -8683,12 +8687,13 @@ const DesignSchema: Record<string, unknown> = {
                                                             "json": "patchStrategy,omitempty"
                                                           },
                                                           "type": "string",
-                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                           "enum": [
                                                             "merge",
                                                             "strategic",
                                                             "add",
                                                             "remove",
+                                                            "replace",
                                                             "copy",
                                                             "move",
                                                             "test"
@@ -9029,12 +9034,13 @@ const DesignSchema: Record<string, unknown> = {
                                                             "json": "patchStrategy,omitempty"
                                                           },
                                                           "type": "string",
-                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                           "enum": [
                                                             "merge",
                                                             "strategic",
                                                             "add",
                                                             "remove",
+                                                            "replace",
                                                             "copy",
                                                             "move",
                                                             "test"
@@ -9389,12 +9395,13 @@ const DesignSchema: Record<string, unknown> = {
                                                             "json": "patchStrategy,omitempty"
                                                           },
                                                           "type": "string",
-                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                           "enum": [
                                                             "merge",
                                                             "strategic",
                                                             "add",
                                                             "remove",
+                                                            "replace",
                                                             "copy",
                                                             "move",
                                                             "test"
@@ -9735,12 +9742,13 @@ const DesignSchema: Record<string, unknown> = {
                                                             "json": "patchStrategy,omitempty"
                                                           },
                                                           "type": "string",
-                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                           "enum": [
                                                             "merge",
                                                             "strategic",
                                                             "add",
                                                             "remove",
+                                                            "replace",
                                                             "copy",
                                                             "move",
                                                             "test"
@@ -13511,12 +13519,13 @@ const DesignSchema: Record<string, unknown> = {
                                                           "json": "patchStrategy,omitempty"
                                                         },
                                                         "type": "string",
-                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                         "enum": [
                                                           "merge",
                                                           "strategic",
                                                           "add",
                                                           "remove",
+                                                          "replace",
                                                           "copy",
                                                           "move",
                                                           "test"
@@ -13857,12 +13866,13 @@ const DesignSchema: Record<string, unknown> = {
                                                           "json": "patchStrategy,omitempty"
                                                         },
                                                         "type": "string",
-                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                         "enum": [
                                                           "merge",
                                                           "strategic",
                                                           "add",
                                                           "remove",
+                                                          "replace",
                                                           "copy",
                                                           "move",
                                                           "test"
@@ -14217,12 +14227,13 @@ const DesignSchema: Record<string, unknown> = {
                                                           "json": "patchStrategy,omitempty"
                                                         },
                                                         "type": "string",
-                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                         "enum": [
                                                           "merge",
                                                           "strategic",
                                                           "add",
                                                           "remove",
+                                                          "replace",
                                                           "copy",
                                                           "move",
                                                           "test"
@@ -14563,12 +14574,13 @@ const DesignSchema: Record<string, unknown> = {
                                                           "json": "patchStrategy,omitempty"
                                                         },
                                                         "type": "string",
-                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                         "enum": [
                                                           "merge",
                                                           "strategic",
                                                           "add",
                                                           "remove",
+                                                          "replace",
                                                           "copy",
                                                           "move",
                                                           "test"
@@ -18708,12 +18720,13 @@ const DesignSchema: Record<string, unknown> = {
                                                           "json": "patchStrategy,omitempty"
                                                         },
                                                         "type": "string",
-                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                         "enum": [
                                                           "merge",
                                                           "strategic",
                                                           "add",
                                                           "remove",
+                                                          "replace",
                                                           "copy",
                                                           "move",
                                                           "test"
@@ -19054,12 +19067,13 @@ const DesignSchema: Record<string, unknown> = {
                                                           "json": "patchStrategy,omitempty"
                                                         },
                                                         "type": "string",
-                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                         "enum": [
                                                           "merge",
                                                           "strategic",
                                                           "add",
                                                           "remove",
+                                                          "replace",
                                                           "copy",
                                                           "move",
                                                           "test"
@@ -19414,12 +19428,13 @@ const DesignSchema: Record<string, unknown> = {
                                                           "json": "patchStrategy,omitempty"
                                                         },
                                                         "type": "string",
-                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                         "enum": [
                                                           "merge",
                                                           "strategic",
                                                           "add",
                                                           "remove",
+                                                          "replace",
                                                           "copy",
                                                           "move",
                                                           "test"
@@ -19760,12 +19775,13 @@ const DesignSchema: Record<string, unknown> = {
                                                           "json": "patchStrategy,omitempty"
                                                         },
                                                         "type": "string",
-                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                         "enum": [
                                                           "merge",
                                                           "strategic",
                                                           "add",
                                                           "remove",
+                                                          "replace",
                                                           "copy",
                                                           "move",
                                                           "test"
@@ -23640,12 +23656,13 @@ const DesignSchema: Record<string, unknown> = {
                                                           "json": "patchStrategy,omitempty"
                                                         },
                                                         "type": "string",
-                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                         "enum": [
                                                           "merge",
                                                           "strategic",
                                                           "add",
                                                           "remove",
+                                                          "replace",
                                                           "copy",
                                                           "move",
                                                           "test"
@@ -23986,12 +24003,13 @@ const DesignSchema: Record<string, unknown> = {
                                                           "json": "patchStrategy,omitempty"
                                                         },
                                                         "type": "string",
-                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                         "enum": [
                                                           "merge",
                                                           "strategic",
                                                           "add",
                                                           "remove",
+                                                          "replace",
                                                           "copy",
                                                           "move",
                                                           "test"
@@ -24346,12 +24364,13 @@ const DesignSchema: Record<string, unknown> = {
                                                           "json": "patchStrategy,omitempty"
                                                         },
                                                         "type": "string",
-                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                         "enum": [
                                                           "merge",
                                                           "strategic",
                                                           "add",
                                                           "remove",
+                                                          "replace",
                                                           "copy",
                                                           "move",
                                                           "test"
@@ -24692,12 +24711,13 @@ const DesignSchema: Record<string, unknown> = {
                                                           "json": "patchStrategy,omitempty"
                                                         },
                                                         "type": "string",
-                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                         "enum": [
                                                           "merge",
                                                           "strategic",
                                                           "add",
                                                           "remove",
+                                                          "replace",
                                                           "copy",
                                                           "move",
                                                           "test"
@@ -28728,12 +28748,13 @@ const DesignSchema: Record<string, unknown> = {
                                                             "json": "patchStrategy,omitempty"
                                                           },
                                                           "type": "string",
-                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                           "enum": [
                                                             "merge",
                                                             "strategic",
                                                             "add",
                                                             "remove",
+                                                            "replace",
                                                             "copy",
                                                             "move",
                                                             "test"
@@ -29074,12 +29095,13 @@ const DesignSchema: Record<string, unknown> = {
                                                             "json": "patchStrategy,omitempty"
                                                           },
                                                           "type": "string",
-                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                           "enum": [
                                                             "merge",
                                                             "strategic",
                                                             "add",
                                                             "remove",
+                                                            "replace",
                                                             "copy",
                                                             "move",
                                                             "test"
@@ -29434,12 +29456,13 @@ const DesignSchema: Record<string, unknown> = {
                                                             "json": "patchStrategy,omitempty"
                                                           },
                                                           "type": "string",
-                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                           "enum": [
                                                             "merge",
                                                             "strategic",
                                                             "add",
                                                             "remove",
+                                                            "replace",
                                                             "copy",
                                                             "move",
                                                             "test"
@@ -29780,12 +29803,13 @@ const DesignSchema: Record<string, unknown> = {
                                                             "json": "patchStrategy,omitempty"
                                                           },
                                                           "type": "string",
-                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                           "enum": [
                                                             "merge",
                                                             "strategic",
                                                             "add",
                                                             "remove",
+                                                            "replace",
                                                             "copy",
                                                             "move",
                                                             "test"
@@ -33703,12 +33727,13 @@ const DesignSchema: Record<string, unknown> = {
                                                                 "json": "patchStrategy,omitempty"
                                                               },
                                                               "type": "string",
-                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                               "enum": [
                                                                 "merge",
                                                                 "strategic",
                                                                 "add",
                                                                 "remove",
+                                                                "replace",
                                                                 "copy",
                                                                 "move",
                                                                 "test"
@@ -34049,12 +34074,13 @@ const DesignSchema: Record<string, unknown> = {
                                                                 "json": "patchStrategy,omitempty"
                                                               },
                                                               "type": "string",
-                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                               "enum": [
                                                                 "merge",
                                                                 "strategic",
                                                                 "add",
                                                                 "remove",
+                                                                "replace",
                                                                 "copy",
                                                                 "move",
                                                                 "test"
@@ -34409,12 +34435,13 @@ const DesignSchema: Record<string, unknown> = {
                                                                 "json": "patchStrategy,omitempty"
                                                               },
                                                               "type": "string",
-                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                               "enum": [
                                                                 "merge",
                                                                 "strategic",
                                                                 "add",
                                                                 "remove",
+                                                                "replace",
                                                                 "copy",
                                                                 "move",
                                                                 "test"
@@ -34755,12 +34782,13 @@ const DesignSchema: Record<string, unknown> = {
                                                                 "json": "patchStrategy,omitempty"
                                                               },
                                                               "type": "string",
-                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                               "enum": [
                                                                 "merge",
                                                                 "strategic",
                                                                 "add",
                                                                 "remove",
+                                                                "replace",
                                                                 "copy",
                                                                 "move",
                                                                 "test"
@@ -39532,12 +39560,13 @@ const DesignSchema: Record<string, unknown> = {
                                             "json": "patchStrategy,omitempty"
                                           },
                                           "type": "string",
-                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                           "enum": [
                                             "merge",
                                             "strategic",
                                             "add",
                                             "remove",
+                                            "replace",
                                             "copy",
                                             "move",
                                             "test"
@@ -39878,12 +39907,13 @@ const DesignSchema: Record<string, unknown> = {
                                             "json": "patchStrategy,omitempty"
                                           },
                                           "type": "string",
-                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                           "enum": [
                                             "merge",
                                             "strategic",
                                             "add",
                                             "remove",
+                                            "replace",
                                             "copy",
                                             "move",
                                             "test"
@@ -40238,12 +40268,13 @@ const DesignSchema: Record<string, unknown> = {
                                             "json": "patchStrategy,omitempty"
                                           },
                                           "type": "string",
-                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                           "enum": [
                                             "merge",
                                             "strategic",
                                             "add",
                                             "remove",
+                                            "replace",
                                             "copy",
                                             "move",
                                             "test"
@@ -40584,12 +40615,13 @@ const DesignSchema: Record<string, unknown> = {
                                             "json": "patchStrategy,omitempty"
                                           },
                                           "type": "string",
-                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                           "enum": [
                                             "merge",
                                             "strategic",
                                             "add",
                                             "remove",
+                                            "replace",
                                             "copy",
                                             "move",
                                             "test"
@@ -44313,12 +44345,13 @@ const DesignSchema: Record<string, unknown> = {
                                                 "json": "patchStrategy,omitempty"
                                               },
                                               "type": "string",
-                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                               "enum": [
                                                 "merge",
                                                 "strategic",
                                                 "add",
                                                 "remove",
+                                                "replace",
                                                 "copy",
                                                 "move",
                                                 "test"
@@ -44659,12 +44692,13 @@ const DesignSchema: Record<string, unknown> = {
                                                 "json": "patchStrategy,omitempty"
                                               },
                                               "type": "string",
-                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                               "enum": [
                                                 "merge",
                                                 "strategic",
                                                 "add",
                                                 "remove",
+                                                "replace",
                                                 "copy",
                                                 "move",
                                                 "test"
@@ -45019,12 +45053,13 @@ const DesignSchema: Record<string, unknown> = {
                                                 "json": "patchStrategy,omitempty"
                                               },
                                               "type": "string",
-                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                               "enum": [
                                                 "merge",
                                                 "strategic",
                                                 "add",
                                                 "remove",
+                                                "replace",
                                                 "copy",
                                                 "move",
                                                 "test"
@@ -45365,12 +45400,13 @@ const DesignSchema: Record<string, unknown> = {
                                                 "json": "patchStrategy,omitempty"
                                               },
                                               "type": "string",
-                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                              "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                               "enum": [
                                                 "merge",
                                                 "strategic",
                                                 "add",
                                                 "remove",
+                                                "replace",
                                                 "copy",
                                                 "move",
                                                 "test"
@@ -49130,12 +49166,13 @@ const DesignSchema: Record<string, unknown> = {
                                                       "json": "patchStrategy,omitempty"
                                                     },
                                                     "type": "string",
-                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                     "enum": [
                                                       "merge",
                                                       "strategic",
                                                       "add",
                                                       "remove",
+                                                      "replace",
                                                       "copy",
                                                       "move",
                                                       "test"
@@ -49476,12 +49513,13 @@ const DesignSchema: Record<string, unknown> = {
                                                       "json": "patchStrategy,omitempty"
                                                     },
                                                     "type": "string",
-                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                     "enum": [
                                                       "merge",
                                                       "strategic",
                                                       "add",
                                                       "remove",
+                                                      "replace",
                                                       "copy",
                                                       "move",
                                                       "test"
@@ -49836,12 +49874,13 @@ const DesignSchema: Record<string, unknown> = {
                                                       "json": "patchStrategy,omitempty"
                                                     },
                                                     "type": "string",
-                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                     "enum": [
                                                       "merge",
                                                       "strategic",
                                                       "add",
                                                       "remove",
+                                                      "replace",
                                                       "copy",
                                                       "move",
                                                       "test"
@@ -50182,12 +50221,13 @@ const DesignSchema: Record<string, unknown> = {
                                                       "json": "patchStrategy,omitempty"
                                                     },
                                                     "type": "string",
-                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                     "enum": [
                                                       "merge",
                                                       "strategic",
                                                       "add",
                                                       "remove",
+                                                      "replace",
                                                       "copy",
                                                       "move",
                                                       "test"
@@ -53981,12 +54021,13 @@ const DesignSchema: Record<string, unknown> = {
                                                     "json": "patchStrategy,omitempty"
                                                   },
                                                   "type": "string",
-                                                  "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                  "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                   "enum": [
                                                     "merge",
                                                     "strategic",
                                                     "add",
                                                     "remove",
+                                                    "replace",
                                                     "copy",
                                                     "move",
                                                     "test"
@@ -54327,12 +54368,13 @@ const DesignSchema: Record<string, unknown> = {
                                                     "json": "patchStrategy,omitempty"
                                                   },
                                                   "type": "string",
-                                                  "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                  "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                   "enum": [
                                                     "merge",
                                                     "strategic",
                                                     "add",
                                                     "remove",
+                                                    "replace",
                                                     "copy",
                                                     "move",
                                                     "test"
@@ -54687,12 +54729,13 @@ const DesignSchema: Record<string, unknown> = {
                                                     "json": "patchStrategy,omitempty"
                                                   },
                                                   "type": "string",
-                                                  "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                  "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                   "enum": [
                                                     "merge",
                                                     "strategic",
                                                     "add",
                                                     "remove",
+                                                    "replace",
                                                     "copy",
                                                     "move",
                                                     "test"
@@ -55033,12 +55076,13 @@ const DesignSchema: Record<string, unknown> = {
                                                     "json": "patchStrategy,omitempty"
                                                   },
                                                   "type": "string",
-                                                  "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                  "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                   "enum": [
                                                     "merge",
                                                     "strategic",
                                                     "add",
                                                     "remove",
+                                                    "replace",
                                                     "copy",
                                                     "move",
                                                     "test"
@@ -58944,12 +58988,13 @@ const DesignSchema: Record<string, unknown> = {
                                                       "json": "patchStrategy,omitempty"
                                                     },
                                                     "type": "string",
-                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                     "enum": [
                                                       "merge",
                                                       "strategic",
                                                       "add",
                                                       "remove",
+                                                      "replace",
                                                       "copy",
                                                       "move",
                                                       "test"
@@ -59290,12 +59335,13 @@ const DesignSchema: Record<string, unknown> = {
                                                       "json": "patchStrategy,omitempty"
                                                     },
                                                     "type": "string",
-                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                     "enum": [
                                                       "merge",
                                                       "strategic",
                                                       "add",
                                                       "remove",
+                                                      "replace",
                                                       "copy",
                                                       "move",
                                                       "test"
@@ -59650,12 +59696,13 @@ const DesignSchema: Record<string, unknown> = {
                                                       "json": "patchStrategy,omitempty"
                                                     },
                                                     "type": "string",
-                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                     "enum": [
                                                       "merge",
                                                       "strategic",
                                                       "add",
                                                       "remove",
+                                                      "replace",
                                                       "copy",
                                                       "move",
                                                       "test"
@@ -59996,12 +60043,13 @@ const DesignSchema: Record<string, unknown> = {
                                                       "json": "patchStrategy,omitempty"
                                                     },
                                                     "type": "string",
-                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                                    "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                                     "enum": [
                                                       "merge",
                                                       "strategic",
                                                       "add",
                                                       "remove",
+                                                      "replace",
                                                       "copy",
                                                       "move",
                                                       "test"

--- a/typescript/generated/v1beta2/relationship/Relationship.ts
+++ b/typescript/generated/v1beta2/relationship/Relationship.ts
@@ -311,12 +311,13 @@ export interface components {
                              *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                              *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                              *     remove: Removes a value.
+                             *     replace: Replaces the value at the target location.
                              *     copy: Copies a value from one location to another.
                              *     move: Moves a value from one location to another.
                              *     test: Tests that a value at the target location is equal to a specified value.
                              * @enum {string}
                              */
-                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                             /** @description JSON ref to value from where patch should be applied. */
                             mutatorRef?: string[][];
                             mutatedRef?: string[][];
@@ -402,12 +403,13 @@ export interface components {
                              *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                              *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                              *     remove: Removes a value.
+                             *     replace: Replaces the value at the target location.
                              *     copy: Copies a value from one location to another.
                              *     move: Moves a value from one location to another.
                              *     test: Tests that a value at the target location is equal to a specified value.
                              * @enum {string}
                              */
-                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                             /** @description JSON ref to value from where patch should be applied. */
                             mutatorRef?: string[][];
                             mutatedRef?: string[][];
@@ -496,12 +498,13 @@ export interface components {
                              *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                              *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                              *     remove: Removes a value.
+                             *     replace: Replaces the value at the target location.
                              *     copy: Copies a value from one location to another.
                              *     move: Moves a value from one location to another.
                              *     test: Tests that a value at the target location is equal to a specified value.
                              * @enum {string}
                              */
-                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                             /** @description JSON ref to value from where patch should be applied. */
                             mutatorRef?: string[][];
                             mutatedRef?: string[][];
@@ -587,12 +590,13 @@ export interface components {
                              *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                              *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                              *     remove: Removes a value.
+                             *     replace: Replaces the value at the target location.
                              *     copy: Copies a value from one location to another.
                              *     move: Moves a value from one location to another.
                              *     test: Tests that a value at the target location is equal to a specified value.
                              * @enum {string}
                              */
-                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                             /** @description JSON ref to value from where patch should be applied. */
                             mutatorRef?: string[][];
                             mutatedRef?: string[][];
@@ -611,12 +615,13 @@ export interface components {
          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
          *     remove: Removes a value.
+         *     replace: Replaces the value at the target location.
          *     copy: Copies a value from one location to another.
          *     move: Moves a value from one location to another.
          *     test: Tests that a value at the target location is equal to a specified value.
          * @enum {string}
          */
-        RelationshipDefinitionSelectorsPatchStrategy: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+        RelationshipDefinitionSelectorsPatchStrategy: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
         /** @description Patch configuration for the selector */
         RelationshipDefinitionSelectorsPatch: {
             /**
@@ -626,12 +631,13 @@ export interface components {
              *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
              *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
              *     remove: Removes a value.
+             *     replace: Replaces the value at the target location.
              *     copy: Copies a value from one location to another.
              *     move: Moves a value from one location to another.
              *     test: Tests that a value at the target location is equal to a specified value.
              * @enum {string}
              */
-            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
             /** @description JSON ref to value from where patch should be applied. */
             mutatorRef?: string[][];
             mutatedRef?: string[][];
@@ -760,12 +766,13 @@ export interface components {
                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                  *     remove: Removes a value.
+                 *     replace: Replaces the value at the target location.
                  *     copy: Copies a value from one location to another.
                  *     move: Moves a value from one location to another.
                  *     test: Tests that a value at the target location is equal to a specified value.
                  * @enum {string}
                  */
-                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                 /** @description JSON ref to value from where patch should be applied. */
                 mutatorRef?: string[][];
                 mutatedRef?: string[][];
@@ -853,12 +860,13 @@ export interface components {
                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                      *     remove: Removes a value.
+                     *     replace: Replaces the value at the target location.
                      *     copy: Copies a value from one location to another.
                      *     move: Moves a value from one location to another.
                      *     test: Tests that a value at the target location is equal to a specified value.
                      * @enum {string}
                      */
-                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                     /** @description JSON ref to value from where patch should be applied. */
                     mutatorRef?: string[][];
                     mutatedRef?: string[][];
@@ -944,12 +952,13 @@ export interface components {
                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                      *     remove: Removes a value.
+                     *     replace: Replaces the value at the target location.
                      *     copy: Copies a value from one location to another.
                      *     move: Moves a value from one location to another.
                      *     test: Tests that a value at the target location is equal to a specified value.
                      * @enum {string}
                      */
-                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                     /** @description JSON ref to value from where patch should be applied. */
                     mutatorRef?: string[][];
                     mutatedRef?: string[][];
@@ -1040,12 +1049,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1131,12 +1141,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1225,12 +1236,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1316,12 +1328,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1413,12 +1426,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1504,12 +1518,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1598,12 +1613,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1689,12 +1705,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];

--- a/typescript/generated/v1beta2/relationship/RelationshipSchema.ts
+++ b/typescript/generated/v1beta2/relationship/RelationshipSchema.ts
@@ -1154,12 +1154,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "patchStrategy,omitempty"
                                 },
                                 "type": "string",
-                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                 "enum": [
                                   "merge",
                                   "strategic",
                                   "add",
                                   "remove",
+                                  "replace",
                                   "copy",
                                   "move",
                                   "test"
@@ -1500,12 +1501,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "patchStrategy,omitempty"
                                 },
                                 "type": "string",
-                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                 "enum": [
                                   "merge",
                                   "strategic",
                                   "add",
                                   "remove",
+                                  "replace",
                                   "copy",
                                   "move",
                                   "test"
@@ -1860,12 +1862,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "patchStrategy,omitempty"
                                 },
                                 "type": "string",
-                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                 "enum": [
                                   "merge",
                                   "strategic",
                                   "add",
                                   "remove",
+                                  "replace",
                                   "copy",
                                   "move",
                                   "test"
@@ -2206,12 +2209,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "patchStrategy,omitempty"
                                 },
                                 "type": "string",
-                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                 "enum": [
                                   "merge",
                                   "strategic",
                                   "add",
                                   "remove",
+                                  "replace",
                                   "copy",
                                   "move",
                                   "test"
@@ -2282,12 +2286,13 @@ const RelationshipSchema: Record<string, unknown> = {
       },
       "RelationshipDefinitionSelectorsPatchStrategy": {
         "type": "string",
-        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
         "enum": [
           "merge",
           "strategic",
           "add",
           "remove",
+          "replace",
           "copy",
           "move",
           "test"
@@ -2303,12 +2308,13 @@ const RelationshipSchema: Record<string, unknown> = {
               "json": "patchStrategy,omitempty"
             },
             "type": "string",
-            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
             "enum": [
               "merge",
               "strategic",
               "add",
               "remove",
+              "replace",
               "copy",
               "move",
               "test"
@@ -2845,12 +2851,13 @@ const RelationshipSchema: Record<string, unknown> = {
                   "json": "patchStrategy,omitempty"
                 },
                 "type": "string",
-                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                 "enum": [
                   "merge",
                   "strategic",
                   "add",
                   "remove",
+                  "replace",
                   "copy",
                   "move",
                   "test"
@@ -3195,12 +3202,13 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "patchStrategy,omitempty"
                       },
                       "type": "string",
-                      "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                      "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                       "enum": [
                         "merge",
                         "strategic",
                         "add",
                         "remove",
+                        "replace",
                         "copy",
                         "move",
                         "test"
@@ -3541,12 +3549,13 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "patchStrategy,omitempty"
                       },
                       "type": "string",
-                      "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                      "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                       "enum": [
                         "merge",
                         "strategic",
                         "add",
                         "remove",
+                        "replace",
                         "copy",
                         "move",
                         "test"
@@ -3908,12 +3917,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "patchStrategy,omitempty"
                           },
                           "type": "string",
-                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                           "enum": [
                             "merge",
                             "strategic",
                             "add",
                             "remove",
+                            "replace",
                             "copy",
                             "move",
                             "test"
@@ -4254,12 +4264,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "patchStrategy,omitempty"
                           },
                           "type": "string",
-                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                           "enum": [
                             "merge",
                             "strategic",
                             "add",
                             "remove",
+                            "replace",
                             "copy",
                             "move",
                             "test"
@@ -4614,12 +4625,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "patchStrategy,omitempty"
                           },
                           "type": "string",
-                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                           "enum": [
                             "merge",
                             "strategic",
                             "add",
                             "remove",
+                            "replace",
                             "copy",
                             "move",
                             "test"
@@ -4960,12 +4972,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "patchStrategy,omitempty"
                           },
                           "type": "string",
-                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                           "enum": [
                             "merge",
                             "strategic",
                             "add",
                             "remove",
+                            "replace",
                             "copy",
                             "move",
                             "test"
@@ -5336,12 +5349,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "patchStrategy,omitempty"
                             },
                             "type": "string",
-                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                             "enum": [
                               "merge",
                               "strategic",
                               "add",
                               "remove",
+                              "replace",
                               "copy",
                               "move",
                               "test"
@@ -5682,12 +5696,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "patchStrategy,omitempty"
                             },
                             "type": "string",
-                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                             "enum": [
                               "merge",
                               "strategic",
                               "add",
                               "remove",
+                              "replace",
                               "copy",
                               "move",
                               "test"
@@ -6042,12 +6057,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "patchStrategy,omitempty"
                             },
                             "type": "string",
-                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                             "enum": [
                               "merge",
                               "strategic",
                               "add",
                               "remove",
+                              "replace",
                               "copy",
                               "move",
                               "test"
@@ -6388,12 +6404,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "patchStrategy,omitempty"
                             },
                             "type": "string",
-                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                             "enum": [
                               "merge",
                               "strategic",
                               "add",
                               "remove",
+                              "replace",
                               "copy",
                               "move",
                               "test"

--- a/typescript/generated/v1beta3/design/Design.ts
+++ b/typescript/generated/v1beta3/design/Design.ts
@@ -1456,12 +1456,13 @@ export interface components {
                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                  *     remove: Removes a value.
+                                 *     replace: Replaces the value at the target location.
                                  *     copy: Copies a value from one location to another.
                                  *     move: Moves a value from one location to another.
                                  *     test: Tests that a value at the target location is equal to a specified value.
                                  * @enum {string}
                                  */
-                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                 /** @description JSON ref to value from where patch should be applied. */
                                 mutatorRef?: string[][];
                                 mutatedRef?: string[][];
@@ -1547,12 +1548,13 @@ export interface components {
                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                  *     remove: Removes a value.
+                                 *     replace: Replaces the value at the target location.
                                  *     copy: Copies a value from one location to another.
                                  *     move: Moves a value from one location to another.
                                  *     test: Tests that a value at the target location is equal to a specified value.
                                  * @enum {string}
                                  */
-                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                 /** @description JSON ref to value from where patch should be applied. */
                                 mutatorRef?: string[][];
                                 mutatedRef?: string[][];
@@ -1641,12 +1643,13 @@ export interface components {
                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                  *     remove: Removes a value.
+                                 *     replace: Replaces the value at the target location.
                                  *     copy: Copies a value from one location to another.
                                  *     move: Moves a value from one location to another.
                                  *     test: Tests that a value at the target location is equal to a specified value.
                                  * @enum {string}
                                  */
-                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                 /** @description JSON ref to value from where patch should be applied. */
                                 mutatorRef?: string[][];
                                 mutatedRef?: string[][];
@@ -1732,12 +1735,13 @@ export interface components {
                                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                                  *     remove: Removes a value.
+                                 *     replace: Replaces the value at the target location.
                                  *     copy: Copies a value from one location to another.
                                  *     move: Moves a value from one location to another.
                                  *     test: Tests that a value at the target location is equal to a specified value.
                                  * @enum {string}
                                  */
-                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                                 /** @description JSON ref to value from where patch should be applied. */
                                 mutatorRef?: string[][];
                                 mutatedRef?: string[][];

--- a/typescript/generated/v1beta3/design/DesignSchema.ts
+++ b/typescript/generated/v1beta3/design/DesignSchema.ts
@@ -14566,12 +14566,13 @@ const DesignSchema: Record<string, unknown> = {
                                             "json": "patchStrategy,omitempty"
                                           },
                                           "type": "string",
-                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                           "enum": [
                                             "merge",
                                             "strategic",
                                             "add",
                                             "remove",
+                                            "replace",
                                             "copy",
                                             "move",
                                             "test"
@@ -14912,12 +14913,13 @@ const DesignSchema: Record<string, unknown> = {
                                             "json": "patchStrategy,omitempty"
                                           },
                                           "type": "string",
-                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                           "enum": [
                                             "merge",
                                             "strategic",
                                             "add",
                                             "remove",
+                                            "replace",
                                             "copy",
                                             "move",
                                             "test"
@@ -15272,12 +15274,13 @@ const DesignSchema: Record<string, unknown> = {
                                             "json": "patchStrategy,omitempty"
                                           },
                                           "type": "string",
-                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                           "enum": [
                                             "merge",
                                             "strategic",
                                             "add",
                                             "remove",
+                                            "replace",
                                             "copy",
                                             "move",
                                             "test"
@@ -15618,12 +15621,13 @@ const DesignSchema: Record<string, unknown> = {
                                             "json": "patchStrategy,omitempty"
                                           },
                                           "type": "string",
-                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                           "enum": [
                                             "merge",
                                             "strategic",
                                             "add",
                                             "remove",
+                                            "replace",
                                             "copy",
                                             "move",
                                             "test"

--- a/typescript/generated/v1beta3/relationship/Relationship.ts
+++ b/typescript/generated/v1beta3/relationship/Relationship.ts
@@ -311,12 +311,13 @@ export interface components {
                              *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                              *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                              *     remove: Removes a value.
+                             *     replace: Replaces the value at the target location.
                              *     copy: Copies a value from one location to another.
                              *     move: Moves a value from one location to another.
                              *     test: Tests that a value at the target location is equal to a specified value.
                              * @enum {string}
                              */
-                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                             /** @description JSON ref to value from where patch should be applied. */
                             mutatorRef?: string[][];
                             mutatedRef?: string[][];
@@ -402,12 +403,13 @@ export interface components {
                              *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                              *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                              *     remove: Removes a value.
+                             *     replace: Replaces the value at the target location.
                              *     copy: Copies a value from one location to another.
                              *     move: Moves a value from one location to another.
                              *     test: Tests that a value at the target location is equal to a specified value.
                              * @enum {string}
                              */
-                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                             /** @description JSON ref to value from where patch should be applied. */
                             mutatorRef?: string[][];
                             mutatedRef?: string[][];
@@ -496,12 +498,13 @@ export interface components {
                              *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                              *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                              *     remove: Removes a value.
+                             *     replace: Replaces the value at the target location.
                              *     copy: Copies a value from one location to another.
                              *     move: Moves a value from one location to another.
                              *     test: Tests that a value at the target location is equal to a specified value.
                              * @enum {string}
                              */
-                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                             /** @description JSON ref to value from where patch should be applied. */
                             mutatorRef?: string[][];
                             mutatedRef?: string[][];
@@ -587,12 +590,13 @@ export interface components {
                              *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                              *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                              *     remove: Removes a value.
+                             *     replace: Replaces the value at the target location.
                              *     copy: Copies a value from one location to another.
                              *     move: Moves a value from one location to another.
                              *     test: Tests that a value at the target location is equal to a specified value.
                              * @enum {string}
                              */
-                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                             /** @description JSON ref to value from where patch should be applied. */
                             mutatorRef?: string[][];
                             mutatedRef?: string[][];
@@ -611,12 +615,13 @@ export interface components {
          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
          *     remove: Removes a value.
+         *     replace: Replaces the value at the target location.
          *     copy: Copies a value from one location to another.
          *     move: Moves a value from one location to another.
          *     test: Tests that a value at the target location is equal to a specified value.
          * @enum {string}
          */
-        RelationshipDefinitionSelectorsPatchStrategy: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+        RelationshipDefinitionSelectorsPatchStrategy: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
         /** @description Patch configuration for the selector */
         RelationshipDefinitionSelectorsPatch: {
             /**
@@ -626,12 +631,13 @@ export interface components {
              *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
              *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
              *     remove: Removes a value.
+             *     replace: Replaces the value at the target location.
              *     copy: Copies a value from one location to another.
              *     move: Moves a value from one location to another.
              *     test: Tests that a value at the target location is equal to a specified value.
              * @enum {string}
              */
-            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+            patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
             /** @description JSON ref to value from where patch should be applied. */
             mutatorRef?: string[][];
             mutatedRef?: string[][];
@@ -760,12 +766,13 @@ export interface components {
                  *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                  *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                  *     remove: Removes a value.
+                 *     replace: Replaces the value at the target location.
                  *     copy: Copies a value from one location to another.
                  *     move: Moves a value from one location to another.
                  *     test: Tests that a value at the target location is equal to a specified value.
                  * @enum {string}
                  */
-                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                 /** @description JSON ref to value from where patch should be applied. */
                 mutatorRef?: string[][];
                 mutatedRef?: string[][];
@@ -853,12 +860,13 @@ export interface components {
                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                      *     remove: Removes a value.
+                     *     replace: Replaces the value at the target location.
                      *     copy: Copies a value from one location to another.
                      *     move: Moves a value from one location to another.
                      *     test: Tests that a value at the target location is equal to a specified value.
                      * @enum {string}
                      */
-                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                     /** @description JSON ref to value from where patch should be applied. */
                     mutatorRef?: string[][];
                     mutatedRef?: string[][];
@@ -944,12 +952,13 @@ export interface components {
                      *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                      *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                      *     remove: Removes a value.
+                     *     replace: Replaces the value at the target location.
                      *     copy: Copies a value from one location to another.
                      *     move: Moves a value from one location to another.
                      *     test: Tests that a value at the target location is equal to a specified value.
                      * @enum {string}
                      */
-                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                    patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                     /** @description JSON ref to value from where patch should be applied. */
                     mutatorRef?: string[][];
                     mutatedRef?: string[][];
@@ -1040,12 +1049,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1131,12 +1141,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1225,12 +1236,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1316,12 +1328,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1413,12 +1426,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1504,12 +1518,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1598,12 +1613,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];
@@ -1689,12 +1705,13 @@ export interface components {
                          *     merge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.
                          *     strategic: specific to Kubernetes and understands the structure of Kubernetes objects.
                          *     remove: Removes a value.
+                         *     replace: Replaces the value at the target location.
                          *     copy: Copies a value from one location to another.
                          *     move: Moves a value from one location to another.
                          *     test: Tests that a value at the target location is equal to a specified value.
                          * @enum {string}
                          */
-                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "copy" | "move" | "test";
+                        patchStrategy?: "merge" | "strategic" | "add" | "remove" | "replace" | "copy" | "move" | "test";
                         /** @description JSON ref to value from where patch should be applied. */
                         mutatorRef?: string[][];
                         mutatedRef?: string[][];

--- a/typescript/generated/v1beta3/relationship/RelationshipSchema.ts
+++ b/typescript/generated/v1beta3/relationship/RelationshipSchema.ts
@@ -1153,12 +1153,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "patchStrategy,omitempty"
                                 },
                                 "type": "string",
-                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                 "enum": [
                                   "merge",
                                   "strategic",
                                   "add",
                                   "remove",
+                                  "replace",
                                   "copy",
                                   "move",
                                   "test"
@@ -1499,12 +1500,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "patchStrategy,omitempty"
                                 },
                                 "type": "string",
-                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                 "enum": [
                                   "merge",
                                   "strategic",
                                   "add",
                                   "remove",
+                                  "replace",
                                   "copy",
                                   "move",
                                   "test"
@@ -1859,12 +1861,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "patchStrategy,omitempty"
                                 },
                                 "type": "string",
-                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                 "enum": [
                                   "merge",
                                   "strategic",
                                   "add",
                                   "remove",
+                                  "replace",
                                   "copy",
                                   "move",
                                   "test"
@@ -2205,12 +2208,13 @@ const RelationshipSchema: Record<string, unknown> = {
                                   "json": "patchStrategy,omitempty"
                                 },
                                 "type": "string",
-                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                                 "enum": [
                                   "merge",
                                   "strategic",
                                   "add",
                                   "remove",
+                                  "replace",
                                   "copy",
                                   "move",
                                   "test"
@@ -2281,12 +2285,13 @@ const RelationshipSchema: Record<string, unknown> = {
       },
       "RelationshipDefinitionSelectorsPatchStrategy": {
         "type": "string",
-        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+        "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
         "enum": [
           "merge",
           "strategic",
           "add",
           "remove",
+          "replace",
           "copy",
           "move",
           "test"
@@ -2302,12 +2307,13 @@ const RelationshipSchema: Record<string, unknown> = {
               "json": "patchStrategy,omitempty"
             },
             "type": "string",
-            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
             "enum": [
               "merge",
               "strategic",
               "add",
               "remove",
+              "replace",
               "copy",
               "move",
               "test"
@@ -2844,12 +2850,13 @@ const RelationshipSchema: Record<string, unknown> = {
                   "json": "patchStrategy,omitempty"
                 },
                 "type": "string",
-                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                 "enum": [
                   "merge",
                   "strategic",
                   "add",
                   "remove",
+                  "replace",
                   "copy",
                   "move",
                   "test"
@@ -3194,12 +3201,13 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "patchStrategy,omitempty"
                       },
                       "type": "string",
-                      "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                      "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                       "enum": [
                         "merge",
                         "strategic",
                         "add",
                         "remove",
+                        "replace",
                         "copy",
                         "move",
                         "test"
@@ -3540,12 +3548,13 @@ const RelationshipSchema: Record<string, unknown> = {
                         "json": "patchStrategy,omitempty"
                       },
                       "type": "string",
-                      "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                      "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                       "enum": [
                         "merge",
                         "strategic",
                         "add",
                         "remove",
+                        "replace",
                         "copy",
                         "move",
                         "test"
@@ -3907,12 +3916,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "patchStrategy,omitempty"
                           },
                           "type": "string",
-                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                           "enum": [
                             "merge",
                             "strategic",
                             "add",
                             "remove",
+                            "replace",
                             "copy",
                             "move",
                             "test"
@@ -4253,12 +4263,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "patchStrategy,omitempty"
                           },
                           "type": "string",
-                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                           "enum": [
                             "merge",
                             "strategic",
                             "add",
                             "remove",
+                            "replace",
                             "copy",
                             "move",
                             "test"
@@ -4613,12 +4624,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "patchStrategy,omitempty"
                           },
                           "type": "string",
-                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                           "enum": [
                             "merge",
                             "strategic",
                             "add",
                             "remove",
+                            "replace",
                             "copy",
                             "move",
                             "test"
@@ -4959,12 +4971,13 @@ const RelationshipSchema: Record<string, unknown> = {
                             "json": "patchStrategy,omitempty"
                           },
                           "type": "string",
-                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                          "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                           "enum": [
                             "merge",
                             "strategic",
                             "add",
                             "remove",
+                            "replace",
                             "copy",
                             "move",
                             "test"
@@ -5335,12 +5348,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "patchStrategy,omitempty"
                             },
                             "type": "string",
-                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                             "enum": [
                               "merge",
                               "strategic",
                               "add",
                               "remove",
+                              "replace",
                               "copy",
                               "move",
                               "test"
@@ -5681,12 +5695,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "patchStrategy,omitempty"
                             },
                             "type": "string",
-                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                             "enum": [
                               "merge",
                               "strategic",
                               "add",
                               "remove",
+                              "replace",
                               "copy",
                               "move",
                               "test"
@@ -6041,12 +6056,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "patchStrategy,omitempty"
                             },
                             "type": "string",
-                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                             "enum": [
                               "merge",
                               "strategic",
                               "add",
                               "remove",
+                              "replace",
                               "copy",
                               "move",
                               "test"
@@ -6387,12 +6403,13 @@ const RelationshipSchema: Record<string, unknown> = {
                               "json": "patchStrategy,omitempty"
                             },
                             "type": "string",
-                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
+                            "description": "patchStrategy allows you to make specific changes to a resource using a standard JSON Patch format (RFC 6902).\n\nadd: Inserts a value into an array or adds a member to an object.\nmerge: Combines the values of the target location with the values from the patch. If the target location doesn't exist, it is created.\nstrategic: specific to Kubernetes and understands the structure of Kubernetes objects.\nremove: Removes a value.\nreplace: Replaces the value at the target location.\ncopy: Copies a value from one location to another.\nmove: Moves a value from one location to another.\ntest: Tests that a value at the target location is equal to a specified value.\n",
                             "enum": [
                               "merge",
                               "strategic",
                               "add",
                               "remove",
+                              "replace",
                               "copy",
                               "move",
                               "test"


### PR DESCRIPTION
**Description**

This PR fixes meshery/schemas#1165.

Adds `replace` to the v1beta3 `RelationshipDefinitionSelectorsPatchStrategy` enum and regenerates the Go and TypeScript artifacts.

**Why**

- The meshery/meshery in-tree relationship corpus carries 8,303 occurrences of `"patchStrategy": "replace"` and zero of any other strategy value, so every shipped definition is out-of-spec relative to the schema it declares.
- The relationship evaluation engine itself emits `replace` in the patches it constructs (`alias_policy.rego`, `matchlabels-policy.rego` in meshery-core), so the engine's own output cannot round-trip through the schema.
- The enum description cites JSON Patch (RFC 6902), which defines `replace` as a core operation.

**Scope**

- `schemas/constructs/v1beta3/relationship/api.yml`: enum value + description line.
- `models/v1beta3/relationship/relationship.go`, `typescript/generated/v1beta3/relationship/{Relationship,RelationshipSchema}.ts`: regenerated via `make build`.
- v1beta2 carries the same gap but is left untouched (legacy version; discussion in the issue).

Adding an enum value is backward-compatible for readers; no wire shape changes.

Surfaced during review of meshery/meshery#21479, whose teaching examples mirror the in-tree corpus and fail the declared v1beta3 enum without this.

**Verification**

- `make build` (bundle + golang + typescript + dts) - clean
- `make validate-schemas` - no blocking violations
- `make consumer-audit` - 250 specs pass, no handler drift
- `go test ./...` - pass
- `npm run build` - pass

**Notes for Reviewers**

Sibling docs PR #1164 touches nearby description blocks in the same file but not the enum; the two merge independently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `replace` as a supported patch strategy for relationship definition selectors.
  * Available consistently across v1beta2 and v1beta3 APIs.

* **Documentation**
  * Updated patch strategy descriptions to explain the `replace` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->