### PR TITLE
feat: add changeAdapterStatus REST contract

### DIFF
--- a/schemas/constructs/v1beta1/system/api.yml
+++ b/schemas/constructs/v1beta1/system/api.yml
@@ -251,6 +251,36 @@ paths:
           description: Failed to reach the cluster or fetch its server version.
 
   /api/system/sync:
+  /api/system/adapter/status:
+    post:
+      x-internal: ["meshery"]
+      tags:
+        - System
+      summary: Change adapter deploy status
+      description: >-
+        Deploys or undeploys a Meshery adapter. Resolves the adapter's
+        default port when targetPort is omitted, then invokes the
+        adapter tracker to bring the adapter to the requested status.
+      operationId: changeAdapterStatus
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangeAdapterStatusRequest"
+      responses:
+        "200":
+          description: The adapter status change was processed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChangeAdapterStatusResponse"
+        "400":
+          description: Missing or invalid adapter name, target port, or target status.
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          description: Failed to deploy or undeploy the adapter.
     get:
       x-internal: ["meshery"]
       tags:
@@ -496,6 +526,45 @@ components:
           description: Recipient address the test email was sent to.
           format: email
           maxLength: 320
+
+    ChangeAdapterStatusRequest:
+      type: object
+      description: Request body to deploy or undeploy a Meshery adapter.
+      additionalProperties: false
+      required:
+        - adapterName
+        - targetStatus
+      properties:
+        adapterName:
+          type: string
+          description: Name of the adapter to deploy or undeploy.
+          maxLength: 256
+        targetPort:
+          type: string
+          description: >-
+            Port the adapter should target. When omitted, the adapter's
+            default port is resolved automatically.
+          maxLength: 32
+          x-oapi-codegen-extra-tags:
+            json: "targetPort,omitempty"
+        targetStatus:
+          type: string
+          description: Desired adapter status.
+          enum:
+            - enabled
+            - disabled
+
+    ChangeAdapterStatusResponse:
+      type: object
+      description: Result of an adapter deploy/undeploy request.
+      additionalProperties: false
+      required:
+        - status
+      properties:
+        status:
+          type: string
+          description: Resulting status of the adapter after the operation.
+          maxLength: 64
 
     SystemMessageResponse:
       type: object

--- a/schemas/constructs/v1beta1/system/api.yml
+++ b/schemas/constructs/v1beta1/system/api.yml
@@ -251,6 +251,25 @@ paths:
           description: Failed to reach the cluster or fetch its server version.
 
   /api/system/sync:
+    get:
+      x-internal: ["meshery"]
+      tags:
+        - System
+      summary: Get initial session bootstrap data
+      description: Returns session bootstrap data for the authenticated user.
+      operationId: getSystemSync
+      responses:
+        "200":
+          description: Session sync payload
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/SystemSessionSync"
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          description: Marshal error while serializing the session sync payload.
+
   /api/system/adapter/status:
     post:
       x-internal: ["meshery"]
@@ -281,25 +300,6 @@ paths:
           $ref: "#/components/responses/401"
         "500":
           description: Failed to deploy or undeploy the adapter.
-    get:
-      x-internal: ["meshery"]
-      tags:
-        - System
-      summary: Get initial session bootstrap data
-      description: Returns session bootstrap data for the authenticated user.
-      operationId: getSystemSync
-      responses:
-        "200":
-          description: Session sync payload
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/SystemSessionSync"
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          description: Marshal error while serializing the session sync payload.
-
   /api/system/controllers/operator/status:
     get:
       x-internal: ["meshery"]

--- a/schemas/constructs/v1beta1/system/api.yml
+++ b/schemas/constructs/v1beta1/system/api.yml
@@ -270,6 +270,36 @@ paths:
         "500":
           description: Marshal error while serializing the session sync payload.
 
+  /api/system/adapter/status:
+    post:
+      x-internal: ["meshery"]
+      tags:
+        - System
+      summary: Change adapter deploy status
+      description: >-
+        Deploys or undeploys a Meshery adapter. Resolves the adapter's
+        default port when targetPort is omitted, then invokes the
+        adapter tracker to bring the adapter to the requested status.
+      operationId: changeAdapterStatus
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/ChangeAdapterStatusRequest"
+      responses:
+        "200":
+          description: The adapter status change was processed.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ChangeAdapterStatusResponse"
+        "400":
+          description: Missing or invalid adapter name, target port, or target status.
+        "401":
+          $ref: "#/components/responses/401"
+        "500":
+          description: Failed to deploy or undeploy the adapter.
   /api/system/controllers/operator/status:
     get:
       x-internal: ["meshery"]

--- a/schemas/constructs/v1beta1/system/api.yml
+++ b/schemas/constructs/v1beta1/system/api.yml
@@ -270,36 +270,6 @@ paths:
         "500":
           description: Marshal error while serializing the session sync payload.
 
-  /api/system/adapter/status:
-    post:
-      x-internal: ["meshery"]
-      tags:
-        - System
-      summary: Change adapter deploy status
-      description: >-
-        Deploys or undeploys a Meshery adapter. Resolves the adapter's
-        default port when targetPort is omitted, then invokes the
-        adapter tracker to bring the adapter to the requested status.
-      operationId: changeAdapterStatus
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              $ref: "#/components/schemas/ChangeAdapterStatusRequest"
-      responses:
-        "200":
-          description: The adapter status change was processed.
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ChangeAdapterStatusResponse"
-        "400":
-          description: Missing or invalid adapter name, target port, or target status.
-        "401":
-          $ref: "#/components/responses/401"
-        "500":
-          description: Failed to deploy or undeploy the adapter.
   /api/system/controllers/operator/status:
     get:
       x-internal: ["meshery"]
@@ -564,7 +534,8 @@ components:
         status:
           type: string
           description: Resulting status of the adapter after the operation.
-          maxLength: 64
+          enum:
+            - processing
 
     SystemMessageResponse:
       type: object


### PR DESCRIPTION
Defines `POST /api/system/adapter/status` with `ChangeAdapterStatusRequest` and `ChangeAdapterStatusResponse` schemas in the `system` construct. Mirrors the Meshery server REST handler added in `meshery/meshery`, enabling RTK Query client generation (`useChangeAdapterStatusMutation`) for the upcoming UI migration.

**Notes for Reviewers**

This is the schema-contract portion of meshery/meshery#21559 ("[Server] Migrate changeAdapterStatus from GraphQL to REST"). The companion REST handler and route registration live in a separate PR against `meshery/meshery`.

Validated locally:
- `go run ./cmd/validate-schemas` — no blocking violations
- `node build/bundle-openapi.js` — bundles cleanly
- `node build/generate-rtk.js` — confirms `useChangeAdapterStatusMutation` is generated correctly

**This PR fixes #**
N/A, this PR is a partial contribution toward meshery/meshery#21559 (schema-contract portion only). See meshery/meshery#21572 for the companion server implementation.


**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added API schemas for requesting adapter deployment or undeployment.
  * Requests now support specifying an adapter name, target enabled or disabled status, and optional target port.
  * Added a response schema exposing the processing status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->