### PR TITLE
fix(invitation): declare the 403 createInvitation and updateInvitation return

### DIFF
--- a/schemas/constructs/v1beta3/invitation/api.yml
+++ b/schemas/constructs/v1beta3/invitation/api.yml
@@ -87,6 +87,8 @@ paths:
           $ref: '#/components/responses/400'
         '401':
           $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
         '404':
           $ref: '#/components/responses/404'
         '500':
@@ -142,6 +144,8 @@ paths:
           $ref: '#/components/responses/400'
         '401':
           $ref: '#/components/responses/401'
+        '403':
+          $ref: '#/components/responses/403'
         '500':
           $ref: '#/components/responses/500'
   /api/organizations/invitations/{invitationId}/accept:
@@ -452,6 +456,8 @@ components:
       $ref: ../../v1beta2/core/api.yml#/components/responses/400
     401:
       $ref: ../../v1beta2/core/api.yml#/components/responses/401
+    403:
+      $ref: ../../v1beta2/core/api.yml#/components/responses/403
     404:
       $ref: ../../v1beta2/core/api.yml#/components/responses/404
     500:


### PR DESCRIPTION
## What

Declares the `403` that `createInvitation` and `updateInvitation` already return.

## Why

Layer5 Cloud answers **403** on both operations when a caller lacking the `IdentityAccessManagementManageInvitations` permission key tries to change an invitation's `is_default` marker - the flag designating an organization's open-signup invitation. Neither operation declared that status, so the spec and the handler disagreed.

Background: `is_default` was previously absent from the invitation INSERT/UPDATE column lists and could never become true, which left `organizations.invite_id` - written behind org-admin authorization - as the only working way to designate an org's open-signup invitation. Making the column writable moved that org-level capability onto two routes carrying no permission middleware, so the write is now gated and refuses with 403. The gate is on the **transition** in both directions, claiming the marker and clearing it, so 403 is reachable on create and on update.

## Scope

Deliberately minimal - **only** the `403` was missing. `updateInvitation` already declares `404`, which covers the other status that work added.

`schemas/constructs/v1beta2/core/api.yml` already defines a `403` response, so this adds a local `$ref` to it alongside the existing 400/401/404/500 and wires it into the two operations. No new response shape is introduced.

## Verification

`make validate-schemas` - `✓ no blocking violations found`.

## Consumer

layer5io/meshery-cloud, branch `fm/mc-open-invitation-not-processed`. That PR does **not** wait on this one; it ships naming the parity gap explicitly and re-pins `@meshery/schemas` in both `go.mod` and `ui/package.json` once this lands and is released.

Fixes #1173


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the invitation API documentation to describe `403 Forbidden` responses for creating and updating invitations.
  - Added the shared `403` response definition for consistent API reference coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->