### PR TITLE
feat(v1beta2): add optional credential orgOwner and organization social links

### DIFF
--- a/models/v1beta2/credential/credential.go
+++ b/models/v1beta2/credential/credential.go
@@ -20,6 +20,9 @@ type Credential struct {
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
 	UserId core.Uuid `db:"owner" json:"userId" yaml:"userId"`
 
+	// OrgOwner A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	OrgOwner *core.Uuid `db:"org_owner" json:"orgOwner,omitempty" yaml:"orgOwner,omitempty"`
+
 	// Type Credential type (e.g. token, basic, AWS).
 	Type string `db:"type" json:"type" yaml:"type"`
 
@@ -61,6 +64,9 @@ type CredentialPayload struct {
 
 	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
 	UserId *core.Uuid `json:"userId,omitempty" yaml:"userId,omitempty"`
+
+	// OrgOwner A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	OrgOwner *core.Uuid `json:"orgOwner,omitempty" yaml:"orgOwner,omitempty"`
 
 	// Type Credential type (e.g. token, basic, AWS).
 	Type string `json:"type" yaml:"type"`

--- a/models/v1beta2/credential/credential_org_owner_test.go
+++ b/models/v1beta2/credential/credential_org_owner_test.go
@@ -1,0 +1,102 @@
+package credential
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/gofrs/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+// orgOwner designates the organization a credential belongs to, for brand
+// profiles that are not owned by a person. It is independent of userId, which
+// keeps its existing required shape and its existing meaning: credentials.owner
+// is NOT NULL with a foreign key to users(id), so every credential still
+// records the user who created it.
+
+func TestUserIdRemainsRequiredAndNonNullable(t *testing.T) {
+	assert := assert.New(t)
+
+	field, ok := reflect.TypeOf(Credential{}).FieldByName("UserId")
+	assert.True(ok, "Credential.UserId must exist")
+	assert.NotEqual(reflect.Ptr, field.Type.Kind(),
+		"Credential.UserId must stay a value type: credentials.owner is NOT NULL with a FK to users(id)")
+	assert.Equal("owner", field.Tag.Get("db"))
+	assert.Equal("userId", field.Tag.Get("json"),
+		"userId stays mandatory on the wire, so it must not gain omitempty")
+}
+
+func TestOrgOwnerIsOptionalAndMapsToItsOwnColumn(t *testing.T) {
+	assert := assert.New(t)
+
+	field, ok := reflect.TypeOf(Credential{}).FieldByName("OrgOwner")
+	assert.True(ok, "Credential.OrgOwner must exist")
+	assert.Equal(reflect.Ptr, field.Type.Kind(),
+		"OrgOwner must be nullable so a personally-owned credential carries no organization")
+	assert.Equal("org_owner", field.Tag.Get("db"))
+}
+
+func TestOrgOwnerIsOmittedUnlessSet(t *testing.T) {
+	user := uuid.Must(uuid.NewV4())
+	org := uuid.Must(uuid.NewV4())
+
+	tests := []struct {
+		name    string
+		cred    Credential
+		wantOrg any
+	}{
+		{
+			name:    "personally owned credential carries no organization",
+			cred:    Credential{Name: "aws", Type: "token", UserId: user},
+			wantOrg: nil,
+		},
+		{
+			name:    "brand credential names its organization and still records the creating user",
+			cred:    Credential{Name: "aws", Type: "token", UserId: user, OrgOwner: &org},
+			wantOrg: org.String(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			encoded, err := json.Marshal(tt.cred)
+			assert.NoError(err)
+
+			var wire map[string]any
+			assert.NoError(json.Unmarshal(encoded, &wire))
+
+			// userId is always present: it is the creating user, not an
+			// alternative to orgOwner.
+			assert.Equal(user.String(), wire["userId"])
+
+			if tt.wantOrg == nil {
+				assert.NotContains(wire, "orgOwner",
+					"an unset organization must be omitted rather than serialized as the nil UUID")
+			} else {
+				assert.Equal(tt.wantOrg, wire["orgOwner"])
+			}
+		})
+	}
+}
+
+func TestCredentialPayloadAcceptsOrgOwner(t *testing.T) {
+	assert := assert.New(t)
+
+	field, ok := reflect.TypeOf(CredentialPayload{}).FieldByName("OrgOwner")
+	assert.True(ok, "CredentialPayload.OrgOwner must exist so a caller can name the organization")
+	assert.Equal(reflect.Ptr, field.Type.Kind(), "CredentialPayload.OrgOwner must be optional")
+
+	// The payload is a wire-only type and must not carry DB column tags.
+	assert.Empty(field.Tag.Get("db"))
+
+	org := uuid.Must(uuid.NewV4())
+	encoded, err := json.Marshal(CredentialPayload{Name: "aws", Type: "token", OrgOwner: &org})
+	assert.NoError(err)
+
+	var wire map[string]any
+	assert.NoError(json.Unmarshal(encoded, &wire))
+	assert.Equal(org.String(), wire["orgOwner"])
+}

--- a/models/v1beta2/organization/links_social_test.go
+++ b/models/v1beta2/organization/links_social_test.go
@@ -2,7 +2,6 @@ package organization
 
 import (
 	"encoding/json"
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -10,22 +9,9 @@ import (
 
 // Links.Social is deliberately a sibling of Links.Support rather than an entry
 // in it: Support renders as support contacts on the auth and error pages, so a
-// brand profile placed there would surface as a way to contact support. These
-// tests pin that separation, and the JSONB shape the field is stored under.
-
-func TestLinksSocialIsASiblingOfSupport(t *testing.T) {
-	assert := assert.New(t)
-	linksType := reflect.TypeOf(Links{})
-
-	social, ok := linksType.FieldByName("Social")
-	assert.True(ok, "Links.Social must exist")
-	assert.Equal(reflect.TypeOf(&Social{}), social.Type,
-		"Links.Social must be its own typed struct, not an entry in the open-ended Support map")
-
-	support, ok := linksType.FieldByName("Support")
-	assert.True(ok, "Links.Support must remain untouched")
-	assert.Equal(reflect.TypeOf(&map[string]string{}), support.Type)
-}
+// brand profile placed there would surface as a way to contact support. This
+// test pins that separation behaviourally, and the JSONB shape the field is
+// stored under.
 
 func TestSocialAndSupportStaySeparateOnTheWire(t *testing.T) {
 	assert := assert.New(t)

--- a/models/v1beta2/organization/links_social_test.go
+++ b/models/v1beta2/organization/links_social_test.go
@@ -1,0 +1,78 @@
+package organization
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Links.Social is deliberately a sibling of Links.Support rather than an entry
+// in it: Support renders as support contacts on the auth and error pages, so a
+// brand profile placed there would surface as a way to contact support. These
+// tests pin that separation, and the JSONB shape the field is stored under.
+
+func TestLinksSocialIsASiblingOfSupport(t *testing.T) {
+	assert := assert.New(t)
+	linksType := reflect.TypeOf(Links{})
+
+	social, ok := linksType.FieldByName("Social")
+	assert.True(ok, "Links.Social must exist")
+	assert.Equal(reflect.TypeOf(&Social{}), social.Type,
+		"Links.Social must be its own typed struct, not an entry in the open-ended Support map")
+
+	support, ok := linksType.FieldByName("Support")
+	assert.True(ok, "Links.Support must remain untouched")
+	assert.Equal(reflect.TypeOf(&map[string]string{}), support.Type)
+}
+
+func TestSocialAndSupportStaySeparateOnTheWire(t *testing.T) {
+	assert := assert.New(t)
+
+	linkedIn := "https://www.linkedin.com/company/layer5"
+	x := "https://x.com/layer5"
+
+	// Links lives inside organization.metadata, which is already JSONB - the
+	// field needs no DDL migration, only this shape. Both social and support
+	// are populated so the separation is actually exercised rather than
+	// passing because support was never set.
+	metadata := OrgMetadata{
+		Preferences: Preferences{
+			Links: &Links{
+				Social:  &Social{LinkedIn: &linkedIn, X: &x},
+				Support: &map[string]string{"slack": "https://slack.meshery.io"},
+			},
+		},
+	}
+
+	encoded, err := json.Marshal(metadata)
+	assert.NoError(err)
+
+	// Assert the wire shape by parsing it, so the lowercase platform keys are
+	// proven rather than assumed - a symmetric struct round-trip would pass
+	// under any tag names.
+	var wire struct {
+		Preferences struct {
+			Links struct {
+				Social  map[string]string `json:"social"`
+				Support map[string]string `json:"support"`
+			} `json:"links"`
+		} `json:"preferences"`
+	}
+	assert.NoError(json.Unmarshal(encoded, &wire))
+
+	assert.Equal(linkedIn, wire.Preferences.Links.Social["linkedin"])
+	assert.Equal(x, wire.Preferences.Links.Social["x"])
+
+	// The brand profiles must not leak into the support contact list, which
+	// renders as ways to contact support.
+	assert.Equal(map[string]string{"slack": "https://slack.meshery.io"}, wire.Preferences.Links.Support)
+	assert.NotContains(wire.Preferences.Links.Support, "linkedin")
+	assert.NotContains(wire.Preferences.Links.Support, "x")
+
+	var decoded OrgMetadata
+	assert.NoError(json.Unmarshal(encoded, &decoded))
+	assert.Equal(linkedIn, *decoded.Preferences.Links.Social.LinkedIn)
+	assert.Equal(x, *decoded.Preferences.Links.Social.X)
+}

--- a/models/v1beta2/organization/organization.go
+++ b/models/v1beta2/organization/organization.go
@@ -79,10 +79,13 @@ type FAQ struct {
 	Question string `json:"question" yaml:"question"`
 }
 
-// Links Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.
+// Links Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.
 type Links struct {
 	// Privacy URL of the organization's Privacy Policy page.
 	Privacy *string `json:"privacy,omitempty" yaml:"privacy,omitempty"`
+
+	// Social The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.
+	Social *Social `json:"social,omitempty" yaml:"social,omitempty"`
 
 	// Support Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number.
 	Support *map[string]string `json:"support,omitempty" yaml:"support,omitempty"`
@@ -224,7 +227,7 @@ type Preferences struct {
 	// Dashboard Preferences specific to dashboard behavior.
 	Dashboard DashboardPrefs `json:"dashboard" yaml:"dashboard"`
 
-	// Links Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.
+	// Links Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.
 	Links *Links `json:"links,omitempty" yaml:"links,omitempty"`
 
 	// ShowAuthCarousel Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it.
@@ -232,6 +235,15 @@ type Preferences struct {
 
 	// Theme UI theme configured for an organization.
 	Theme Theme `json:"theme" yaml:"theme"`
+}
+
+// Social The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.
+type Social struct {
+	// LinkedIn URL of the organization's LinkedIn profile.
+	LinkedIn *string `json:"linkedin,omitempty" yaml:"linkedin,omitempty"`
+
+	// X URL of the organization's X (formerly Twitter) profile.
+	X *string `json:"x,omitempty" yaml:"x,omitempty"`
 }
 
 // TeamsOrganizationsMapping Junction record linking a team to an organization.

--- a/schemas/constructs/v1beta2/credential/api.yml
+++ b/schemas/constructs/v1beta2/credential/api.yml
@@ -233,17 +233,29 @@ components:
           x-order: 3
           x-oapi-codegen-extra-tags:
             db: "owner"
+        orgOwner:
+          $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
+          description: >-
+            UUID of the organization designated as the owner of this
+            credential, for credentials that belong to a brand profile rather
+            than to a person. Optional and independent of userId: userId
+            continues to identify the user who created and owns the record,
+            while orgOwner designates the organization the credential is for.
+          x-order: 4
+          x-go-name: OrgOwner
+          x-oapi-codegen-extra-tags:
+            db: "org_owner"
         type:
           type: string
           description: Credential type (e.g. token, basic, AWS).
-          x-order: 4
+          x-order: 5
           x-oapi-codegen-extra-tags:
             db: "type"
           maxLength: 255
         secret:
           type: object
           description: Key-value pairs containing the sensitive credential data.
-          x-order: 5
+          x-order: 6
           x-go-type: core.Map
           x-go-type-import:
             path: github.com/meshery/schemas/models/core
@@ -256,7 +268,7 @@ components:
           description: Timestamp when the credential was created.
           x-go-type: time.Time
           x-go-type-skip-optional-pointer: true
-          x-order: 6
+          x-order: 7
           x-oapi-codegen-extra-tags:
             db: "created_at"
         updatedAt:
@@ -265,7 +277,7 @@ components:
           description: Timestamp when the credential was last updated.
           x-go-type: time.Time
           x-go-type-skip-optional-pointer: true
-          x-order: 7
+          x-order: 8
           x-oapi-codegen-extra-tags:
             db: "updated_at"
         deletedAt:
@@ -276,7 +288,7 @@ components:
           x-go-type-import:
             path: github.com/meshery/schemas/models/core
           x-go-type-skip-optional-pointer: true
-          x-order: 8
+          x-order: 9
           x-oapi-codegen-extra-tags:
             db: "deleted_at"
 
@@ -305,15 +317,26 @@ components:
           x-order: 3
           x-oapi-codegen-extra-tags:
             json: "userId,omitempty"
+        orgOwner:
+          $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
+          description: >-
+            UUID of the organization to designate as the owner of this
+            credential. A caller may supply this field; the server authorizes
+            it against the authenticated principal and rejects the request
+            when that principal may not write for the named organization.
+          x-order: 4
+          x-go-name: OrgOwner
+          x-oapi-codegen-extra-tags:
+            json: "orgOwner,omitempty"
         type:
           type: string
           description: Credential type (e.g. token, basic, AWS).
-          x-order: 4
+          x-order: 5
           maxLength: 255
         secret:
           type: object
           description: Key-value pairs containing the sensitive credential data.
-          x-order: 5
+          x-order: 6
           x-go-type: core.Map
           x-go-type-import:
             path: github.com/meshery/schemas/models/core

--- a/schemas/constructs/v1beta2/organization/api.yml
+++ b/schemas/constructs/v1beta2/organization/api.yml
@@ -503,11 +503,11 @@ components:
       type: object
       x-internal: ["cloud"]
       description: >-
-        Per-organization overrides for the legal and support links shown on
-        the auth pages and the error page. termsOfService and privacy are the
-        named legal links; support is an open-ended set of named support
-        contacts/links. Empty or omitted fields fall back to the platform
-        defaults.
+        Per-organization overrides for the legal, support, and social links
+        shown on the auth pages and the error page. termsOfService and privacy
+        are the named legal links; support is an open-ended set of named
+        support contacts/links; social carries the organization's brand
+        profiles. Empty or omitted fields fall back to the platform defaults.
       properties:
         termsOfService:
           type: string
@@ -530,6 +530,33 @@ components:
             URL, a mailto:/tel: link, or free text. For example a "slack"
             entry pointing at https://slack.meshery.io, a "discussion forum"
             entry, or a "support desk" entry holding a phone number.
+        social:
+          x-go-type: "Social"
+          $ref: "#/components/schemas/Social"
+
+    Social:
+      type: object
+      x-internal: ["cloud"]
+      description: >-
+        The organization's social brand profiles. Deliberately a sibling of
+        support rather than an entry in it: support renders as support
+        contacts on the auth and error pages, where a brand profile does not
+        belong. Each platform is a named, individually validated URL so
+        consumers can render the matching platform icon. Empty or omitted
+        fields fall back to the platform defaults.
+      properties:
+        linkedin:
+          type: string
+          format: uri
+          maxLength: 2048
+          description: URL of the organization's LinkedIn profile.
+          x-go-name: LinkedIn
+        x:
+          type: string
+          format: uri
+          maxLength: 2048
+          description: URL of the organization's X (formerly Twitter) profile.
+          x-go-name: X
 
     CarouselSlide:
       type: object

--- a/typescript/generated/v1beta2/credential/Credential.ts
+++ b/typescript/generated/v1beta2/credential/Credential.ts
@@ -74,6 +74,11 @@ export interface components {
              * @description UUID of the user who owns this credential.
              */
             userId: string;
+            /**
+             * Format: uuid
+             * @description UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for.
+             */
+            orgOwner?: string;
             /** @description Credential type (e.g. token, basic, AWS). */
             type: string;
             /** @description Key-value pairs containing the sensitive credential data. */
@@ -108,6 +113,11 @@ export interface components {
              * @description UUID of the user who owns this credential.
              */
             userId?: string;
+            /**
+             * Format: uuid
+             * @description UUID of the organization to designate as the owner of this credential. A caller may supply this field; the server authorizes it against the authenticated principal and rejects the request when that principal may not write for the named organization.
+             */
+            orgOwner?: string;
             /** @description Credential type (e.g. token, basic, AWS). */
             type: string;
             /** @description Key-value pairs containing the sensitive credential data. */
@@ -129,6 +139,11 @@ export interface components {
                  * @description UUID of the user who owns this credential.
                  */
                 userId: string;
+                /**
+                 * Format: uuid
+                 * @description UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for.
+                 */
+                orgOwner?: string;
                 /** @description Credential type (e.g. token, basic, AWS). */
                 type: string;
                 /** @description Key-value pairs containing the sensitive credential data. */
@@ -264,6 +279,11 @@ export interface operations {
                              * @description UUID of the user who owns this credential.
                              */
                             userId: string;
+                            /**
+                             * Format: uuid
+                             * @description UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for.
+                             */
+                            orgOwner?: string;
                             /** @description Credential type (e.g. token, basic, AWS). */
                             type: string;
                             /** @description Key-value pairs containing the sensitive credential data. */
@@ -335,6 +355,11 @@ export interface operations {
                      * @description UUID of the user who owns this credential.
                      */
                     userId?: string;
+                    /**
+                     * Format: uuid
+                     * @description UUID of the organization to designate as the owner of this credential. A caller may supply this field; the server authorizes it against the authenticated principal and rejects the request when that principal may not write for the named organization.
+                     */
+                    orgOwner?: string;
                     /** @description Credential type (e.g. token, basic, AWS). */
                     type: string;
                     /** @description Key-value pairs containing the sensitive credential data. */
@@ -362,6 +387,11 @@ export interface operations {
                          * @description UUID of the user who owns this credential.
                          */
                         userId: string;
+                        /**
+                         * Format: uuid
+                         * @description UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for.
+                         */
+                        orgOwner?: string;
                         /** @description Credential type (e.g. token, basic, AWS). */
                         type: string;
                         /** @description Key-value pairs containing the sensitive credential data. */
@@ -444,6 +474,11 @@ export interface operations {
                      * @description UUID of the user who owns this credential.
                      */
                     userId?: string;
+                    /**
+                     * Format: uuid
+                     * @description UUID of the organization to designate as the owner of this credential. A caller may supply this field; the server authorizes it against the authenticated principal and rejects the request when that principal may not write for the named organization.
+                     */
+                    orgOwner?: string;
                     /** @description Credential type (e.g. token, basic, AWS). */
                     type: string;
                     /** @description Key-value pairs containing the sensitive credential data. */
@@ -471,6 +506,11 @@ export interface operations {
                          * @description UUID of the user who owns this credential.
                          */
                         userId: string;
+                        /**
+                         * Format: uuid
+                         * @description UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for.
+                         */
+                        orgOwner?: string;
                         /** @description Credential type (e.g. token, basic, AWS). */
                         type: string;
                         /** @description Key-value pairs containing the sensitive credential data. */
@@ -610,6 +650,11 @@ export interface operations {
                          * @description UUID of the user who owns this credential.
                          */
                         userId: string;
+                        /**
+                         * Format: uuid
+                         * @description UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for.
+                         */
+                        orgOwner?: string;
                         /** @description Credential type (e.g. token, basic, AWS). */
                         type: string;
                         /** @description Key-value pairs containing the sensitive credential data. */

--- a/typescript/generated/v1beta2/credential/CredentialSchema.ts
+++ b/typescript/generated/v1beta2/credential/CredentialSchema.ts
@@ -169,10 +169,24 @@ const CredentialSchema: Record<string, unknown> = {
                               "path": "github.com/gofrs/uuid"
                             }
                           },
+                          "orgOwner": {
+                            "description": "UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for.",
+                            "x-order": 4,
+                            "x-go-name": "OrgOwner",
+                            "x-oapi-codegen-extra-tags": {
+                              "db": "org_owner"
+                            },
+                            "type": "string",
+                            "format": "uuid",
+                            "x-go-type": "uuid.UUID",
+                            "x-go-type-import": {
+                              "path": "github.com/gofrs/uuid"
+                            }
+                          },
                           "type": {
                             "type": "string",
                             "description": "Credential type (e.g. token, basic, AWS).",
-                            "x-order": 4,
+                            "x-order": 5,
                             "x-oapi-codegen-extra-tags": {
                               "db": "type"
                             },
@@ -181,7 +195,7 @@ const CredentialSchema: Record<string, unknown> = {
                           "secret": {
                             "type": "object",
                             "description": "Key-value pairs containing the sensitive credential data.",
-                            "x-order": 5,
+                            "x-order": 6,
                             "x-go-type": "core.Map",
                             "x-go-type-import": {
                               "path": "github.com/meshery/schemas/models/core"
@@ -197,7 +211,7 @@ const CredentialSchema: Record<string, unknown> = {
                             "description": "Timestamp when the credential was created.",
                             "x-go-type": "time.Time",
                             "x-go-type-skip-optional-pointer": true,
-                            "x-order": 6,
+                            "x-order": 7,
                             "x-oapi-codegen-extra-tags": {
                               "db": "created_at"
                             }
@@ -208,7 +222,7 @@ const CredentialSchema: Record<string, unknown> = {
                             "description": "Timestamp when the credential was last updated.",
                             "x-go-type": "time.Time",
                             "x-go-type-skip-optional-pointer": true,
-                            "x-order": 7,
+                            "x-order": 8,
                             "x-oapi-codegen-extra-tags": {
                               "db": "updated_at"
                             }
@@ -222,7 +236,7 @@ const CredentialSchema: Record<string, unknown> = {
                               "path": "github.com/meshery/schemas/models/core"
                             },
                             "x-go-type-skip-optional-pointer": true,
-                            "x-order": 8,
+                            "x-order": 9,
                             "x-oapi-codegen-extra-tags": {
                               "db": "deleted_at"
                             }
@@ -333,16 +347,30 @@ const CredentialSchema: Record<string, unknown> = {
                       "path": "github.com/gofrs/uuid"
                     }
                   },
+                  "orgOwner": {
+                    "description": "UUID of the organization to designate as the owner of this credential. A caller may supply this field; the server authorizes it against the authenticated principal and rejects the request when that principal may not write for the named organization.",
+                    "x-order": 4,
+                    "x-go-name": "OrgOwner",
+                    "x-oapi-codegen-extra-tags": {
+                      "json": "orgOwner,omitempty"
+                    },
+                    "type": "string",
+                    "format": "uuid",
+                    "x-go-type": "uuid.UUID",
+                    "x-go-type-import": {
+                      "path": "github.com/gofrs/uuid"
+                    }
+                  },
                   "type": {
                     "type": "string",
                     "description": "Credential type (e.g. token, basic, AWS).",
-                    "x-order": 4,
+                    "x-order": 5,
                     "maxLength": 255
                   },
                   "secret": {
                     "type": "object",
                     "description": "Key-value pairs containing the sensitive credential data.",
-                    "x-order": 5,
+                    "x-order": 6,
                     "x-go-type": "core.Map",
                     "x-go-type-import": {
                       "path": "github.com/meshery/schemas/models/core"
@@ -408,10 +436,24 @@ const CredentialSchema: Record<string, unknown> = {
                         "path": "github.com/gofrs/uuid"
                       }
                     },
+                    "orgOwner": {
+                      "description": "UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for.",
+                      "x-order": 4,
+                      "x-go-name": "OrgOwner",
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "org_owner"
+                      },
+                      "type": "string",
+                      "format": "uuid",
+                      "x-go-type": "uuid.UUID",
+                      "x-go-type-import": {
+                        "path": "github.com/gofrs/uuid"
+                      }
+                    },
                     "type": {
                       "type": "string",
                       "description": "Credential type (e.g. token, basic, AWS).",
-                      "x-order": 4,
+                      "x-order": 5,
                       "x-oapi-codegen-extra-tags": {
                         "db": "type"
                       },
@@ -420,7 +462,7 @@ const CredentialSchema: Record<string, unknown> = {
                     "secret": {
                       "type": "object",
                       "description": "Key-value pairs containing the sensitive credential data.",
-                      "x-order": 5,
+                      "x-order": 6,
                       "x-go-type": "core.Map",
                       "x-go-type-import": {
                         "path": "github.com/meshery/schemas/models/core"
@@ -436,7 +478,7 @@ const CredentialSchema: Record<string, unknown> = {
                       "description": "Timestamp when the credential was created.",
                       "x-go-type": "time.Time",
                       "x-go-type-skip-optional-pointer": true,
-                      "x-order": 6,
+                      "x-order": 7,
                       "x-oapi-codegen-extra-tags": {
                         "db": "created_at"
                       }
@@ -447,7 +489,7 @@ const CredentialSchema: Record<string, unknown> = {
                       "description": "Timestamp when the credential was last updated.",
                       "x-go-type": "time.Time",
                       "x-go-type-skip-optional-pointer": true,
-                      "x-order": 7,
+                      "x-order": 8,
                       "x-oapi-codegen-extra-tags": {
                         "db": "updated_at"
                       }
@@ -461,7 +503,7 @@ const CredentialSchema: Record<string, unknown> = {
                         "path": "github.com/meshery/schemas/models/core"
                       },
                       "x-go-type-skip-optional-pointer": true,
-                      "x-order": 8,
+                      "x-order": 9,
                       "x-oapi-codegen-extra-tags": {
                         "db": "deleted_at"
                       }
@@ -559,16 +601,30 @@ const CredentialSchema: Record<string, unknown> = {
                       "path": "github.com/gofrs/uuid"
                     }
                   },
+                  "orgOwner": {
+                    "description": "UUID of the organization to designate as the owner of this credential. A caller may supply this field; the server authorizes it against the authenticated principal and rejects the request when that principal may not write for the named organization.",
+                    "x-order": 4,
+                    "x-go-name": "OrgOwner",
+                    "x-oapi-codegen-extra-tags": {
+                      "json": "orgOwner,omitempty"
+                    },
+                    "type": "string",
+                    "format": "uuid",
+                    "x-go-type": "uuid.UUID",
+                    "x-go-type-import": {
+                      "path": "github.com/gofrs/uuid"
+                    }
+                  },
                   "type": {
                     "type": "string",
                     "description": "Credential type (e.g. token, basic, AWS).",
-                    "x-order": 4,
+                    "x-order": 5,
                     "maxLength": 255
                   },
                   "secret": {
                     "type": "object",
                     "description": "Key-value pairs containing the sensitive credential data.",
-                    "x-order": 5,
+                    "x-order": 6,
                     "x-go-type": "core.Map",
                     "x-go-type-import": {
                       "path": "github.com/meshery/schemas/models/core"
@@ -634,10 +690,24 @@ const CredentialSchema: Record<string, unknown> = {
                         "path": "github.com/gofrs/uuid"
                       }
                     },
+                    "orgOwner": {
+                      "description": "UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for.",
+                      "x-order": 4,
+                      "x-go-name": "OrgOwner",
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "org_owner"
+                      },
+                      "type": "string",
+                      "format": "uuid",
+                      "x-go-type": "uuid.UUID",
+                      "x-go-type-import": {
+                        "path": "github.com/gofrs/uuid"
+                      }
+                    },
                     "type": {
                       "type": "string",
                       "description": "Credential type (e.g. token, basic, AWS).",
-                      "x-order": 4,
+                      "x-order": 5,
                       "x-oapi-codegen-extra-tags": {
                         "db": "type"
                       },
@@ -646,7 +716,7 @@ const CredentialSchema: Record<string, unknown> = {
                     "secret": {
                       "type": "object",
                       "description": "Key-value pairs containing the sensitive credential data.",
-                      "x-order": 5,
+                      "x-order": 6,
                       "x-go-type": "core.Map",
                       "x-go-type-import": {
                         "path": "github.com/meshery/schemas/models/core"
@@ -662,7 +732,7 @@ const CredentialSchema: Record<string, unknown> = {
                       "description": "Timestamp when the credential was created.",
                       "x-go-type": "time.Time",
                       "x-go-type-skip-optional-pointer": true,
-                      "x-order": 6,
+                      "x-order": 7,
                       "x-oapi-codegen-extra-tags": {
                         "db": "created_at"
                       }
@@ -673,7 +743,7 @@ const CredentialSchema: Record<string, unknown> = {
                       "description": "Timestamp when the credential was last updated.",
                       "x-go-type": "time.Time",
                       "x-go-type-skip-optional-pointer": true,
-                      "x-order": 7,
+                      "x-order": 8,
                       "x-oapi-codegen-extra-tags": {
                         "db": "updated_at"
                       }
@@ -687,7 +757,7 @@ const CredentialSchema: Record<string, unknown> = {
                         "path": "github.com/meshery/schemas/models/core"
                       },
                       "x-go-type-skip-optional-pointer": true,
-                      "x-order": 8,
+                      "x-order": 9,
                       "x-oapi-codegen-extra-tags": {
                         "db": "deleted_at"
                       }
@@ -897,10 +967,24 @@ const CredentialSchema: Record<string, unknown> = {
                         "path": "github.com/gofrs/uuid"
                       }
                     },
+                    "orgOwner": {
+                      "description": "UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for.",
+                      "x-order": 4,
+                      "x-go-name": "OrgOwner",
+                      "x-oapi-codegen-extra-tags": {
+                        "db": "org_owner"
+                      },
+                      "type": "string",
+                      "format": "uuid",
+                      "x-go-type": "uuid.UUID",
+                      "x-go-type-import": {
+                        "path": "github.com/gofrs/uuid"
+                      }
+                    },
                     "type": {
                       "type": "string",
                       "description": "Credential type (e.g. token, basic, AWS).",
-                      "x-order": 4,
+                      "x-order": 5,
                       "x-oapi-codegen-extra-tags": {
                         "db": "type"
                       },
@@ -909,7 +993,7 @@ const CredentialSchema: Record<string, unknown> = {
                     "secret": {
                       "type": "object",
                       "description": "Key-value pairs containing the sensitive credential data.",
-                      "x-order": 5,
+                      "x-order": 6,
                       "x-go-type": "core.Map",
                       "x-go-type-import": {
                         "path": "github.com/meshery/schemas/models/core"
@@ -925,7 +1009,7 @@ const CredentialSchema: Record<string, unknown> = {
                       "description": "Timestamp when the credential was created.",
                       "x-go-type": "time.Time",
                       "x-go-type-skip-optional-pointer": true,
-                      "x-order": 6,
+                      "x-order": 7,
                       "x-oapi-codegen-extra-tags": {
                         "db": "created_at"
                       }
@@ -936,7 +1020,7 @@ const CredentialSchema: Record<string, unknown> = {
                       "description": "Timestamp when the credential was last updated.",
                       "x-go-type": "time.Time",
                       "x-go-type-skip-optional-pointer": true,
-                      "x-order": 7,
+                      "x-order": 8,
                       "x-oapi-codegen-extra-tags": {
                         "db": "updated_at"
                       }
@@ -950,7 +1034,7 @@ const CredentialSchema: Record<string, unknown> = {
                         "path": "github.com/meshery/schemas/models/core"
                       },
                       "x-go-type-skip-optional-pointer": true,
-                      "x-order": 8,
+                      "x-order": 9,
                       "x-oapi-codegen-extra-tags": {
                         "db": "deleted_at"
                       }
@@ -1169,10 +1253,24 @@ const CredentialSchema: Record<string, unknown> = {
               "path": "github.com/gofrs/uuid"
             }
           },
+          "orgOwner": {
+            "description": "UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for.",
+            "x-order": 4,
+            "x-go-name": "OrgOwner",
+            "x-oapi-codegen-extra-tags": {
+              "db": "org_owner"
+            },
+            "type": "string",
+            "format": "uuid",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/gofrs/uuid"
+            }
+          },
           "type": {
             "type": "string",
             "description": "Credential type (e.g. token, basic, AWS).",
-            "x-order": 4,
+            "x-order": 5,
             "x-oapi-codegen-extra-tags": {
               "db": "type"
             },
@@ -1181,7 +1279,7 @@ const CredentialSchema: Record<string, unknown> = {
           "secret": {
             "type": "object",
             "description": "Key-value pairs containing the sensitive credential data.",
-            "x-order": 5,
+            "x-order": 6,
             "x-go-type": "core.Map",
             "x-go-type-import": {
               "path": "github.com/meshery/schemas/models/core"
@@ -1197,7 +1295,7 @@ const CredentialSchema: Record<string, unknown> = {
             "description": "Timestamp when the credential was created.",
             "x-go-type": "time.Time",
             "x-go-type-skip-optional-pointer": true,
-            "x-order": 6,
+            "x-order": 7,
             "x-oapi-codegen-extra-tags": {
               "db": "created_at"
             }
@@ -1208,7 +1306,7 @@ const CredentialSchema: Record<string, unknown> = {
             "description": "Timestamp when the credential was last updated.",
             "x-go-type": "time.Time",
             "x-go-type-skip-optional-pointer": true,
-            "x-order": 7,
+            "x-order": 8,
             "x-oapi-codegen-extra-tags": {
               "db": "updated_at"
             }
@@ -1222,7 +1320,7 @@ const CredentialSchema: Record<string, unknown> = {
               "path": "github.com/meshery/schemas/models/core"
             },
             "x-go-type-skip-optional-pointer": true,
-            "x-order": 8,
+            "x-order": 9,
             "x-oapi-codegen-extra-tags": {
               "db": "deleted_at"
             }
@@ -1270,16 +1368,30 @@ const CredentialSchema: Record<string, unknown> = {
               "path": "github.com/gofrs/uuid"
             }
           },
+          "orgOwner": {
+            "description": "UUID of the organization to designate as the owner of this credential. A caller may supply this field; the server authorizes it against the authenticated principal and rejects the request when that principal may not write for the named organization.",
+            "x-order": 4,
+            "x-go-name": "OrgOwner",
+            "x-oapi-codegen-extra-tags": {
+              "json": "orgOwner,omitempty"
+            },
+            "type": "string",
+            "format": "uuid",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/gofrs/uuid"
+            }
+          },
           "type": {
             "type": "string",
             "description": "Credential type (e.g. token, basic, AWS).",
-            "x-order": 4,
+            "x-order": 5,
             "maxLength": 255
           },
           "secret": {
             "type": "object",
             "description": "Key-value pairs containing the sensitive credential data.",
-            "x-order": 5,
+            "x-order": 6,
             "x-go-type": "core.Map",
             "x-go-type-import": {
               "path": "github.com/meshery/schemas/models/core"
@@ -1350,10 +1462,24 @@ const CredentialSchema: Record<string, unknown> = {
                     "path": "github.com/gofrs/uuid"
                   }
                 },
+                "orgOwner": {
+                  "description": "UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for.",
+                  "x-order": 4,
+                  "x-go-name": "OrgOwner",
+                  "x-oapi-codegen-extra-tags": {
+                    "db": "org_owner"
+                  },
+                  "type": "string",
+                  "format": "uuid",
+                  "x-go-type": "uuid.UUID",
+                  "x-go-type-import": {
+                    "path": "github.com/gofrs/uuid"
+                  }
+                },
                 "type": {
                   "type": "string",
                   "description": "Credential type (e.g. token, basic, AWS).",
-                  "x-order": 4,
+                  "x-order": 5,
                   "x-oapi-codegen-extra-tags": {
                     "db": "type"
                   },
@@ -1362,7 +1488,7 @@ const CredentialSchema: Record<string, unknown> = {
                 "secret": {
                   "type": "object",
                   "description": "Key-value pairs containing the sensitive credential data.",
-                  "x-order": 5,
+                  "x-order": 6,
                   "x-go-type": "core.Map",
                   "x-go-type-import": {
                     "path": "github.com/meshery/schemas/models/core"
@@ -1378,7 +1504,7 @@ const CredentialSchema: Record<string, unknown> = {
                   "description": "Timestamp when the credential was created.",
                   "x-go-type": "time.Time",
                   "x-go-type-skip-optional-pointer": true,
-                  "x-order": 6,
+                  "x-order": 7,
                   "x-oapi-codegen-extra-tags": {
                     "db": "created_at"
                   }
@@ -1389,7 +1515,7 @@ const CredentialSchema: Record<string, unknown> = {
                   "description": "Timestamp when the credential was last updated.",
                   "x-go-type": "time.Time",
                   "x-go-type-skip-optional-pointer": true,
-                  "x-order": 7,
+                  "x-order": 8,
                   "x-oapi-codegen-extra-tags": {
                     "db": "updated_at"
                   }
@@ -1403,7 +1529,7 @@ const CredentialSchema: Record<string, unknown> = {
                     "path": "github.com/meshery/schemas/models/core"
                   },
                   "x-go-type-skip-optional-pointer": true,
-                  "x-order": 8,
+                  "x-order": 9,
                   "x-oapi-codegen-extra-tags": {
                     "db": "deleted_at"
                   }

--- a/typescript/generated/v1beta2/organization/Organization.ts
+++ b/typescript/generated/v1beta2/organization/Organization.ts
@@ -261,7 +261,7 @@ export interface components {
         DashboardPrefs: {
             [key: string]: unknown;
         };
-        /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+        /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
         Links: {
             /**
              * Format: uri
@@ -277,6 +277,32 @@ export interface components {
             support?: {
                 [key: string]: string;
             };
+            /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+            social?: {
+                /**
+                 * Format: uri
+                 * @description URL of the organization's LinkedIn profile.
+                 */
+                linkedin?: string;
+                /**
+                 * Format: uri
+                 * @description URL of the organization's X (formerly Twitter) profile.
+                 */
+                x?: string;
+            };
+        };
+        /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+        Social: {
+            /**
+             * Format: uri
+             * @description URL of the organization's LinkedIn profile.
+             */
+            linkedin?: string;
+            /**
+             * Format: uri
+             * @description URL of the organization's X (formerly Twitter) profile.
+             */
+            x?: string;
         };
         /** @description A single slide in the auth-page feature carousel. */
         CarouselSlide: {
@@ -390,7 +416,7 @@ export interface components {
                     answer: string;
                 }[];
             };
-            /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+            /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
             links?: {
                 /**
                  * Format: uri
@@ -405,6 +431,19 @@ export interface components {
                 /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                 support?: {
                     [key: string]: string;
+                };
+                /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                social?: {
+                    /**
+                     * Format: uri
+                     * @description URL of the organization's LinkedIn profile.
+                     */
+                    linkedin?: string;
+                    /**
+                     * Format: uri
+                     * @description URL of the organization's X (formerly Twitter) profile.
+                     */
+                    x?: string;
                 };
             };
             /**
@@ -486,7 +525,7 @@ export interface components {
                         answer: string;
                     }[];
                 };
-                /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                 links?: {
                     /**
                      * Format: uri
@@ -501,6 +540,19 @@ export interface components {
                     /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                     support?: {
                         [key: string]: string;
+                    };
+                    /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                    social?: {
+                        /**
+                         * Format: uri
+                         * @description URL of the organization's LinkedIn profile.
+                         */
+                        linkedin?: string;
+                        /**
+                         * Format: uri
+                         * @description URL of the organization's X (formerly Twitter) profile.
+                         */
+                        x?: string;
                     };
                 };
                 /**
@@ -642,7 +694,7 @@ export interface components {
                             answer: string;
                         }[];
                     };
-                    /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                    /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                     links?: {
                         /**
                          * Format: uri
@@ -657,6 +709,19 @@ export interface components {
                         /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                         support?: {
                             [key: string]: string;
+                        };
+                        /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                        social?: {
+                            /**
+                             * Format: uri
+                             * @description URL of the organization's LinkedIn profile.
+                             */
+                            linkedin?: string;
+                            /**
+                             * Format: uri
+                             * @description URL of the organization's X (formerly Twitter) profile.
+                             */
+                            x?: string;
                         };
                     };
                     /**
@@ -782,7 +847,7 @@ export interface components {
                                 answer: string;
                             }[];
                         };
-                        /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                        /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                         links?: {
                             /**
                              * Format: uri
@@ -797,6 +862,19 @@ export interface components {
                             /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                             support?: {
                                 [key: string]: string;
+                            };
+                            /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                            social?: {
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's LinkedIn profile.
+                                 */
+                                linkedin?: string;
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's X (formerly Twitter) profile.
+                                 */
+                                x?: string;
                             };
                         };
                         /**
@@ -923,7 +1001,7 @@ export interface components {
                                 answer: string;
                             }[];
                         };
-                        /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                        /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                         links?: {
                             /**
                              * Format: uri
@@ -938,6 +1016,19 @@ export interface components {
                             /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                             support?: {
                                 [key: string]: string;
+                            };
+                            /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                            social?: {
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's LinkedIn profile.
+                                 */
+                                linkedin?: string;
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's X (formerly Twitter) profile.
+                                 */
+                                x?: string;
                             };
                         };
                         /**
@@ -1047,7 +1138,7 @@ export interface components {
                         answer: string;
                     }[];
                 };
-                /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                 links?: {
                     /**
                      * Format: uri
@@ -1062,6 +1153,19 @@ export interface components {
                     /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                     support?: {
                         [key: string]: string;
+                    };
+                    /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                    social?: {
+                        /**
+                         * Format: uri
+                         * @description URL of the organization's LinkedIn profile.
+                         */
+                        linkedin?: string;
+                        /**
+                         * Format: uri
+                         * @description URL of the organization's X (formerly Twitter) profile.
+                         */
+                        x?: string;
                     };
                 };
                 /**
@@ -1458,7 +1562,7 @@ export interface components {
                                 answer: string;
                             }[];
                         };
-                        /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                        /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                         links?: {
                             /**
                              * Format: uri
@@ -1473,6 +1577,19 @@ export interface components {
                             /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                             support?: {
                                 [key: string]: string;
+                            };
+                            /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                            social?: {
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's LinkedIn profile.
+                                 */
+                                linkedin?: string;
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's X (formerly Twitter) profile.
+                                 */
+                                x?: string;
                             };
                         };
                         /**
@@ -1615,7 +1732,7 @@ export interface operations {
                                             answer: string;
                                         }[];
                                     };
-                                    /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                                    /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                                     links?: {
                                         /**
                                          * Format: uri
@@ -1630,6 +1747,19 @@ export interface operations {
                                         /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                                         support?: {
                                             [key: string]: string;
+                                        };
+                                        /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                                        social?: {
+                                            /**
+                                             * Format: uri
+                                             * @description URL of the organization's LinkedIn profile.
+                                             */
+                                            linkedin?: string;
+                                            /**
+                                             * Format: uri
+                                             * @description URL of the organization's X (formerly Twitter) profile.
+                                             */
+                                            x?: string;
                                         };
                                     };
                                     /**
@@ -1777,7 +1907,7 @@ export interface operations {
                                 answer: string;
                             }[];
                         };
-                        /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                        /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                         links?: {
                             /**
                              * Format: uri
@@ -1792,6 +1922,19 @@ export interface operations {
                             /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                             support?: {
                                 [key: string]: string;
+                            };
+                            /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                            social?: {
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's LinkedIn profile.
+                                 */
+                                linkedin?: string;
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's X (formerly Twitter) profile.
+                                 */
+                                x?: string;
                             };
                         };
                         /**
@@ -1909,7 +2052,7 @@ export interface operations {
                                             answer: string;
                                         }[];
                                     };
-                                    /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                                    /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                                     links?: {
                                         /**
                                          * Format: uri
@@ -1924,6 +2067,19 @@ export interface operations {
                                         /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                                         support?: {
                                             [key: string]: string;
+                                        };
+                                        /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                                        social?: {
+                                            /**
+                                             * Format: uri
+                                             * @description URL of the organization's LinkedIn profile.
+                                             */
+                                            linkedin?: string;
+                                            /**
+                                             * Format: uri
+                                             * @description URL of the organization's X (formerly Twitter) profile.
+                                             */
+                                            x?: string;
                                         };
                                     };
                                     /**
@@ -2191,7 +2347,7 @@ export interface operations {
                                             answer: string;
                                         }[];
                                     };
-                                    /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                                    /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                                     links?: {
                                         /**
                                          * Format: uri
@@ -2206,6 +2362,19 @@ export interface operations {
                                         /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                                         support?: {
                                             [key: string]: string;
+                                        };
+                                        /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                                        social?: {
+                                            /**
+                                             * Format: uri
+                                             * @description URL of the organization's LinkedIn profile.
+                                             */
+                                            linkedin?: string;
+                                            /**
+                                             * Format: uri
+                                             * @description URL of the organization's X (formerly Twitter) profile.
+                                             */
+                                            x?: string;
                                         };
                                     };
                                     /**
@@ -2367,7 +2536,7 @@ export interface operations {
                                 answer: string;
                             }[];
                         };
-                        /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                        /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                         links?: {
                             /**
                              * Format: uri
@@ -2382,6 +2551,19 @@ export interface operations {
                             /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                             support?: {
                                 [key: string]: string;
+                            };
+                            /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                            social?: {
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's LinkedIn profile.
+                                 */
+                                linkedin?: string;
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's X (formerly Twitter) profile.
+                                 */
+                                x?: string;
                             };
                         };
                         /**
@@ -2499,7 +2681,7 @@ export interface operations {
                                             answer: string;
                                         }[];
                                     };
-                                    /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                                    /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                                     links?: {
                                         /**
                                          * Format: uri
@@ -2514,6 +2696,19 @@ export interface operations {
                                         /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                                         support?: {
                                             [key: string]: string;
+                                        };
+                                        /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                                        social?: {
+                                            /**
+                                             * Format: uri
+                                             * @description URL of the organization's LinkedIn profile.
+                                             */
+                                            linkedin?: string;
+                                            /**
+                                             * Format: uri
+                                             * @description URL of the organization's X (formerly Twitter) profile.
+                                             */
+                                            x?: string;
                                         };
                                     };
                                     /**
@@ -2745,7 +2940,7 @@ export interface operations {
                                     answer: string;
                                 }[];
                             };
-                            /** @description Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+                            /** @description Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
                             links?: {
                                 /**
                                  * Format: uri
@@ -2760,6 +2955,19 @@ export interface operations {
                                 /** @description Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
                                 support?: {
                                     [key: string]: string;
+                                };
+                                /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+                                social?: {
+                                    /**
+                                     * Format: uri
+                                     * @description URL of the organization's LinkedIn profile.
+                                     */
+                                    linkedin?: string;
+                                    /**
+                                     * Format: uri
+                                     * @description URL of the organization's X (formerly Twitter) profile.
+                                     */
+                                    x?: string;
                                 };
                             };
                             /**

--- a/typescript/generated/v1beta2/organization/OrganizationSchema.ts
+++ b/typescript/generated/v1beta2/organization/OrganizationSchema.ts
@@ -385,7 +385,7 @@ const OrganizationSchema: Record<string, unknown> = {
                                     "x-internal": [
                                       "cloud"
                                     ],
-                                    "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                                    "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                                     "properties": {
                                       "termsOfService": {
                                         "type": "string",
@@ -406,6 +406,30 @@ const OrganizationSchema: Record<string, unknown> = {
                                           "maxLength": 2048
                                         },
                                         "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                                      },
+                                      "social": {
+                                        "x-go-type": "Social",
+                                        "type": "object",
+                                        "x-internal": [
+                                          "cloud"
+                                        ],
+                                        "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                                        "properties": {
+                                          "linkedin": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "maxLength": 2048,
+                                            "description": "URL of the organization's LinkedIn profile.",
+                                            "x-go-name": "LinkedIn"
+                                          },
+                                          "x": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "maxLength": 2048,
+                                            "description": "URL of the organization's X (formerly Twitter) profile.",
+                                            "x-go-name": "X"
+                                          }
+                                        }
                                       }
                                     }
                                   },
@@ -742,7 +766,7 @@ const OrganizationSchema: Record<string, unknown> = {
                         "x-internal": [
                           "cloud"
                         ],
-                        "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                        "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                         "properties": {
                           "termsOfService": {
                             "type": "string",
@@ -763,6 +787,30 @@ const OrganizationSchema: Record<string, unknown> = {
                               "maxLength": 2048
                             },
                             "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                          },
+                          "social": {
+                            "x-go-type": "Social",
+                            "type": "object",
+                            "x-internal": [
+                              "cloud"
+                            ],
+                            "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                            "properties": {
+                              "linkedin": {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 2048,
+                                "description": "URL of the organization's LinkedIn profile.",
+                                "x-go-name": "LinkedIn"
+                              },
+                              "x": {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 2048,
+                                "description": "URL of the organization's X (formerly Twitter) profile.",
+                                "x-go-name": "X"
+                              }
+                            }
                           }
                         }
                       },
@@ -1077,7 +1125,7 @@ const OrganizationSchema: Record<string, unknown> = {
                                     "x-internal": [
                                       "cloud"
                                     ],
-                                    "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                                    "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                                     "properties": {
                                       "termsOfService": {
                                         "type": "string",
@@ -1098,6 +1146,30 @@ const OrganizationSchema: Record<string, unknown> = {
                                           "maxLength": 2048
                                         },
                                         "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                                      },
+                                      "social": {
+                                        "x-go-type": "Social",
+                                        "type": "object",
+                                        "x-internal": [
+                                          "cloud"
+                                        ],
+                                        "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                                        "properties": {
+                                          "linkedin": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "maxLength": 2048,
+                                            "description": "URL of the organization's LinkedIn profile.",
+                                            "x-go-name": "LinkedIn"
+                                          },
+                                          "x": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "maxLength": 2048,
+                                            "description": "URL of the organization's X (formerly Twitter) profile.",
+                                            "x-go-name": "X"
+                                          }
+                                        }
                                       }
                                     }
                                   },
@@ -1718,7 +1790,7 @@ const OrganizationSchema: Record<string, unknown> = {
                                     "x-internal": [
                                       "cloud"
                                     ],
-                                    "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                                    "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                                     "properties": {
                                       "termsOfService": {
                                         "type": "string",
@@ -1739,6 +1811,30 @@ const OrganizationSchema: Record<string, unknown> = {
                                           "maxLength": 2048
                                         },
                                         "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                                      },
+                                      "social": {
+                                        "x-go-type": "Social",
+                                        "type": "object",
+                                        "x-internal": [
+                                          "cloud"
+                                        ],
+                                        "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                                        "properties": {
+                                          "linkedin": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "maxLength": 2048,
+                                            "description": "URL of the organization's LinkedIn profile.",
+                                            "x-go-name": "LinkedIn"
+                                          },
+                                          "x": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "maxLength": 2048,
+                                            "description": "URL of the organization's X (formerly Twitter) profile.",
+                                            "x-go-name": "X"
+                                          }
+                                        }
                                       }
                                     }
                                   },
@@ -2208,7 +2304,7 @@ const OrganizationSchema: Record<string, unknown> = {
                         "x-internal": [
                           "cloud"
                         ],
-                        "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                        "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                         "properties": {
                           "termsOfService": {
                             "type": "string",
@@ -2229,6 +2325,30 @@ const OrganizationSchema: Record<string, unknown> = {
                               "maxLength": 2048
                             },
                             "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                          },
+                          "social": {
+                            "x-go-type": "Social",
+                            "type": "object",
+                            "x-internal": [
+                              "cloud"
+                            ],
+                            "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                            "properties": {
+                              "linkedin": {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 2048,
+                                "description": "URL of the organization's LinkedIn profile.",
+                                "x-go-name": "LinkedIn"
+                              },
+                              "x": {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 2048,
+                                "description": "URL of the organization's X (formerly Twitter) profile.",
+                                "x-go-name": "X"
+                              }
+                            }
                           }
                         }
                       },
@@ -2543,7 +2663,7 @@ const OrganizationSchema: Record<string, unknown> = {
                                     "x-internal": [
                                       "cloud"
                                     ],
-                                    "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                                    "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                                     "properties": {
                                       "termsOfService": {
                                         "type": "string",
@@ -2564,6 +2684,30 @@ const OrganizationSchema: Record<string, unknown> = {
                                           "maxLength": 2048
                                         },
                                         "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                                      },
+                                      "social": {
+                                        "x-go-type": "Social",
+                                        "type": "object",
+                                        "x-internal": [
+                                          "cloud"
+                                        ],
+                                        "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                                        "properties": {
+                                          "linkedin": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "maxLength": 2048,
+                                            "description": "URL of the organization's LinkedIn profile.",
+                                            "x-go-name": "LinkedIn"
+                                          },
+                                          "x": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "maxLength": 2048,
+                                            "description": "URL of the organization's X (formerly Twitter) profile.",
+                                            "x-go-name": "X"
+                                          }
+                                        }
                                       }
                                     }
                                   },
@@ -2931,7 +3075,7 @@ const OrganizationSchema: Record<string, unknown> = {
                           "x-internal": [
                             "cloud"
                           ],
-                          "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                          "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                           "properties": {
                             "termsOfService": {
                               "type": "string",
@@ -2952,6 +3096,30 @@ const OrganizationSchema: Record<string, unknown> = {
                                 "maxLength": 2048
                               },
                               "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                            },
+                            "social": {
+                              "x-go-type": "Social",
+                              "type": "object",
+                              "x-internal": [
+                                "cloud"
+                              ],
+                              "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                              "properties": {
+                                "linkedin": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "maxLength": 2048,
+                                  "description": "URL of the organization's LinkedIn profile.",
+                                  "x-go-name": "LinkedIn"
+                                },
+                                "x": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "maxLength": 2048,
+                                  "description": "URL of the organization's X (formerly Twitter) profile.",
+                                  "x-go-name": "X"
+                                }
+                              }
                             }
                           }
                         },
@@ -4160,7 +4328,7 @@ const OrganizationSchema: Record<string, unknown> = {
                       "x-internal": [
                         "cloud"
                       ],
-                      "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                      "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                       "properties": {
                         "termsOfService": {
                           "type": "string",
@@ -4181,6 +4349,30 @@ const OrganizationSchema: Record<string, unknown> = {
                             "maxLength": 2048
                           },
                           "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                        },
+                        "social": {
+                          "x-go-type": "Social",
+                          "type": "object",
+                          "x-internal": [
+                            "cloud"
+                          ],
+                          "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                          "properties": {
+                            "linkedin": {
+                              "type": "string",
+                              "format": "uri",
+                              "maxLength": 2048,
+                              "description": "URL of the organization's LinkedIn profile.",
+                              "x-go-name": "LinkedIn"
+                            },
+                            "x": {
+                              "type": "string",
+                              "format": "uri",
+                              "maxLength": 2048,
+                              "description": "URL of the organization's X (formerly Twitter) profile.",
+                              "x-go-name": "X"
+                            }
+                          }
                         }
                       }
                     },
@@ -4489,7 +4681,7 @@ const OrganizationSchema: Record<string, unknown> = {
         "x-internal": [
           "cloud"
         ],
-        "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+        "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
         "properties": {
           "termsOfService": {
             "type": "string",
@@ -4510,6 +4702,53 @@ const OrganizationSchema: Record<string, unknown> = {
               "maxLength": 2048
             },
             "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+          },
+          "social": {
+            "x-go-type": "Social",
+            "type": "object",
+            "x-internal": [
+              "cloud"
+            ],
+            "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+            "properties": {
+              "linkedin": {
+                "type": "string",
+                "format": "uri",
+                "maxLength": 2048,
+                "description": "URL of the organization's LinkedIn profile.",
+                "x-go-name": "LinkedIn"
+              },
+              "x": {
+                "type": "string",
+                "format": "uri",
+                "maxLength": 2048,
+                "description": "URL of the organization's X (formerly Twitter) profile.",
+                "x-go-name": "X"
+              }
+            }
+          }
+        }
+      },
+      "Social": {
+        "type": "object",
+        "x-internal": [
+          "cloud"
+        ],
+        "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+        "properties": {
+          "linkedin": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 2048,
+            "description": "URL of the organization's LinkedIn profile.",
+            "x-go-name": "LinkedIn"
+          },
+          "x": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 2048,
+            "description": "URL of the organization's X (formerly Twitter) profile.",
+            "x-go-name": "X"
           }
         }
       },
@@ -4849,7 +5088,7 @@ const OrganizationSchema: Record<string, unknown> = {
             "x-internal": [
               "cloud"
             ],
-            "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+            "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
             "properties": {
               "termsOfService": {
                 "type": "string",
@@ -4870,6 +5109,30 @@ const OrganizationSchema: Record<string, unknown> = {
                   "maxLength": 2048
                 },
                 "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+              },
+              "social": {
+                "x-go-type": "Social",
+                "type": "object",
+                "x-internal": [
+                  "cloud"
+                ],
+                "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                "properties": {
+                  "linkedin": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 2048,
+                    "description": "URL of the organization's LinkedIn profile.",
+                    "x-go-name": "LinkedIn"
+                  },
+                  "x": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 2048,
+                    "description": "URL of the organization's X (formerly Twitter) profile.",
+                    "x-go-name": "X"
+                  }
+                }
               }
             }
           },
@@ -5099,7 +5362,7 @@ const OrganizationSchema: Record<string, unknown> = {
                 "x-internal": [
                   "cloud"
                 ],
-                "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                 "properties": {
                   "termsOfService": {
                     "type": "string",
@@ -5120,6 +5383,30 @@ const OrganizationSchema: Record<string, unknown> = {
                       "maxLength": 2048
                     },
                     "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                  },
+                  "social": {
+                    "x-go-type": "Social",
+                    "type": "object",
+                    "x-internal": [
+                      "cloud"
+                    ],
+                    "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                    "properties": {
+                      "linkedin": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2048,
+                        "description": "URL of the organization's LinkedIn profile.",
+                        "x-go-name": "LinkedIn"
+                      },
+                      "x": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2048,
+                        "description": "URL of the organization's X (formerly Twitter) profile.",
+                        "x-go-name": "X"
+                      }
+                    }
                   }
                 }
               },
@@ -5535,7 +5822,7 @@ const OrganizationSchema: Record<string, unknown> = {
                     "x-internal": [
                       "cloud"
                     ],
-                    "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                    "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                     "properties": {
                       "termsOfService": {
                         "type": "string",
@@ -5556,6 +5843,30 @@ const OrganizationSchema: Record<string, unknown> = {
                           "maxLength": 2048
                         },
                         "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                      },
+                      "social": {
+                        "x-go-type": "Social",
+                        "type": "object",
+                        "x-internal": [
+                          "cloud"
+                        ],
+                        "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                        "properties": {
+                          "linkedin": {
+                            "type": "string",
+                            "format": "uri",
+                            "maxLength": 2048,
+                            "description": "URL of the organization's LinkedIn profile.",
+                            "x-go-name": "LinkedIn"
+                          },
+                          "x": {
+                            "type": "string",
+                            "format": "uri",
+                            "maxLength": 2048,
+                            "description": "URL of the organization's X (formerly Twitter) profile.",
+                            "x-go-name": "X"
+                          }
+                        }
                       }
                     }
                   },
@@ -5894,7 +6205,7 @@ const OrganizationSchema: Record<string, unknown> = {
                           "x-internal": [
                             "cloud"
                           ],
-                          "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                          "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                           "properties": {
                             "termsOfService": {
                               "type": "string",
@@ -5915,6 +6226,30 @@ const OrganizationSchema: Record<string, unknown> = {
                                 "maxLength": 2048
                               },
                               "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                            },
+                            "social": {
+                              "x-go-type": "Social",
+                              "type": "object",
+                              "x-internal": [
+                                "cloud"
+                              ],
+                              "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                              "properties": {
+                                "linkedin": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "maxLength": 2048,
+                                  "description": "URL of the organization's LinkedIn profile.",
+                                  "x-go-name": "LinkedIn"
+                                },
+                                "x": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "maxLength": 2048,
+                                  "description": "URL of the organization's X (formerly Twitter) profile.",
+                                  "x-go-name": "X"
+                                }
+                              }
                             }
                           }
                         },
@@ -6257,7 +6592,7 @@ const OrganizationSchema: Record<string, unknown> = {
                           "x-internal": [
                             "cloud"
                           ],
-                          "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                          "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                           "properties": {
                             "termsOfService": {
                               "type": "string",
@@ -6278,6 +6613,30 @@ const OrganizationSchema: Record<string, unknown> = {
                                 "maxLength": 2048
                               },
                               "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                            },
+                            "social": {
+                              "x-go-type": "Social",
+                              "type": "object",
+                              "x-internal": [
+                                "cloud"
+                              ],
+                              "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                              "properties": {
+                                "linkedin": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "maxLength": 2048,
+                                  "description": "URL of the organization's LinkedIn profile.",
+                                  "x-go-name": "LinkedIn"
+                                },
+                                "x": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "maxLength": 2048,
+                                  "description": "URL of the organization's X (formerly Twitter) profile.",
+                                  "x-go-name": "X"
+                                }
+                              }
                             }
                           }
                         },
@@ -6565,7 +6924,7 @@ const OrganizationSchema: Record<string, unknown> = {
                 "x-internal": [
                   "cloud"
                 ],
-                "description": "Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults.",
+                "description": "Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults.",
                 "properties": {
                   "termsOfService": {
                     "type": "string",
@@ -6586,6 +6945,30 @@ const OrganizationSchema: Record<string, unknown> = {
                       "maxLength": 2048
                     },
                     "description": "Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a \"slack\" entry pointing at https://slack.meshery.io, a \"discussion forum\" entry, or a \"support desk\" entry holding a phone number."
+                  },
+                  "social": {
+                    "x-go-type": "Social",
+                    "type": "object",
+                    "x-internal": [
+                      "cloud"
+                    ],
+                    "description": "The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults.",
+                    "properties": {
+                      "linkedin": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2048,
+                        "description": "URL of the organization's LinkedIn profile.",
+                        "x-go-name": "LinkedIn"
+                      },
+                      "x": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2048,
+                        "description": "URL of the organization's X (formerly Twitter) profile.",
+                        "x-go-name": "X"
+                      }
+                    }
                   }
                 }
               },

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -1954,6 +1954,8 @@ export type GetUserCredentialsApiResponse = /** status 200 Credentials response 
     name: string;
     /** UUID of the user who owns this credential. */
     userId: string;
+    /** UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for. */
+    orgOwner?: string;
     /** Credential type (e.g. token, basic, AWS). */
     type: string;
     /** Key-value pairs containing the sensitive credential data. */
@@ -1991,6 +1993,8 @@ export type SaveUserCredentialApiResponse = /** status 201 Credential saved */ {
   name: string;
   /** UUID of the user who owns this credential. */
   userId: string;
+  /** UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for. */
+  orgOwner?: string;
   /** Credential type (e.g. token, basic, AWS). */
   type: string;
   /** Key-value pairs containing the sensitive credential data. */
@@ -2010,6 +2014,8 @@ export type SaveUserCredentialApiArg = {
     name: string;
     /** UUID of the user who owns this credential. */
     userId?: string;
+    /** UUID of the organization to designate as the owner of this credential. A caller may supply this field; the server authorizes it against the authenticated principal and rejects the request when that principal may not write for the named organization. */
+    orgOwner?: string;
     /** Credential type (e.g. token, basic, AWS). */
     type: string;
     /** Key-value pairs containing the sensitive credential data. */
@@ -2023,6 +2029,8 @@ export type UpdateUserCredentialApiResponse = /** status 200 Credential updated 
   name: string;
   /** UUID of the user who owns this credential. */
   userId: string;
+  /** UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for. */
+  orgOwner?: string;
   /** Credential type (e.g. token, basic, AWS). */
   type: string;
   /** Key-value pairs containing the sensitive credential data. */
@@ -2042,6 +2050,8 @@ export type UpdateUserCredentialApiArg = {
     name: string;
     /** UUID of the user who owns this credential. */
     userId?: string;
+    /** UUID of the organization to designate as the owner of this credential. A caller may supply this field; the server authorizes it against the authenticated principal and rejects the request when that principal may not write for the named organization. */
+    orgOwner?: string;
     /** Credential type (e.g. token, basic, AWS). */
     type: string;
     /** Key-value pairs containing the sensitive credential data. */
@@ -2060,6 +2070,8 @@ export type GetCredentialByIdApiResponse = /** status 200 Credential response */
   name: string;
   /** UUID of the user who owns this credential. */
   userId: string;
+  /** UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for. */
+  orgOwner?: string;
   /** Credential type (e.g. token, basic, AWS). */
   type: string;
   /** Key-value pairs containing the sensitive credential data. */
@@ -2729,7 +2741,7 @@ export type GetOrgsApiResponse = /** status 200 Organizations response */ {
             answer: string;
           }[];
         };
-        /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+        /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
         links?: {
           /** URL of the organization's Terms of Service page. */
           termsOfService?: string;
@@ -2738,6 +2750,13 @@ export type GetOrgsApiResponse = /** status 200 Organizations response */ {
           /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
           support?: {
             [key: string]: string;
+          };
+          /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+          social?: {
+            /** URL of the organization's LinkedIn profile. */
+            linkedin?: string;
+            /** URL of the organization's X (formerly Twitter) profile. */
+            x?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -2854,7 +2873,7 @@ export type CreateOrgApiResponse = /** status 201 Single-organization page respo
             answer: string;
           }[];
         };
-        /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+        /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
         links?: {
           /** URL of the organization's Terms of Service page. */
           termsOfService?: string;
@@ -2863,6 +2882,13 @@ export type CreateOrgApiResponse = /** status 201 Single-organization page respo
           /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
           support?: {
             [key: string]: string;
+          };
+          /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+          social?: {
+            /** URL of the organization's LinkedIn profile. */
+            linkedin?: string;
+            /** URL of the organization's X (formerly Twitter) profile. */
+            x?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -2955,7 +2981,7 @@ export type CreateOrgApiArg = {
           answer: string;
         }[];
       };
-      /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+      /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
       links?: {
         /** URL of the organization's Terms of Service page. */
         termsOfService?: string;
@@ -2964,6 +2990,13 @@ export type CreateOrgApiArg = {
         /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
         support?: {
           [key: string]: string;
+        };
+        /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+        social?: {
+          /** URL of the organization's LinkedIn profile. */
+          linkedin?: string;
+          /** URL of the organization's X (formerly Twitter) profile. */
+          x?: string;
         };
       };
       /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -3089,7 +3122,7 @@ export type GetOrgApiResponse = /** status 200 Single-organization page response
             answer: string;
           }[];
         };
-        /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+        /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
         links?: {
           /** URL of the organization's Terms of Service page. */
           termsOfService?: string;
@@ -3098,6 +3131,13 @@ export type GetOrgApiResponse = /** status 200 Single-organization page response
           /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
           support?: {
             [key: string]: string;
+          };
+          /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+          social?: {
+            /** URL of the organization's LinkedIn profile. */
+            linkedin?: string;
+            /** URL of the organization's X (formerly Twitter) profile. */
+            x?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -3211,7 +3251,7 @@ export type UpdateOrgApiResponse = /** status 200 Single-organization page respo
             answer: string;
           }[];
         };
-        /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+        /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
         links?: {
           /** URL of the organization's Terms of Service page. */
           termsOfService?: string;
@@ -3220,6 +3260,13 @@ export type UpdateOrgApiResponse = /** status 200 Single-organization page respo
           /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
           support?: {
             [key: string]: string;
+          };
+          /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+          social?: {
+            /** URL of the organization's LinkedIn profile. */
+            linkedin?: string;
+            /** URL of the organization's X (formerly Twitter) profile. */
+            x?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -3314,7 +3361,7 @@ export type UpdateOrgApiArg = {
           answer: string;
         }[];
       };
-      /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+      /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
       links?: {
         /** URL of the organization's Terms of Service page. */
         termsOfService?: string;
@@ -3323,6 +3370,13 @@ export type UpdateOrgApiArg = {
         /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
         support?: {
           [key: string]: string;
+        };
+        /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+        social?: {
+          /** URL of the organization's LinkedIn profile. */
+          linkedin?: string;
+          /** URL of the organization's X (formerly Twitter) profile. */
+          x?: string;
         };
       };
       /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -3396,7 +3450,7 @@ export type GetOrgPreferencesApiResponse = /** status 200 Organization metadata,
         answer: string;
       }[];
     };
-    /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+    /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
     links?: {
       /** URL of the organization's Terms of Service page. */
       termsOfService?: string;
@@ -3405,6 +3459,13 @@ export type GetOrgPreferencesApiResponse = /** status 200 Organization metadata,
       /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
       support?: {
         [key: string]: string;
+      };
+      /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+      social?: {
+        /** URL of the organization's LinkedIn profile. */
+        linkedin?: string;
+        /** URL of the organization's X (formerly Twitter) profile. */
+        x?: string;
       };
     };
     /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -11292,6 +11292,8 @@ export type GetUserCredentialsApiResponse = /** status 200 Credentials response 
     name: string;
     /** UUID of the user who owns this credential. */
     userId: string;
+    /** UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for. */
+    orgOwner?: string;
     /** Credential type (e.g. token, basic, AWS). */
     type: string;
     /** Key-value pairs containing the sensitive credential data. */
@@ -11329,6 +11331,8 @@ export type SaveUserCredentialApiResponse = /** status 201 Credential saved */ {
   name: string;
   /** UUID of the user who owns this credential. */
   userId: string;
+  /** UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for. */
+  orgOwner?: string;
   /** Credential type (e.g. token, basic, AWS). */
   type: string;
   /** Key-value pairs containing the sensitive credential data. */
@@ -11348,6 +11352,8 @@ export type SaveUserCredentialApiArg = {
     name: string;
     /** UUID of the user who owns this credential. */
     userId?: string;
+    /** UUID of the organization to designate as the owner of this credential. A caller may supply this field; the server authorizes it against the authenticated principal and rejects the request when that principal may not write for the named organization. */
+    orgOwner?: string;
     /** Credential type (e.g. token, basic, AWS). */
     type: string;
     /** Key-value pairs containing the sensitive credential data. */
@@ -11361,6 +11367,8 @@ export type UpdateUserCredentialApiResponse = /** status 200 Credential updated 
   name: string;
   /** UUID of the user who owns this credential. */
   userId: string;
+  /** UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for. */
+  orgOwner?: string;
   /** Credential type (e.g. token, basic, AWS). */
   type: string;
   /** Key-value pairs containing the sensitive credential data. */
@@ -11380,6 +11388,8 @@ export type UpdateUserCredentialApiArg = {
     name: string;
     /** UUID of the user who owns this credential. */
     userId?: string;
+    /** UUID of the organization to designate as the owner of this credential. A caller may supply this field; the server authorizes it against the authenticated principal and rejects the request when that principal may not write for the named organization. */
+    orgOwner?: string;
     /** Credential type (e.g. token, basic, AWS). */
     type: string;
     /** Key-value pairs containing the sensitive credential data. */
@@ -11398,6 +11408,8 @@ export type GetCredentialByIdApiResponse = /** status 200 Credential response */
   name: string;
   /** UUID of the user who owns this credential. */
   userId: string;
+  /** UUID of the organization designated as the owner of this credential, for credentials that belong to a brand profile rather than to a person. Optional and independent of userId: userId continues to identify the user who created and owns the record, while orgOwner designates the organization the credential is for. */
+  orgOwner?: string;
   /** Credential type (e.g. token, basic, AWS). */
   type: string;
   /** Key-value pairs containing the sensitive credential data. */
@@ -11542,7 +11554,7 @@ export type GetOrgsApiResponse = /** status 200 Organizations response */ {
             answer: string;
           }[];
         };
-        /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+        /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
         links?: {
           /** URL of the organization's Terms of Service page. */
           termsOfService?: string;
@@ -11551,6 +11563,13 @@ export type GetOrgsApiResponse = /** status 200 Organizations response */ {
           /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
           support?: {
             [key: string]: string;
+          };
+          /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+          social?: {
+            /** URL of the organization's LinkedIn profile. */
+            linkedin?: string;
+            /** URL of the organization's X (formerly Twitter) profile. */
+            x?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -11667,7 +11686,7 @@ export type CreateOrgApiResponse = /** status 201 Single-organization page respo
             answer: string;
           }[];
         };
-        /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+        /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
         links?: {
           /** URL of the organization's Terms of Service page. */
           termsOfService?: string;
@@ -11676,6 +11695,13 @@ export type CreateOrgApiResponse = /** status 201 Single-organization page respo
           /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
           support?: {
             [key: string]: string;
+          };
+          /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+          social?: {
+            /** URL of the organization's LinkedIn profile. */
+            linkedin?: string;
+            /** URL of the organization's X (formerly Twitter) profile. */
+            x?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -11768,7 +11794,7 @@ export type CreateOrgApiArg = {
           answer: string;
         }[];
       };
-      /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+      /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
       links?: {
         /** URL of the organization's Terms of Service page. */
         termsOfService?: string;
@@ -11777,6 +11803,13 @@ export type CreateOrgApiArg = {
         /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
         support?: {
           [key: string]: string;
+        };
+        /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+        social?: {
+          /** URL of the organization's LinkedIn profile. */
+          linkedin?: string;
+          /** URL of the organization's X (formerly Twitter) profile. */
+          x?: string;
         };
       };
       /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -11902,7 +11935,7 @@ export type GetOrgApiResponse = /** status 200 Single-organization page response
             answer: string;
           }[];
         };
-        /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+        /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
         links?: {
           /** URL of the organization's Terms of Service page. */
           termsOfService?: string;
@@ -11911,6 +11944,13 @@ export type GetOrgApiResponse = /** status 200 Single-organization page response
           /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
           support?: {
             [key: string]: string;
+          };
+          /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+          social?: {
+            /** URL of the organization's LinkedIn profile. */
+            linkedin?: string;
+            /** URL of the organization's X (formerly Twitter) profile. */
+            x?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -12024,7 +12064,7 @@ export type UpdateOrgApiResponse = /** status 200 Single-organization page respo
             answer: string;
           }[];
         };
-        /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+        /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
         links?: {
           /** URL of the organization's Terms of Service page. */
           termsOfService?: string;
@@ -12033,6 +12073,13 @@ export type UpdateOrgApiResponse = /** status 200 Single-organization page respo
           /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
           support?: {
             [key: string]: string;
+          };
+          /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+          social?: {
+            /** URL of the organization's LinkedIn profile. */
+            linkedin?: string;
+            /** URL of the organization's X (formerly Twitter) profile. */
+            x?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -12127,7 +12174,7 @@ export type UpdateOrgApiArg = {
           answer: string;
         }[];
       };
-      /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+      /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
       links?: {
         /** URL of the organization's Terms of Service page. */
         termsOfService?: string;
@@ -12136,6 +12183,13 @@ export type UpdateOrgApiArg = {
         /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
         support?: {
           [key: string]: string;
+        };
+        /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+        social?: {
+          /** URL of the organization's LinkedIn profile. */
+          linkedin?: string;
+          /** URL of the organization's X (formerly Twitter) profile. */
+          x?: string;
         };
       };
       /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -12209,7 +12263,7 @@ export type GetOrgPreferencesApiResponse = /** status 200 Organization metadata,
         answer: string;
       }[];
     };
-    /** Per-organization overrides for the legal and support links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links. Empty or omitted fields fall back to the platform defaults. */
+    /** Per-organization overrides for the legal, support, and social links shown on the auth pages and the error page. termsOfService and privacy are the named legal links; support is an open-ended set of named support contacts/links; social carries the organization's brand profiles. Empty or omitted fields fall back to the platform defaults. */
     links?: {
       /** URL of the organization's Terms of Service page. */
       termsOfService?: string;
@@ -12218,6 +12272,13 @@ export type GetOrgPreferencesApiResponse = /** status 200 Organization metadata,
       /** Open-ended set of named support contacts/links rendered on the auth and error pages, keyed by display name with a value that is a URL, a mailto:/tel: link, or free text. For example a "slack" entry pointing at https://slack.meshery.io, a "discussion forum" entry, or a "support desk" entry holding a phone number. */
       support?: {
         [key: string]: string;
+      };
+      /** The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
+      social?: {
+        /** URL of the organization's LinkedIn profile. */
+        linkedin?: string;
+        /** URL of the organization's X (formerly Twitter) profile. */
+        x?: string;
       };
     };
     /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */


### PR DESCRIPTION
## Intent

Ship Phase 0.1 and 0.2 of Outbox's Postgres persistence work as two meshery/schemas construct changes in one PR (they share one regeneration cycle). This is a prerequisite: it gates the meshery-cloud credentials work, which gates moving Outbox's platform secrets into the database.

0.1 - Credential construct, per a captain ruling that supersedes the earlier design. Add a new OPTIONAL org_owner field to the credential schema so that brand profiles (organizations) can be designated as the owner of a credential. Two points are explicit and must not be re-litigated:
- The field is `org_owner`, NOT `organization_id`. Rendered per this repo's CI-enforced casing contract as property `orgOwner` on the wire with `x-oapi-codegen-extra-tags: db: "org_owner"`, mirroring how the existing `userId` property already maps to the `owner` column. If a reviewer believes the wire property should instead be literal snake_case `org_owner`, say so rather than assuming; the casing contract in AGENTS.md § Casing rules at a glance was applied deliberately.
- DO NOT relax `user_id`. It keeps its current required shape and its current meaning. An earlier revision made it optional/nullable; the captain reversed that. orgOwner is INDEPENDENT of userId, not an alternative to it. Consequently the generated Go diff against the base commit is purely additive (only the two OrgOwner fields are added; no existing line changes), so no Go consumer needs a source change, there is no downstream Go migration, and the existing server-side control that prevents a client-supplied userId from redirecting a credential onto another account is untouched. Do not flag a Go break; there is none. Do not propose relaxing user_id.
Established from evidence, not invented, and load-bearing for the above: a brand-owned credential still records the authenticated user who created it in user_id, because meshery-cloud's credentials.owner is `uuid NOT NULL` with no default and a foreign key `credentials_user_id_fkey FOREIGN KEY (owner) REFERENCES public.users(id) ON DELETE CASCADE`, so a nil UUID, a sentinel, or an organization id would all be rejected by the database; every write path already sets it to the authenticated user.
Per-field semantics, as ruled: orgOwner is a field a caller MAY supply, authorized against the authenticated principal and rejected when that principal may not write for the named organization. userId's semantics are unchanged. These must be stated per field, never as one blanket sentence about both.

0.2 - Organization social links, unchanged and already accepted. In schemas/constructs/v1beta2/organization/api.yml, add a first-class `social` property to Links as a named-field object (linkedin, x) rather than a map[string]string. Named fields were chosen because they match the sibling termsOfService/privacy treatment, carry per-platform `format: uri` validation, and let consumers render the matching platform icon, which an untyped map cannot support. Explicit constraint: `social` MUST be a sibling of `support`, never an entry in it - support renders as support contacts on auth and error pages, and a brand's LinkedIn URL appearing as a support contact is the exact bug this avoids. No DDL migration is needed for this half, because Links lives inside organization.metadata, which is already JSONB.

Both changes: regenerate all three targets (make generate-golang, make generate-ts, make generate-rtk); verify the generated Go and TypeScript compile and run the repo's own tests. Do NOT cut a release - that follows merge with green CI as a separate decision, so no release step, no version bump and no publish belongs here. Stage deliberately rather than `git add -A`, because .claude/settings.local.json exists in every local copy and must never be committed.

Decisions already made and settled above the implementation level - treat these as accepted context, not open questions:

- Scoped to v1beta2 ONLY. v1beta1/credential is x-deprecated with x-superseded-by: v1beta2, so no new field belongs in it. meshery-cloud imports only credentialv1beta2.

- The "exactly one owner" style invariant is NOT expressed with an OpenAPI oneOf, and this was MEASURED rather than assumed, on this branch, in an isolated clone. Adding oneOf to the Credential response schema makes oapi-codegen add an unexported `union json.RawMessage` field, emit the branches as bare `interface{}` (carrying no constraint), and generate union Marshal/UnmarshalJSON that DO NOT COMPILE here - 5 errors - because build/generate-golang.js renames Id->ID and applies x-go-name: OrgOwner on the struct fields while those generated marshallers still reference the pre-rename identifiers. TypeScript degrades to `{...} & (unknown | unknown)`, identical to unconstrained. It buys zero enforcement on either consumer surface while breaking the Go build, so ownership rules stay server-enforced. Do not re-propose oneOf/anyOf.

- Endpoint work is deliberately OUT OF SCOPE and is the separately tracked meshery-cloud follow-on. This PR makes an organization-owned credential REPRESENTABLE; it does not make it listable or creatable through these operations, and the user-scoped operation descriptions (getUserCredentials, saveUserCredential, updateUserCredential) are intentionally left unchanged. Do not add endpoint or list-filter work here.

- Migration scoping must not be overstated in either direction: no DDL is needed for the organization Links change because it is inside existing JSONB, but org_owner IS a new column and DOES require a DDL migration in meshery-cloud, tracked separately.

- Test shape reflects accepted review feedback from an earlier round: reflection assertions that merely snapshot generated struct shape were trimmed in favour of behavioural assertions, and a previously vacuous assertion (asserting Support was nil in a test that never set Support) was replaced with one that actually populates both social and support and parses the emitted JSON, so the lowercase wire keys and the social/support separation are proven rather than assumed. db-tag assertions were kept because that column mapping has no other observable surface.

Verification already run locally, all green: make validate-schemas; make consumer-audit against local meshery and meshery-cloud checkouts (its only two findings are pre-existing snake_case user_id query params in meshery-cloud ui/api/catalog.ts, unrelated to these constructs); go build ./...; go vet ./...; go test ./...; npm run build; make test-ts; make test-rtk; make test-enums-ts. All three generators were run twice to confirm an idempotent diff.

## What Changed

- **Credential (v1beta2)**: added an optional `orgOwner` UUID property to both the `Credential` response schema (mapped to the `org_owner` DB column via `x-oapi-codegen-extra-tags`) and the credential payload schema (`json:"orgOwner,omitempty"`), so an organization can be designated as the owner of a credential. `userId` is unchanged — it keeps its existing required shape and continues to identify the user who created the record; `orgOwner` is independent of it, and the generated Go diff is purely additive.
- **Organization (v1beta2)**: added a first-class `social` property to `Links` as a named-field object (`linkedin`, `x`) with per-platform `format: uri` validation, declared as a sibling of `support` rather than an entry inside it, matching the existing `termsOfService`/`privacy` treatment. `Links` lives inside `organization.metadata` (already JSONB), so no DDL is involved on this side.
- Regenerated the Go models, TypeScript types/schemas, and RTK clients for both constructs, and added Go tests covering the `orgOwner` db-tag mapping and the emitted JSON for organization `social`/`support` (lowercase wire keys and the social/support separation).

- No `CHANGELOG.md` entry was added, and that is deliberate rather than an oversight: this repository has touched that file in only four commits in its entire history, nothing in `AGENTS.md`, `CONTRIBUTING.md` or `docs/release-procedure.md` requires a per-PR entry, and release notes are produced by Release Drafter rather than from that file. If maintainers do intend `## Unreleased` to record every consumer-visible schema addition, that convention is worth writing into `docs/release-procedure.md` so it is settled once instead of re-decided on each PR.

## Risk Assessment

✅ Low: Both halves are additive, optional schema fields whose regenerated Go/TS/RTK output matches the schema edits exactly, with no existing field, required list, or wire key altered.

## Testing

Ran the repo's targeted Go tests for both constructs, then proved the intent at the contract level: validated real credential payloads/responses and organization Links bodies against the bundled published OpenAPI spec with ajv (brand credential accepted, orgOwner optional, non-UUID orgOwner rejected, response missing userId still rejected, malformed LinkedIn URL rejected per-platform, social-inside-support rejected), and type-checked a consumer file against the generated RTK client under --strict with both negative assertions verified to fail when their expect-error markers are removed. Also confirmed regeneration is idempotent (git worktree unchanged after running all three generators), validate-schemas is clean, go build passes, and the commit contains no release/version bump or settings.local.json. No screenshots or rendered UI: this is a schema/codegen repository with no runnable user-facing surface, so the equivalent end-user artifacts are the published contract validation transcript and the consumer compile.

<details>
<summary>Evidence: Published OpenAPI contract validation (ajv against _openapi_build/cloud_openapi.yml)</summary>

<code>PASS [CredentialPayload] POST a brand-owned credential (orgOwner supplied) -&gt; ACCEPTED&#10;PASS [CredentialPayload] POST a personal credential (orgOwner omitted -- optional) -&gt; ACCEPTED&#10;PASS [CredentialPayload] POST with a non-UUID orgOwner is rejected -&gt; REJECTED: data/orgOwner must match format &#34;uuid&#34;&#10;PASS [Credential] Response for a brand credential still records the creating user in userId -&gt; ACCEPTED&#10;PASS [Credential] Response omitting userId is rejected -- user_id was NOT relaxed -&gt; REJECTED: data must have required property &#39;userId&#39;&#10;PASS [Links] social sits beside support, each carrying its own contacts -&gt; ACCEPTED&#10;PASS [Links] a malformed LinkedIn URL is rejected per-platform (format: uri) -&gt; REJECTED: data/social/linkedin must match format &#34;uri&#34;&#10;PASS [Links] the social object cannot be nested inside support -&gt; REJECTED: data/support/social must be string&#10;&#10;All contract expectations held.</code>

```text
PASS  [CredentialPayload] POST a brand-owned credential (orgOwner supplied)
        body: {"name":"outbox-platform-secret","type":"token","secret":{"token":"x"},"orgOwner":"22222222-2222-4222-8222-222222222222"}
        contract says: ACCEPTED
PASS  [CredentialPayload] POST a personal credential (orgOwner omitted -- optional)
        body: {"name":"aws","type":"token","secret":{}}
        contract says: ACCEPTED
PASS  [CredentialPayload] POST with a non-UUID orgOwner is rejected
        body: {"name":"aws","type":"token","orgOwner":"layer5"}
        contract says: REJECTED -> data/orgOwner must match format "uuid"
PASS  [Credential] Response for a brand credential still records the creating user in userId
        body: {"id":"22222222-2222-4222-8222-222222222222","name":"n","userId":"11111111-1111-4111-8111-111111111111","orgOwner":"22222222-2222-4222-8222-222222222222","type":"token","secret":{},"createdAt":"2026-09-01T00:00:00Z","updatedAt":"2026-09-01T00:00:00Z"}
        contract says: ACCEPTED
PASS  [Credential] Response omitting userId is rejected -- user_id was NOT relaxed
        body: {"id":"22222222-2222-4222-8222-222222222222","name":"n","orgOwner":"22222222-2222-4222-8222-222222222222","type":"token","secret":{},"createdAt":"2026-09-01T00:00:00Z","updatedAt":"2026-09-01T00:00:00Z"}
        contract says: REJECTED -> data must have required property 'userId'
PASS  [Links] social sits beside support, each carrying its own contacts
        body: {"social":{"linkedin":"https://www.linkedin.com/company/layer5","x":"https://x.com/layer5"},"support":{"slack":"https://slack.meshery.io"}}
        contract says: ACCEPTED
PASS  [Links] a malformed LinkedIn URL is rejected per-platform (format: uri)
        body: {"social":{"linkedin":"layer5-on-linkedin"}}
        contract says: REJECTED -> data/social/linkedin must match format "uri"
PASS  [Links] the social object cannot be nested inside support
        body: {"support":{"social":{"linkedin":"https://www.linkedin.com/company/layer5"}}}
        contract says: REJECTED -> data/support/social must be string

All contract expectations held.
```
</details>
<details>
<summary>Evidence: Contract validation script (reusable)</summary>

```text
// Validates real request/response bodies against the PUBLISHED bundled OpenAPI
// contract (_openapi_build/cloud_openapi.yml) -- the artifact downstream
// consumers and the docs site are generated from.
const fs = require('fs');
const yaml = require('js-yaml');
const Ajv = require('ajv');

const ROOT = process.argv[2];
const spec = yaml.load(fs.readFileSync(ROOT + '/_openapi_build/cloud_openapi.yml', 'utf8'));

const ajv = new Ajv({ strict: false, allErrors: true });
ajv.addFormat('uuid', /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/);
ajv.addFormat('uri', /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\/\S+$/);
ajv.addFormat('date-time', () => true);

const payload = spec.paths['/api/integrations/credentials'].post.requestBody.content['application/json'].schema;
const credential = spec.paths['/api/integrations/credentials/{credentialId}'].get.responses['200'].content['application/json'].schema;
const orgs = spec.paths['/api/identity/orgs'].get.responses['200'].content['application/json'].schema;
const links = orgs.properties.organizations.items.properties.metadata.properties.preferences.properties.links;

const USER = '11111111-1111-4111-8111-111111111111';
const ORG = '22222222-2222-4222-8222-222222222222';

const cases = [
  ['CredentialPayload', payload, 'POST a brand-owned credential (orgOwner supplied)',
    { name: 'outbox-platform-secret', type: 'token', secret: { token: 'x' }, orgOwner: ORG }, true],
  ['CredentialPayload', payload, 'POST a personal credential (orgOwner omitted -- optional)',
    { name: 'aws', type: 'token', secret: {} }, true],
  ['CredentialPayload', payload, 'POST with a non-UUID orgOwner is rejected',
    { name: 'aws', type: 'token', orgOwner: 'layer5' }, false],
  ['Credential', credential, 'Response for a brand credential still records the creating user in userId',
    { id: ORG, name: 'n', userId: USER, orgOwner: ORG, type: 'token', secret: {}, createdAt: '2026-09-01T00:00:00Z', updatedAt: '2026-09-01T00:00:00Z' }, true],
  ['Credential', credential, 'Response omitting userId is rejected -- user_id was NOT relaxed',
    { id: ORG, name: 'n', orgOwner: ORG, type: 'token', secret: {}, createdAt: '2026-09-01T00:00:00Z', updatedAt: '2026-09-01T00:00:00Z' }, false],
  ['Links', links, 'social sits beside support, each carrying its own contacts',
    { social: { linkedin: 'https://www.linkedin.com/company/layer5', x: 'https://x.com/layer5' },
      support: { slack: 'https://slack.meshery.io' } }, true],
  ['Links', links, 'a malformed LinkedIn URL is rejected per-platform (format: uri)',
    { social: { linkedin: 'layer5-on-linkedin' } }, false],
  ['Links', links, 'the social object cannot be nested inside support',
    { support: { social: { linkedin: 'https://www.linkedin.com/company/layer5' } } }, false],
];

let failed = 0;
for (const [schemaName, schema, desc, body, shouldPass] of cases) {
  const validate = ajv.compile(schema);
  const ok = validate(body);
  const correct = ok === shouldPass;
  if (!correct) failed++;
  console.log(`${correct ? 'PASS' : 'FAIL'}  [${schemaName}] ${desc}`);
  console.log(`        body: ${JSON.stringify(body)}`);
  console.log(`        contract says: ${ok ? 'ACCEPTED' : 'REJECTED -> ' + ajv.errorsText(validate.errors)}`);
}
console.log(failed === 0 ? '\nAll contract expectations held.' : `\n${failed} expectation(s) violated.`);
process.exit(failed === 0 ? 0 : 1);
```
</details>
<details>
<summary>Evidence: TypeScript consumer compile check against generated RTK client</summary>

<code>tsc --noEmit --strict =&gt; exit 0&#10;Control run with both @ts-expect-error markers removed =&gt; exit 2:&#10;error TS2741: Property &#39;userId&#39; is missing in type &#39;{ id; name; type; secret; createdAt; updatedAt }&#39; but required in type &#39;GetCredentialByIdApiResponse&#39;.&#10;error TS2322: Type &#39;{ linkedin?: string; x?: string }&#39; is not assignable to type &#39;string&#39;.</code>

```text
// Consumer-surface check: exercises the generated TypeScript exactly as the
// meshery-cloud UI would, through the generated RTK Query client types.
import type {
  SaveUserCredentialApiArg,
  GetCredentialByIdApiResponse,
  GetOrgsApiResponse,
} from '../../worktrees/7baef7a06130/01M1ERBT2CVZYX20AN5VWFGKEN/typescript/rtk/cloud';

// --- 0.1 Credential: a brand-owned credential is representable ------------
const brandCredential: SaveUserCredentialApiArg = {
  body: {
    name: 'outbox-platform-secret',
    type: 'token',
    secret: { token: 'redacted' },
    orgOwner: '3f1a2b6c-0000-4000-8000-000000000001',
  },
};

// A personal credential simply omits orgOwner: it is optional.
const personalCredential: SaveUserCredentialApiArg = {
  body: { name: 'aws', type: 'token', secret: {} },
};

// userId is NOT relaxed on the response: it stays required, and orgOwner is
// additive alongside it rather than an alternative to it.
declare const cred: GetCredentialByIdApiResponse;
const creatingUser: string = cred.userId; // compiles => still non-optional
const owningOrg: string | undefined = cred.orgOwner; // optional

// @ts-expect-error userId must remain required on the credential response
const badResponse: GetCredentialByIdApiResponse = {
  id: 'x', name: 'n', type: 'token', secret: {}, createdAt: '', updatedAt: '',
};

// --- 0.2 Organization links: social is a sibling of support ---------------
declare const orgs: GetOrgsApiResponse;
const links = orgs.organizations![0].metadata!.preferences.links!;

// Named, per-platform fields (so a consumer can pick the platform icon):
const linkedin: string | undefined = links.social?.linkedin;
const x: string | undefined = links.social?.x;

// support is untouched: still the open-ended contact map.
const supportContacts: { [k: string]: string } | undefined = links.support;

// @ts-expect-error the social object cannot be smuggled into the support map
const leaked: NonNullable<typeof links.support> = { social: links.social! };

export { brandCredential, personalCredential, creatingUser, owningOrg, linkedin, x, supportContacts, badResponse, leaked };
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"95c7fa82a61150c504ba010d22df3803701f5f73","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `models/v1beta2/organization/links_social_test.go:15` - TestLinksSocialIsASiblingOfSupport (models/v1beta2/organization/links_social_test.go:15) asserts only the reflected field types of the generated Links struct, a snapshot of generated struct shape rather than behavior; the sibling-vs-entry invariant it names is already proven behaviourally by TestSocialAndSupportStaySeparateOnTheWire, which populates both social and support and parses the emitted JSON. Unlike the credential db-tag assertions (kept because that column mapping has no other observable surface), this one has a full behavioural equivalent and could be dropped.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`go test ./models/v1beta2/credential/... ./models/v1beta2/organization/... -v` (org_owner + links social behavioural tests, all pass)</code>
- <code>`node contract-check.js` — 8 request/response bodies validated with ajv against `_openapi_build/cloud_openapi.yml` (saveUserCredential requestBody, getCredentialById 200, getOrgs 200 → metadata.preferences.links)</code>
- <code>`./node_modules/.bin/tsc --noEmit --strict` on a consumer file importing `SaveUserCredentialApiArg` / `GetCredentialByIdApiResponse` / `GetOrgsApiResponse` from `typescript/rtk/cloud.ts`</code>
- <code>Negative control: re-ran the same tsc check with both `@ts-expect-error` markers stripped and confirmed it fails with `Property &#39;userId&#39; is missing` and `{linkedin?, x?} is not assignable to type &#39;string&#39;`</code>
- <code>`make bundle-openapi generate-golang generate-rtk generate-ts` then `git status --porcelain` — empty, so committed generated artifacts are idempotent (generate-rtk also ran `make test-rtk`)</code>
- <code>`make validate-schemas` — no blocking violations</code>
- <code>`go build ./...` — clean</code>
- <code>`git show --stat --name-only 95c7fa82` — confirmed no `.claude/settings.local.json`, no `package.json` version bump, no v1beta1 credential changes</code>
- <code>Cleaned up transient `node_modules/` and `_openapi_build/` afterwards; worktree left clean</code>
</details>

<details>
<summary>⚠️ **Document** - 1 info</summary>

- ℹ️ `CHANGELOG.md:5` - Judgment call, deliberately left unchanged: no entry was added to the `## Unreleased` section for the new `orgOwner` and `Links.social` wire fields. Rationale for the no-op: CHANGELOG.md has been touched in only 4 commits in the repo&#39;s entire history and carries a single substantive Unreleased entry, so a per-PR changelog entry is not this repo&#39;s convention; no policy in AGENTS.md, CONTRIBUTING.md, or docs/release-procedure.md requires one; and release notes are produced by Release Drafter, not from this file. Both additions are also purely additive and require no consumer action. If the maintainers do intend Unreleased to record every consumer-visible schema addition, this change warrants one line and the convention should be written down in docs/release-procedure.md so it is not a judgment call next time.
</details>

<details>
<summary>⚠️ **Lint** - 2 infos</summary>

- ℹ️ `models/v1beta2/organization/organization.go:9` - The generated file is not gofmt-clean: the import block orders github.com/meshery/schemas/models/core before github.com/gofrs/uuid, and several struct field-tag columns (AvailableTeam, TeamsOrganizationsMapping, UsersOrganizationsMapping) are misaligned. Verified pre-existing: `gofmt -l` also flags this file at base commit a756916, so this change did not introduce it. Not fixed here because AGENTS.md forbids hand-editing generated output in models/ and the real fix belongs in build/generate-golang.js. `make build` does not gate on gofmt and no CI workflow runs golangci-lint, so nothing is currently red. Flagging as a possible follow-up to add a gofmt pass to the Go generator.
- ℹ️ `make golangci` could not be executed in this environment: the installed golangci-lint 2.12.2 is built with go1.26.2 while the repo&#39;s sources require go1.27 (local toolchain is go1.27.0), so the run panics with &#34;file requires newer Go version go1.27&#34; before reporting any diagnostics. This is a local toolchain mismatch, not a defect in the change. Coverage was preserved by other means: gofmt and `go vet` were run over both changed packages and are clean. golangci-lint is not invoked by `make build` or by any workflow in .github/workflows, so it is not a merge gate.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>