### PR TITLE
Give updateView its own partial-update payload

### DIFF
--- a/models/v1beta1/view/view.go
+++ b/models/v1beta1/view/view.go
@@ -113,7 +113,7 @@ type MesheryViewWithLocation struct {
 	WorkspaceName string `db:"workspace_name" json:"workspace_name,omitempty" yaml:"workspace_name,omitempty"`
 }
 
-// ViewPayload Payload for creating or updating a view.
+// ViewPayload Payload for creating a view.
 type ViewPayload struct {
 	// Filters Filter configuration for this view.
 	Filters core.Map `json:"filters,omitempty" yaml:"filters,omitempty"`
@@ -123,6 +123,21 @@ type ViewPayload struct {
 
 	// Name Display name of the view.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	// Visibility Visibility level of the view.
+	Visibility *string `json:"visibility,omitempty" yaml:"visibility,omitempty"`
+}
+
+// ViewUpdatePayload Partial update for a view. Every property is optional; an omitted property retains its stored value. A supplied name still cannot be empty.
+type ViewUpdatePayload struct {
+	// Filters Filter configuration for this view.
+	Filters core.Map `json:"filters,omitempty" yaml:"filters,omitempty"`
+
+	// Metadata Metadata associated with the view.
+	Metadata core.Map `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	// Name Display name of the view.
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	// Visibility Visibility level of the view.
 	Visibility *string `json:"visibility,omitempty" yaml:"visibility,omitempty"`

--- a/models/v1beta2/view/view.go
+++ b/models/v1beta2/view/view.go
@@ -124,7 +124,7 @@ type MesheryViewWithLocation struct {
 	WorkspaceName string `db:"workspace_name" json:"workspaceName,omitempty" yaml:"workspaceName,omitempty"`
 }
 
-// ViewPayload Payload for creating or updating a view.
+// ViewPayload Payload for creating a view.
 type ViewPayload struct {
 	// Filters Filter configuration for this view.
 	Filters core.Map `json:"filters,omitempty" yaml:"filters,omitempty"`
@@ -134,6 +134,21 @@ type ViewPayload struct {
 
 	// Name Display name of the view.
 	Name string `json:"name,omitempty" yaml:"name,omitempty"`
+
+	// Visibility Visibility level of the view.
+	Visibility *string `json:"visibility,omitempty" yaml:"visibility,omitempty"`
+}
+
+// ViewUpdatePayload Partial update for a view. Every property is optional; an omitted property retains its stored value. A supplied name still cannot be empty.
+type ViewUpdatePayload struct {
+	// Filters Filter configuration for this view.
+	Filters core.Map `json:"filters,omitempty" yaml:"filters,omitempty"`
+
+	// Metadata Metadata associated with the view.
+	Metadata core.Map `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+
+	// Name Display name of the view.
+	Name *string `json:"name,omitempty" yaml:"name,omitempty"`
 
 	// Visibility Visibility level of the view.
 	Visibility *string `json:"visibility,omitempty" yaml:"visibility,omitempty"`

--- a/schemas/constructs/v1beta1/view/api.yml
+++ b/schemas/constructs/v1beta1/view/api.yml
@@ -171,9 +171,50 @@ components:
 
     ViewPayload:
       type: object
-      description: Payload for creating or updating a view.
+      description: Payload for creating a view.
       required:
         - name
+      properties:
+        name:
+          type: string
+          description: Display name of the view.
+          maxLength: 255
+          minLength: 1
+          x-oapi-codegen-extra-tags:
+            json: "name,omitempty"
+        filters:
+          type: object
+          description: Filter configuration for this view.
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+            name: core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "filters,omitempty"
+        visibility:
+          type: string
+          description: Visibility level of the view.
+          maxLength: 255
+          x-oapi-codegen-extra-tags:
+            json: "visibility,omitempty"
+        metadata:
+          type: object
+          description: Metadata associated with the view.
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+            name: core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "metadata,omitempty"
+
+    ViewUpdatePayload:
+      type: object
+      description: >
+        Partial update for a view. Every property is optional; an omitted
+        property retains its stored value. A supplied name still cannot be
+        empty.
       properties:
         name:
           type: string
@@ -264,12 +305,19 @@ components:
 
   requestBodies:
     viewPayload:
-      description: Body for creating or updating a view
+      description: Body for creating a view
       required: true
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/ViewPayload"
+    viewUpdatePayload:
+      description: Body for partially updating a view. Omitted properties retain their stored value.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ViewUpdatePayload"
     contentSharePayload:
       description: Body for sharing a view with recipients by email.
       required: true
@@ -415,7 +463,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/viewId"
       requestBody:
-        $ref: "#/components/requestBodies/viewPayload"
+        $ref: "#/components/requestBodies/viewUpdatePayload"
       responses:
         "200":
           description: Updated view

--- a/schemas/constructs/v1beta2/view/api.yml
+++ b/schemas/constructs/v1beta2/view/api.yml
@@ -206,9 +206,50 @@ components:
 
     ViewPayload:
       type: object
-      description: Payload for creating or updating a view.
+      description: Payload for creating a view.
       required:
         - name
+      properties:
+        name:
+          type: string
+          description: Display name of the view.
+          maxLength: 255
+          minLength: 1
+          x-oapi-codegen-extra-tags:
+            json: "name,omitempty"
+        filters:
+          type: object
+          description: Filter configuration for this view.
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+            name: core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "filters,omitempty"
+        visibility:
+          type: string
+          description: Visibility level of the view.
+          maxLength: 255
+          x-oapi-codegen-extra-tags:
+            json: "visibility,omitempty"
+        metadata:
+          type: object
+          description: Metadata associated with the view.
+          x-go-type: core.Map
+          x-go-type-import:
+            path: github.com/meshery/schemas/models/core
+            name: core
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            json: "metadata,omitempty"
+
+    ViewUpdatePayload:
+      type: object
+      description: >
+        Partial update for a view. Every property is optional; an omitted
+        property retains its stored value. A supplied name still cannot be
+        empty.
       properties:
         name:
           type: string
@@ -316,12 +357,19 @@ components:
 
   requestBodies:
     viewPayload:
-      description: Body for creating or updating a view
+      description: Body for creating a view
       required: true
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/ViewPayload"
+    viewUpdatePayload:
+      description: Body for partially updating a view. Omitted properties retain their stored value.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/ViewUpdatePayload"
     contentSharePayload:
       description: Body for sharing a view with recipients by email.
       required: true
@@ -463,7 +511,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/viewId"
       requestBody:
-        $ref: "#/components/requestBodies/viewPayload"
+        $ref: "#/components/requestBodies/viewUpdatePayload"
       responses:
         "200":
           description: Updated view

--- a/typescript/generated/v1beta1/view/View.ts
+++ b/typescript/generated/v1beta1/view/View.ts
@@ -181,10 +181,21 @@ export interface components {
              */
             deleted_at?: string;
         };
-        /** @description Payload for creating or updating a view. */
+        /** @description Payload for creating a view. */
         ViewPayload: {
             /** @description Display name of the view. */
             name: string;
+            /** @description Filter configuration for this view. */
+            filters?: Record<string, never>;
+            /** @description Visibility level of the view. */
+            visibility?: string;
+            /** @description Metadata associated with the view. */
+            metadata?: Record<string, never>;
+        };
+        /** @description Partial update for a view. Every property is optional; an omitted property retains its stored value. A supplied name still cannot be empty. */
+        ViewUpdatePayload: {
+            /** @description Display name of the view. */
+            name?: string;
             /** @description Filter configuration for this view. */
             filters?: Record<string, never>;
             /** @description Visibility level of the view. */
@@ -334,12 +345,27 @@ export interface components {
         orgIdQuery: string;
     };
     requestBodies: {
-        /** @description Body for creating or updating a view */
+        /** @description Body for creating a view */
         viewPayload: {
             content: {
                 "application/json": {
                     /** @description Display name of the view. */
                     name: string;
+                    /** @description Filter configuration for this view. */
+                    filters?: Record<string, never>;
+                    /** @description Visibility level of the view. */
+                    visibility?: string;
+                    /** @description Metadata associated with the view. */
+                    metadata?: Record<string, never>;
+                };
+            };
+        };
+        /** @description Body for partially updating a view. Omitted properties retain their stored value. */
+        viewUpdatePayload: {
+            content: {
+                "application/json": {
+                    /** @description Display name of the view. */
+                    name?: string;
                     /** @description Filter configuration for this view. */
                     filters?: Record<string, never>;
                     /** @description Visibility level of the view. */
@@ -495,7 +521,7 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        /** @description Body for creating or updating a view */
+        /** @description Body for creating a view */
         requestBody: {
             content: {
                 "application/json": {
@@ -771,12 +797,12 @@ export interface operations {
             };
             cookie?: never;
         };
-        /** @description Body for creating or updating a view */
+        /** @description Body for partially updating a view. Omitted properties retain their stored value. */
         requestBody: {
             content: {
                 "application/json": {
                     /** @description Display name of the view. */
-                    name: string;
+                    name?: string;
                     /** @description Filter configuration for this view. */
                     filters?: Record<string, never>;
                     /** @description Visibility level of the view. */

--- a/typescript/generated/v1beta1/view/ViewSchema.ts
+++ b/typescript/generated/v1beta1/view/ViewSchema.ts
@@ -496,10 +496,59 @@ const ViewSchema: Record<string, unknown> = {
       },
       "ViewPayload": {
         "type": "object",
-        "description": "Payload for creating or updating a view.",
+        "description": "Payload for creating a view.",
         "required": [
           "name"
         ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name of the view.",
+            "maxLength": 255,
+            "minLength": 1,
+            "x-oapi-codegen-extra-tags": {
+              "json": "name,omitempty"
+            }
+          },
+          "filters": {
+            "type": "object",
+            "description": "Filter configuration for this view.",
+            "x-go-type": "core.Map",
+            "x-go-type-import": {
+              "path": "github.com/meshery/schemas/models/core",
+              "name": "core"
+            },
+            "x-go-type-skip-optional-pointer": true,
+            "x-oapi-codegen-extra-tags": {
+              "json": "filters,omitempty"
+            }
+          },
+          "visibility": {
+            "type": "string",
+            "description": "Visibility level of the view.",
+            "maxLength": 255,
+            "x-oapi-codegen-extra-tags": {
+              "json": "visibility,omitempty"
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata associated with the view.",
+            "x-go-type": "core.Map",
+            "x-go-type-import": {
+              "path": "github.com/meshery/schemas/models/core",
+              "name": "core"
+            },
+            "x-go-type-skip-optional-pointer": true,
+            "x-oapi-codegen-extra-tags": {
+              "json": "metadata,omitempty"
+            }
+          }
+        }
+      },
+      "ViewUpdatePayload": {
+        "type": "object",
+        "description": "Partial update for a view. Every property is optional; an omitted property retains its stored value. A supplied name still cannot be empty.\n",
         "properties": {
           "name": {
             "type": "string",
@@ -785,16 +834,73 @@ const ViewSchema: Record<string, unknown> = {
     },
     "requestBodies": {
       "viewPayload": {
-        "description": "Body for creating or updating a view",
+        "description": "Body for creating a view",
         "required": true,
         "content": {
           "application/json": {
             "schema": {
               "type": "object",
-              "description": "Payload for creating or updating a view.",
+              "description": "Payload for creating a view.",
               "required": [
                 "name"
               ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Display name of the view.",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "x-oapi-codegen-extra-tags": {
+                    "json": "name,omitempty"
+                  }
+                },
+                "filters": {
+                  "type": "object",
+                  "description": "Filter configuration for this view.",
+                  "x-go-type": "core.Map",
+                  "x-go-type-import": {
+                    "path": "github.com/meshery/schemas/models/core",
+                    "name": "core"
+                  },
+                  "x-go-type-skip-optional-pointer": true,
+                  "x-oapi-codegen-extra-tags": {
+                    "json": "filters,omitempty"
+                  }
+                },
+                "visibility": {
+                  "type": "string",
+                  "description": "Visibility level of the view.",
+                  "maxLength": 255,
+                  "x-oapi-codegen-extra-tags": {
+                    "json": "visibility,omitempty"
+                  }
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "Metadata associated with the view.",
+                  "x-go-type": "core.Map",
+                  "x-go-type-import": {
+                    "path": "github.com/meshery/schemas/models/core",
+                    "name": "core"
+                  },
+                  "x-go-type-skip-optional-pointer": true,
+                  "x-oapi-codegen-extra-tags": {
+                    "json": "metadata,omitempty"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "viewUpdatePayload": {
+        "description": "Body for partially updating a view. Omitted properties retain their stored value.",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "description": "Partial update for a view. Every property is optional; an omitted property retains its stored value. A supplied name still cannot be empty.\n",
               "properties": {
                 "name": {
                   "type": "string",
@@ -907,13 +1013,13 @@ const ViewSchema: Record<string, unknown> = {
         "summary": "Create a view",
         "description": "Creates a new view with the given filters and metadata.",
         "requestBody": {
-          "description": "Body for creating or updating a view",
+          "description": "Body for creating a view",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "Payload for creating or updating a view.",
+                "description": "Payload for creating a view.",
                 "required": [
                   "name"
                 ],
@@ -1851,16 +1957,13 @@ const ViewSchema: Record<string, unknown> = {
           }
         ],
         "requestBody": {
-          "description": "Body for creating or updating a view",
+          "description": "Body for partially updating a view. Omitted properties retain their stored value.",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "Payload for creating or updating a view.",
-                "required": [
-                  "name"
-                ],
+                "description": "Partial update for a view. Every property is optional; an omitted property retains its stored value. A supplied name still cannot be empty.\n",
                 "properties": {
                   "name": {
                     "type": "string",

--- a/typescript/generated/v1beta2/view/View.ts
+++ b/typescript/generated/v1beta2/view/View.ts
@@ -181,10 +181,21 @@ export interface components {
              */
             deletedAt?: string | null;
         };
-        /** @description Payload for creating or updating a view. */
+        /** @description Payload for creating a view. */
         ViewPayload: {
             /** @description Display name of the view. */
             name: string;
+            /** @description Filter configuration for this view. */
+            filters?: Record<string, never>;
+            /** @description Visibility level of the view. */
+            visibility?: string;
+            /** @description Metadata associated with the view. */
+            metadata?: Record<string, never>;
+        };
+        /** @description Partial update for a view. Every property is optional; an omitted property retains its stored value. A supplied name still cannot be empty. */
+        ViewUpdatePayload: {
+            /** @description Display name of the view. */
+            name?: string;
             /** @description Filter configuration for this view. */
             filters?: Record<string, never>;
             /** @description Visibility level of the view. */
@@ -344,12 +355,27 @@ export interface components {
         userIdQuery: string;
     };
     requestBodies: {
-        /** @description Body for creating or updating a view */
+        /** @description Body for creating a view */
         viewPayload: {
             content: {
                 "application/json": {
                     /** @description Display name of the view. */
                     name: string;
+                    /** @description Filter configuration for this view. */
+                    filters?: Record<string, never>;
+                    /** @description Visibility level of the view. */
+                    visibility?: string;
+                    /** @description Metadata associated with the view. */
+                    metadata?: Record<string, never>;
+                };
+            };
+        };
+        /** @description Body for partially updating a view. Omitted properties retain their stored value. */
+        viewUpdatePayload: {
+            content: {
+                "application/json": {
+                    /** @description Display name of the view. */
+                    name?: string;
                     /** @description Filter configuration for this view. */
                     filters?: Record<string, never>;
                     /** @description Visibility level of the view. */
@@ -513,7 +539,7 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        /** @description Body for creating or updating a view */
+        /** @description Body for creating a view */
         requestBody: {
             content: {
                 "application/json": {
@@ -789,12 +815,12 @@ export interface operations {
             };
             cookie?: never;
         };
-        /** @description Body for creating or updating a view */
+        /** @description Body for partially updating a view. Omitted properties retain their stored value. */
         requestBody: {
             content: {
                 "application/json": {
                     /** @description Display name of the view. */
-                    name: string;
+                    name?: string;
                     /** @description Filter configuration for this view. */
                     filters?: Record<string, never>;
                     /** @description Visibility level of the view. */

--- a/typescript/generated/v1beta2/view/ViewSchema.ts
+++ b/typescript/generated/v1beta2/view/ViewSchema.ts
@@ -516,10 +516,59 @@ const ViewSchema: Record<string, unknown> = {
       },
       "ViewPayload": {
         "type": "object",
-        "description": "Payload for creating or updating a view.",
+        "description": "Payload for creating a view.",
         "required": [
           "name"
         ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Display name of the view.",
+            "maxLength": 255,
+            "minLength": 1,
+            "x-oapi-codegen-extra-tags": {
+              "json": "name,omitempty"
+            }
+          },
+          "filters": {
+            "type": "object",
+            "description": "Filter configuration for this view.",
+            "x-go-type": "core.Map",
+            "x-go-type-import": {
+              "path": "github.com/meshery/schemas/models/core",
+              "name": "core"
+            },
+            "x-go-type-skip-optional-pointer": true,
+            "x-oapi-codegen-extra-tags": {
+              "json": "filters,omitempty"
+            }
+          },
+          "visibility": {
+            "type": "string",
+            "description": "Visibility level of the view.",
+            "maxLength": 255,
+            "x-oapi-codegen-extra-tags": {
+              "json": "visibility,omitempty"
+            }
+          },
+          "metadata": {
+            "type": "object",
+            "description": "Metadata associated with the view.",
+            "x-go-type": "core.Map",
+            "x-go-type-import": {
+              "path": "github.com/meshery/schemas/models/core",
+              "name": "core"
+            },
+            "x-go-type-skip-optional-pointer": true,
+            "x-oapi-codegen-extra-tags": {
+              "json": "metadata,omitempty"
+            }
+          }
+        }
+      },
+      "ViewUpdatePayload": {
+        "type": "object",
+        "description": "Partial update for a view. Every property is optional; an omitted property retains its stored value. A supplied name still cannot be empty.\n",
         "properties": {
           "name": {
             "type": "string",
@@ -825,16 +874,73 @@ const ViewSchema: Record<string, unknown> = {
     },
     "requestBodies": {
       "viewPayload": {
-        "description": "Body for creating or updating a view",
+        "description": "Body for creating a view",
         "required": true,
         "content": {
           "application/json": {
             "schema": {
               "type": "object",
-              "description": "Payload for creating or updating a view.",
+              "description": "Payload for creating a view.",
               "required": [
                 "name"
               ],
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Display name of the view.",
+                  "maxLength": 255,
+                  "minLength": 1,
+                  "x-oapi-codegen-extra-tags": {
+                    "json": "name,omitempty"
+                  }
+                },
+                "filters": {
+                  "type": "object",
+                  "description": "Filter configuration for this view.",
+                  "x-go-type": "core.Map",
+                  "x-go-type-import": {
+                    "path": "github.com/meshery/schemas/models/core",
+                    "name": "core"
+                  },
+                  "x-go-type-skip-optional-pointer": true,
+                  "x-oapi-codegen-extra-tags": {
+                    "json": "filters,omitempty"
+                  }
+                },
+                "visibility": {
+                  "type": "string",
+                  "description": "Visibility level of the view.",
+                  "maxLength": 255,
+                  "x-oapi-codegen-extra-tags": {
+                    "json": "visibility,omitempty"
+                  }
+                },
+                "metadata": {
+                  "type": "object",
+                  "description": "Metadata associated with the view.",
+                  "x-go-type": "core.Map",
+                  "x-go-type-import": {
+                    "path": "github.com/meshery/schemas/models/core",
+                    "name": "core"
+                  },
+                  "x-go-type-skip-optional-pointer": true,
+                  "x-oapi-codegen-extra-tags": {
+                    "json": "metadata,omitempty"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "viewUpdatePayload": {
+        "description": "Body for partially updating a view. Omitted properties retain their stored value.",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "description": "Partial update for a view. Every property is optional; an omitted property retains its stored value. A supplied name still cannot be empty.\n",
               "properties": {
                 "name": {
                   "type": "string",
@@ -953,13 +1059,13 @@ const ViewSchema: Record<string, unknown> = {
         "summary": "Create a view",
         "description": "Creates a new view with the given filters and metadata.",
         "requestBody": {
-          "description": "Body for creating or updating a view",
+          "description": "Body for creating a view",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "Payload for creating or updating a view.",
+                "description": "Payload for creating a view.",
                 "required": [
                   "name"
                 ],
@@ -1928,16 +2034,13 @@ const ViewSchema: Record<string, unknown> = {
           }
         ],
         "requestBody": {
-          "description": "Body for creating or updating a view",
+          "description": "Body for partially updating a view. Omitted properties retain their stored value.",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "Payload for creating or updating a view.",
-                "required": [
-                  "name"
-                ],
+                "description": "Partial update for a view. Every property is optional; an omitted property retains its stored value. A supplied name still cannot be empty.\n",
                 "properties": {
                   "name": {
                     "type": "string",

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -4987,7 +4987,7 @@ export type CreateViewApiResponse = /** status 201 Created view */ {
   deletedAt?: string | null;
 };
 export type CreateViewApiArg = {
-  /** Body for creating or updating a view */
+  /** Body for creating a view */
   body: {
     /** Display name of the view. */
     name: string;
@@ -5122,10 +5122,10 @@ export type UpdateViewApiResponse = /** status 200 Updated view */ {
 export type UpdateViewApiArg = {
   /** View ID */
   viewId: string;
-  /** Body for creating or updating a view */
+  /** Body for partially updating a view. Omitted properties retain their stored value. */
   body: {
     /** Display name of the view. */
-    name: string;
+    name?: string;
     /** Filter configuration for this view. */
     filters?: object;
     /** Visibility level of the view. */


### PR DESCRIPTION
Fixes #1147

`updateView` is a partial-update PUT but reused the create-shaped `ViewPayload`, which requires a non-empty `name` on every request. There was no schema-valid way to express a visibility-only update: omitting `name` violates the `required` list, an empty `name` violates `minLength`, and resending the client's cached `name` is a write that can silently revert a rename made elsewhere.

The provider (`meshery-cloud`'s `UpdateView`) has always implemented a real partial update, retaining any field the caller omits. The schema's "always send a non-empty name" contract disagreed with that. Nothing enforces the schema at runtime yet only because `UpdateView` unmarshals by hand with no request-validation middleware in front of it — the issue notes this is exactly the kind of latent defect that turns into a live 400 regression the moment validation is introduced upstream.

Per the issue's own "Ask": added `ViewUpdatePayload`, with every property optional and `minLength` retained on a *supplied* name, and pointed `updateView`'s requestBody at it instead of the create payload — in both `v1beta1` and `v1beta2` (the issue notes the defect exists in both). Also corrected `ViewPayload`'s now-inaccurate "creating or updating" description since it's create-only now.

Regenerated the Go models, TypeScript types, and RTK client so everything stays in sync.

## Test plan
- [x] `make generate-golang` — confirmed `ViewUpdatePayload.Name` generates as `*string` (optional) vs. `ViewPayload.Name string` (required)
- [x] `make generate-rtk` and `make generate-ts` — confirmed `updateView`'s operation-level requestBody now has `name?: string` instead of `name: string`
- [x] `make validate-schemas` — no blocking violations
- [x] `test-gofmt` and `test-rtk` regression suites pass

Note: while verifying generation locally I hit a pre-existing `SyntaxError` in `build/generate-golang.js` (duplicate `const helperPath`, introduced by #1180) that breaks `make generate-golang` on current master for everyone. That's unrelated to this fix, so I've filed it separately rather than bundling it in here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for partial view updates, allowing clients to provide only the fields they want to change.
  * Omitted update fields now retain their existing values.
  * View names remain subject to non-empty validation when supplied.

* **Documentation**
  * Clarified that view creation payloads are intended for creating views only.
  * Updated API and client type definitions to reflect optional fields for view updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->