### PR TITLE
Fix duplicate helperPath declaration in generate-golang.js

### DIFF
--- a/build/generate-golang.js
+++ b/build/generate-golang.js
@@ -1525,12 +1525,6 @@ async function generateGoModels(pkg) {
       formatGoFile(helperPath);
     }
 
-    execSync(`gofmt -w "${outputPath}"`, { stdio: "inherit" });
-    const helperPath = path.join(outputDir, "zz_generated.helpers.go");
-    if (fs.existsSync(helperPath)) {
-      execSync(`gofmt -w "${helperPath}"`, { stdio: "inherit" });
-    }
-
     logger.success(`Generated: ${paths.relativePath(outputPath)}`);
   } catch (err) {
     throw new Error(


### PR DESCRIPTION
#1180 added an earlier declaration of \`helperPath\` (from \`writeGeneratedHelperFile\`'s return value, used to gofmt the helper file via the new shared \`formatGoFile\` helper) but didn't remove the old tail code that re-declared \`helperPath\` and gofmt'd it and \`outputPath\` manually. Two \`const helperPath\` in the same scope is a \`SyntaxError\`, so \`node build/generate-golang.js\` — and therefore \`make generate-golang\` — fails immediately for every construct on current master:

\`\`\`
build/generate-golang.js:1529
    const helperPath = path.join(outputDir, "zz_generated.helpers.go");
          ^
SyntaxError: Identifier 'helperPath' has already been declared
\`\`\`

Found this while verifying a schema PR locally — it blocks any contributor from regenerating Go models after an OpenAPI change.

The old tail block is fully redundant: \`formatGoFile(outputPath)\` and \`formatGoFile(helperPath)\` above it already do the same formatting via the new shared helper introduced by #1180. Removed it.

## Test plan
- [x] \`make generate-golang\` now completes for every construct package with no errors
- [x] No generated-model drift — diff is the script file only
- [x] \`test-gofmt\` regression suite passes