### PR TITLE
Give updateEnvironment its own partial-update payload

### DIFF
--- a/models/v1beta1/environment/environment.go
+++ b/models/v1beta1/environment/environment.go
@@ -89,6 +89,15 @@ type EnvironmentPayload struct {
 	OrgId uuid.UUID `json:"organization_id" yaml:"organization_id"`
 }
 
+// EnvironmentUpdatePayload Partial update for an environment. Every property is optional; an omitted property retains its stored value. organization_id is accepted for symmetry with the create payload but is not actually mutable - see its own description - so omitting it is the normal case.
+type EnvironmentUpdatePayload struct {
+	Description core.Text `json:"description,omitempty" yaml:"description,omitempty"`
+	Name        core.Text `json:"name,omitempty" yaml:"name,omitempty"`
+
+	// OrgId The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
+	OrgId uuid.UUID `json:"organization_id" yaml:"organization_id"`
+}
+
 // EnvironmentId defines model for environmentId.
 type EnvironmentId = core.Id
 

--- a/models/v1beta1/environment/environment.go
+++ b/models/v1beta1/environment/environment.go
@@ -95,7 +95,7 @@ type EnvironmentUpdatePayload struct {
 	Name        core.Text `json:"name,omitempty" yaml:"name,omitempty"`
 
 	// OrgId The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
-	OrgId uuid.UUID `json:"organization_id" yaml:"organization_id"`
+	OrgId *uuid.UUID `json:"organization_id,omitempty" yaml:"organization_id,omitempty"`
 }
 
 // EnvironmentId defines model for environmentId.

--- a/models/v1beta3/environment/environment.go
+++ b/models/v1beta3/environment/environment.go
@@ -132,6 +132,15 @@ type EnvironmentPayload struct {
 	OrgID uuid.UUID `json:"organizationId" yaml:"organizationId"`
 }
 
+// EnvironmentUpdatePayload Partial update for an environment. Every property is optional; an omitted property retains its stored value. organizationId is accepted for symmetry with the create payload but is not actually mutable - see its own description - so omitting it is the normal case.
+type EnvironmentUpdatePayload struct {
+	Description core.Text `json:"description,omitempty" yaml:"description,omitempty"`
+	Name        core.Text `json:"name,omitempty" yaml:"name,omitempty"`
+
+	// OrgID The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
+	OrgID uuid.UUID `json:"organizationId" yaml:"organizationId"`
+}
+
 // EnvironmentId defines model for environmentId.
 type EnvironmentId = core.Id
 

--- a/models/v1beta3/environment/environment.go
+++ b/models/v1beta3/environment/environment.go
@@ -138,7 +138,7 @@ type EnvironmentUpdatePayload struct {
 	Name        core.Text `json:"name,omitempty" yaml:"name,omitempty"`
 
 	// OrgID The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
-	OrgID uuid.UUID `json:"organizationId" yaml:"organizationId"`
+	OrgID *uuid.UUID `json:"organizationId,omitempty" yaml:"organizationId,omitempty"`
 }
 
 // EnvironmentId defines model for environmentId.

--- a/schemas/constructs/v1beta1/environment/api.yml
+++ b/schemas/constructs/v1beta1/environment/api.yml
@@ -112,6 +112,29 @@ components:
       required:
         - name
         - organization_id
+    EnvironmentUpdatePayload:
+      description: >-
+        Partial update for an environment. Every property is optional; an
+        omitted property retains its stored value. organization_id is
+        accepted for symmetry with the create payload but is not actually
+        mutable - see its own description - so omitting it is the normal
+        case.
+      properties:
+        name:
+          $ref: ../core/api.yml#/components/schemas/Text
+          description: An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation.
+        description:
+          $ref: ../core/api.yml#/components/schemas/Text
+          description: "An environment is a collection of resources, such as connections & credentail. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any Time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments)."
+        organization_id:
+          type: string
+          description: The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
+          x-go-type-skip-optional-pointer: true
+          x-go-name: OrgId
+          x-oapi-codegen-extra-tags:
+            json: organization_id
+          maxLength: 500
+          format: uuid
     EnvironmentPage:
       properties:
         page:
@@ -152,12 +175,19 @@ components:
 
   requestBodies:
     environmentPayload:
-      description: Body for creating environment
+      description: Body for creating an environment
       required: true
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/EnvironmentPayload"
+    environmentUpdatePayload:
+      description: Body for partially updating an environment. Omitted properties retain their stored value.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/EnvironmentUpdatePayload"
 
 paths:
   /api/environments:
@@ -242,7 +272,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/environmentId"
       requestBody:
-        $ref: "#/components/requestBodies/environmentPayload"
+        $ref: "#/components/requestBodies/environmentUpdatePayload"
       responses:
         "200":
           description: Environment page

--- a/schemas/constructs/v1beta1/environment/api.yml
+++ b/schemas/constructs/v1beta1/environment/api.yml
@@ -129,10 +129,9 @@ components:
         organization_id:
           type: string
           description: The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
-          x-go-type-skip-optional-pointer: true
           x-go-name: OrgId
           x-oapi-codegen-extra-tags:
-            json: organization_id
+            json: organization_id,omitempty
           maxLength: 500
           format: uuid
     EnvironmentPage:

--- a/schemas/constructs/v1beta3/environment/api.yml
+++ b/schemas/constructs/v1beta3/environment/api.yml
@@ -150,6 +150,29 @@ components:
             json: organizationId
           maxLength: 500
           format: uuid
+    EnvironmentUpdatePayload:
+      type: object
+      description: >-
+        Partial update for an environment. Every property is optional; an
+        omitted property retains its stored value. organizationId is accepted
+        for symmetry with the create payload but is not actually mutable -
+        see its own description - so omitting it is the normal case.
+      properties:
+        name:
+          $ref: ../../v1alpha1/core/api.yml#/components/schemas/Text
+          description: An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation.
+        description:
+          $ref: ../../v1alpha1/core/api.yml#/components/schemas/Text
+          description: "An environment is a collection of resources, such as connections & credentials. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments)."
+        organizationId:
+          type: string
+          description: The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
+          x-go-type-skip-optional-pointer: true
+          x-go-name: OrgID
+          x-oapi-codegen-extra-tags:
+            json: organizationId
+          maxLength: 500
+          format: uuid
     EnvironmentPage:
       type: object
       description: Paginated list of environments.
@@ -244,12 +267,19 @@ components:
 
   requestBodies:
     environmentPayload:
-      description: Body for creating environment
+      description: Body for creating an environment
       required: true
       content:
         application/json:
           schema:
             $ref: "#/components/schemas/EnvironmentPayload"
+    environmentUpdatePayload:
+      description: Body for partially updating an environment. Omitted properties retain their stored value.
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/EnvironmentUpdatePayload"
 
 paths:
   /api/environments:
@@ -335,7 +365,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/environmentId"
       requestBody:
-        $ref: "#/components/requestBodies/environmentPayload"
+        $ref: "#/components/requestBodies/environmentUpdatePayload"
       responses:
         "200":
           description: Environment page

--- a/schemas/constructs/v1beta3/environment/api.yml
+++ b/schemas/constructs/v1beta3/environment/api.yml
@@ -167,10 +167,9 @@ components:
         organizationId:
           type: string
           description: The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
-          x-go-type-skip-optional-pointer: true
           x-go-name: OrgID
           x-oapi-codegen-extra-tags:
-            json: organizationId
+            json: organizationId,omitempty
           maxLength: 500
           format: uuid
     EnvironmentPage:

--- a/typescript/generated/v1beta1/environment/Environment.ts
+++ b/typescript/generated/v1beta1/environment/Environment.ts
@@ -169,6 +169,18 @@ export interface components {
              */
             organization_id: string;
         };
+        /** @description Partial update for an environment. Every property is optional; an omitted property retains its stored value. organization_id is accepted for symmetry with the create payload but is not actually mutable - see its own description - so omitting it is the normal case. */
+        EnvironmentUpdatePayload: {
+            /** @description An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation. */
+            name?: string;
+            /** @description An environment is a collection of resources, such as connections & credentail. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any Time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments). */
+            description?: string;
+            /**
+             * Format: uuid
+             * @description The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
+             */
+            organization_id?: string;
+        };
         EnvironmentPage: {
             page?: number;
             page_size?: number;
@@ -301,7 +313,7 @@ export interface components {
         orgIdQuery: string;
     };
     requestBodies: {
-        /** @description Body for creating environment */
+        /** @description Body for creating an environment */
         environmentPayload: {
             content: {
                 "application/json": {
@@ -314,6 +326,22 @@ export interface components {
                      * @description Select an organization in which you want to create this new environment. Keep in mind that the organization cannot be changed after creation.
                      */
                     organization_id: string;
+                };
+            };
+        };
+        /** @description Body for partially updating an environment. Omitted properties retain their stored value. */
+        environmentUpdatePayload: {
+            content: {
+                "application/json": {
+                    /** @description An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation. */
+                    name?: string;
+                    /** @description An environment is a collection of resources, such as connections & credentail. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any Time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments). */
+                    description?: string;
+                    /**
+                     * Format: uuid
+                     * @description The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
+                     */
+                    organization_id?: string;
                 };
             };
         };
@@ -435,7 +463,7 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        /** @description Body for creating environment */
+        /** @description Body for creating an environment */
         requestBody: {
             content: {
                 "application/json": {
@@ -668,19 +696,19 @@ export interface operations {
             };
             cookie?: never;
         };
-        /** @description Body for creating environment */
+        /** @description Body for partially updating an environment. Omitted properties retain their stored value. */
         requestBody: {
             content: {
                 "application/json": {
                     /** @description An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation. */
-                    name: string;
+                    name?: string;
                     /** @description An environment is a collection of resources, such as connections & credentail. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any Time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments). */
                     description?: string;
                     /**
                      * Format: uuid
-                     * @description Select an organization in which you want to create this new environment. Keep in mind that the organization cannot be changed after creation.
+                     * @description The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
                      */
-                    organization_id: string;
+                    organization_id?: string;
                 };
             };
         };

--- a/typescript/generated/v1beta1/environment/EnvironmentSchema.ts
+++ b/typescript/generated/v1beta1/environment/EnvironmentSchema.ts
@@ -424,6 +424,32 @@ const EnvironmentSchema: Record<string, unknown> = {
           "organization_id"
         ]
       },
+      "EnvironmentUpdatePayload": {
+        "description": "Partial update for an environment. Every property is optional; an omitted property retains its stored value. organization_id is accepted for symmetry with the create payload but is not actually mutable - see its own description - so omitting it is the normal case.",
+        "properties": {
+          "name": {
+            "description": "An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation.",
+            "type": "string",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "description": {
+            "description": "An environment is a collection of resources, such as connections & credentail. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any Time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments).",
+            "type": "string",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "organization_id": {
+            "type": "string",
+            "description": "The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.",
+            "x-go-type-skip-optional-pointer": true,
+            "x-go-name": "OrgId",
+            "x-oapi-codegen-extra-tags": {
+              "json": "organization_id"
+            },
+            "maxLength": 500,
+            "format": "uuid"
+          }
+        }
+      },
       "EnvironmentPage": {
         "properties": {
           "page": {
@@ -647,7 +673,7 @@ const EnvironmentSchema: Record<string, unknown> = {
     },
     "requestBodies": {
       "environmentPayload": {
-        "description": "Body for creating environment",
+        "description": "Body for creating an environment",
         "required": true,
         "content": {
           "application/json": {
@@ -682,6 +708,40 @@ const EnvironmentSchema: Record<string, unknown> = {
             }
           }
         }
+      },
+      "environmentUpdatePayload": {
+        "description": "Body for partially updating an environment. Omitted properties retain their stored value.",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "description": "Partial update for an environment. Every property is optional; an omitted property retains its stored value. organization_id is accepted for symmetry with the create payload but is not actually mutable - see its own description - so omitting it is the normal case.",
+              "properties": {
+                "name": {
+                  "description": "An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation.",
+                  "type": "string",
+                  "x-go-type-skip-optional-pointer": true
+                },
+                "description": {
+                  "description": "An environment is a collection of resources, such as connections & credentail. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any Time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments).",
+                  "type": "string",
+                  "x-go-type-skip-optional-pointer": true
+                },
+                "organization_id": {
+                  "type": "string",
+                  "description": "The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.",
+                  "x-go-type-skip-optional-pointer": true,
+                  "x-go-name": "OrgId",
+                  "x-oapi-codegen-extra-tags": {
+                    "json": "organization_id"
+                  },
+                  "maxLength": 500,
+                  "format": "uuid"
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -699,7 +759,7 @@ const EnvironmentSchema: Record<string, unknown> = {
         "summary": "Create an environment",
         "description": "Creates a new environment",
         "requestBody": {
-          "description": "Body for creating environment",
+          "description": "Body for creating an environment",
           "required": true,
           "content": {
             "application/json": {
@@ -1529,11 +1589,12 @@ const EnvironmentSchema: Record<string, unknown> = {
           }
         ],
         "requestBody": {
-          "description": "Body for creating environment",
+          "description": "Body for partially updating an environment. Omitted properties retain their stored value.",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
+                "description": "Partial update for an environment. Every property is optional; an omitted property retains its stored value. organization_id is accepted for symmetry with the create payload but is not actually mutable - see its own description - so omitting it is the normal case.",
                 "properties": {
                   "name": {
                     "description": "An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation.",
@@ -1547,7 +1608,7 @@ const EnvironmentSchema: Record<string, unknown> = {
                   },
                   "organization_id": {
                     "type": "string",
-                    "description": "Select an organization in which you want to create this new environment. Keep in mind that the organization cannot be changed after creation.",
+                    "description": "The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.",
                     "x-go-type-skip-optional-pointer": true,
                     "x-go-name": "OrgId",
                     "x-oapi-codegen-extra-tags": {
@@ -1556,11 +1617,7 @@ const EnvironmentSchema: Record<string, unknown> = {
                     "maxLength": 500,
                     "format": "uuid"
                   }
-                },
-                "required": [
-                  "name",
-                  "organization_id"
-                ]
+                }
               }
             }
           }

--- a/typescript/generated/v1beta1/environment/EnvironmentSchema.ts
+++ b/typescript/generated/v1beta1/environment/EnvironmentSchema.ts
@@ -440,10 +440,9 @@ const EnvironmentSchema: Record<string, unknown> = {
           "organization_id": {
             "type": "string",
             "description": "The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.",
-            "x-go-type-skip-optional-pointer": true,
             "x-go-name": "OrgId",
             "x-oapi-codegen-extra-tags": {
-              "json": "organization_id"
+              "json": "organization_id,omitempty"
             },
             "maxLength": 500,
             "format": "uuid"
@@ -730,10 +729,9 @@ const EnvironmentSchema: Record<string, unknown> = {
                 "organization_id": {
                   "type": "string",
                   "description": "The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.",
-                  "x-go-type-skip-optional-pointer": true,
                   "x-go-name": "OrgId",
                   "x-oapi-codegen-extra-tags": {
-                    "json": "organization_id"
+                    "json": "organization_id,omitempty"
                   },
                   "maxLength": 500,
                   "format": "uuid"
@@ -1609,10 +1607,9 @@ const EnvironmentSchema: Record<string, unknown> = {
                   "organization_id": {
                     "type": "string",
                     "description": "The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.",
-                    "x-go-type-skip-optional-pointer": true,
                     "x-go-name": "OrgId",
                     "x-oapi-codegen-extra-tags": {
-                      "json": "organization_id"
+                      "json": "organization_id,omitempty"
                     },
                     "maxLength": 500,
                     "format": "uuid"

--- a/typescript/generated/v1beta3/environment/Environment.ts
+++ b/typescript/generated/v1beta3/environment/Environment.ts
@@ -194,6 +194,18 @@ export interface components {
              */
             organizationId: string;
         };
+        /** @description Partial update for an environment. Every property is optional; an omitted property retains its stored value. organizationId is accepted for symmetry with the create payload but is not actually mutable - see its own description - so omitting it is the normal case. */
+        EnvironmentUpdatePayload: {
+            /** @description An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation. */
+            name?: string;
+            /** @description An environment is a collection of resources, such as connections & credentials. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments). */
+            description?: string;
+            /**
+             * Format: uuid
+             * @description The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
+             */
+            organizationId?: string;
+        };
         /** @description Paginated list of environments. */
         EnvironmentPage: {
             /** @description Zero-based page index returned in this response. */
@@ -391,7 +403,7 @@ export interface components {
         orgIdQuery: string;
     };
     requestBodies: {
-        /** @description Body for creating environment */
+        /** @description Body for creating an environment */
         environmentPayload: {
             content: {
                 "application/json": {
@@ -404,6 +416,22 @@ export interface components {
                      * @description Select an organization in which you want to create this new environment. Keep in mind that the organization cannot be changed after creation.
                      */
                     organizationId: string;
+                };
+            };
+        };
+        /** @description Body for partially updating an environment. Omitted properties retain their stored value. */
+        environmentUpdatePayload: {
+            content: {
+                "application/json": {
+                    /** @description An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation. */
+                    name?: string;
+                    /** @description An environment is a collection of resources, such as connections & credentials. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments). */
+                    description?: string;
+                    /**
+                     * Format: uuid
+                     * @description The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
+                     */
+                    organizationId?: string;
                 };
             };
         };
@@ -546,7 +574,7 @@ export interface operations {
             path?: never;
             cookie?: never;
         };
-        /** @description Body for creating environment */
+        /** @description Body for creating an environment */
         requestBody: {
             content: {
                 "application/json": {
@@ -808,19 +836,19 @@ export interface operations {
             };
             cookie?: never;
         };
-        /** @description Body for creating environment */
+        /** @description Body for partially updating an environment. Omitted properties retain their stored value. */
         requestBody: {
             content: {
                 "application/json": {
                     /** @description An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation. */
-                    name: string;
+                    name?: string;
                     /** @description An environment is a collection of resources, such as connections & credentials. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments). */
                     description?: string;
                     /**
                      * Format: uuid
-                     * @description Select an organization in which you want to create this new environment. Keep in mind that the organization cannot be changed after creation.
+                     * @description The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.
                      */
-                    organizationId: string;
+                    organizationId?: string;
                 };
             };
         };

--- a/typescript/generated/v1beta3/environment/EnvironmentSchema.ts
+++ b/typescript/generated/v1beta3/environment/EnvironmentSchema.ts
@@ -470,6 +470,33 @@ const EnvironmentSchema: Record<string, unknown> = {
           }
         }
       },
+      "EnvironmentUpdatePayload": {
+        "type": "object",
+        "description": "Partial update for an environment. Every property is optional; an omitted property retains its stored value. organizationId is accepted for symmetry with the create payload but is not actually mutable - see its own description - so omitting it is the normal case.",
+        "properties": {
+          "name": {
+            "description": "An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation.",
+            "type": "string",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "description": {
+            "description": "An environment is a collection of resources, such as connections & credentials. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments).",
+            "type": "string",
+            "x-go-type-skip-optional-pointer": true
+          },
+          "organizationId": {
+            "type": "string",
+            "description": "The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.",
+            "x-go-type-skip-optional-pointer": true,
+            "x-go-name": "OrgID",
+            "x-oapi-codegen-extra-tags": {
+              "json": "organizationId"
+            },
+            "maxLength": 500,
+            "format": "uuid"
+          }
+        }
+      },
       "EnvironmentPage": {
         "type": "object",
         "description": "Paginated list of environments.",
@@ -855,7 +882,7 @@ const EnvironmentSchema: Record<string, unknown> = {
     },
     "requestBodies": {
       "environmentPayload": {
-        "description": "Body for creating environment",
+        "description": "Body for creating an environment",
         "required": true,
         "content": {
           "application/json": {
@@ -892,6 +919,41 @@ const EnvironmentSchema: Record<string, unknown> = {
             }
           }
         }
+      },
+      "environmentUpdatePayload": {
+        "description": "Body for partially updating an environment. Omitted properties retain their stored value.",
+        "required": true,
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "description": "Partial update for an environment. Every property is optional; an omitted property retains its stored value. organizationId is accepted for symmetry with the create payload but is not actually mutable - see its own description - so omitting it is the normal case.",
+              "properties": {
+                "name": {
+                  "description": "An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation.",
+                  "type": "string",
+                  "x-go-type-skip-optional-pointer": true
+                },
+                "description": {
+                  "description": "An environment is a collection of resources, such as connections & credentials. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments).",
+                  "type": "string",
+                  "x-go-type-skip-optional-pointer": true
+                },
+                "organizationId": {
+                  "type": "string",
+                  "description": "The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.",
+                  "x-go-type-skip-optional-pointer": true,
+                  "x-go-name": "OrgID",
+                  "x-oapi-codegen-extra-tags": {
+                    "json": "organizationId"
+                  },
+                  "maxLength": 500,
+                  "format": "uuid"
+                }
+              }
+            }
+          }
+        }
       }
     }
   },
@@ -909,7 +971,7 @@ const EnvironmentSchema: Record<string, unknown> = {
         "summary": "Create an environment",
         "description": "Creates a new environment",
         "requestBody": {
-          "description": "Body for creating environment",
+          "description": "Body for creating an environment",
           "required": true,
           "content": {
             "application/json": {
@@ -1838,17 +1900,13 @@ const EnvironmentSchema: Record<string, unknown> = {
           }
         ],
         "requestBody": {
-          "description": "Body for creating environment",
+          "description": "Body for partially updating an environment. Omitted properties retain their stored value.",
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "description": "Payload for creating or updating an environment. Carries only the client-settable fields. Server-owned fields are deliberately absent: `id`, `owner`, `createdAt`, `updatedAt` and `deletedAt` because the server assigns them, and `purpose` because permission to create an environment must not confer the ability to designate it administrative. Excluding it here is a codegen guarantee rather than access control: the registrant connection inlines the full environment entity, so `purpose` still reaches the `registerRegistryComponent` and `registerRegistryRelationship` request types, and every consumer must refuse it on input whatever surface it arrives on. Do not add `purpose` here - see https://github.com/meshery/schemas/blob/master/docs/environment-purpose-contract.md.",
-                "required": [
-                  "name",
-                  "organizationId"
-                ],
+                "description": "Partial update for an environment. Every property is optional; an omitted property retains its stored value. organizationId is accepted for symmetry with the create payload but is not actually mutable - see its own description - so omitting it is the normal case.",
                 "properties": {
                   "name": {
                     "description": "An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation.",
@@ -1862,7 +1920,7 @@ const EnvironmentSchema: Record<string, unknown> = {
                   },
                   "organizationId": {
                     "type": "string",
-                    "description": "Select an organization in which you want to create this new environment. Keep in mind that the organization cannot be changed after creation.",
+                    "description": "The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.",
                     "x-go-type-skip-optional-pointer": true,
                     "x-go-name": "OrgID",
                     "x-oapi-codegen-extra-tags": {

--- a/typescript/generated/v1beta3/environment/EnvironmentSchema.ts
+++ b/typescript/generated/v1beta3/environment/EnvironmentSchema.ts
@@ -487,10 +487,9 @@ const EnvironmentSchema: Record<string, unknown> = {
           "organizationId": {
             "type": "string",
             "description": "The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.",
-            "x-go-type-skip-optional-pointer": true,
             "x-go-name": "OrgID",
             "x-oapi-codegen-extra-tags": {
-              "json": "organizationId"
+              "json": "organizationId,omitempty"
             },
             "maxLength": 500,
             "format": "uuid"
@@ -942,10 +941,9 @@ const EnvironmentSchema: Record<string, unknown> = {
                 "organizationId": {
                   "type": "string",
                   "description": "The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.",
-                  "x-go-type-skip-optional-pointer": true,
                   "x-go-name": "OrgID",
                   "x-oapi-codegen-extra-tags": {
-                    "json": "organizationId"
+                    "json": "organizationId,omitempty"
                   },
                   "maxLength": 500,
                   "format": "uuid"
@@ -1921,10 +1919,9 @@ const EnvironmentSchema: Record<string, unknown> = {
                   "organizationId": {
                     "type": "string",
                     "description": "The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update.",
-                    "x-go-type-skip-optional-pointer": true,
                     "x-go-name": "OrgID",
                     "x-oapi-codegen-extra-tags": {
-                      "json": "organizationId"
+                      "json": "organizationId,omitempty"
                     },
                     "maxLength": 500,
                     "format": "uuid"

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -12248,7 +12248,7 @@ export type CreateEnvironmentApiResponse = /** status 201 Created environment */
   purpose?: "user" | "administrative";
 };
 export type CreateEnvironmentApiArg = {
-  /** Body for creating environment */
+  /** Body for creating an environment */
   body: {
     /** An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation. */
     name: string;
@@ -12404,14 +12404,14 @@ export type UpdateEnvironmentApiResponse = /** status 200 Environment page */ {
 export type UpdateEnvironmentApiArg = {
   /** Environment ID */
   environmentId: string;
-  /** Body for creating environment */
+  /** Body for partially updating an environment. Omitted properties retain their stored value. */
   body: {
     /** An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation. */
-    name: string;
+    name?: string;
     /** An environment is a collection of resources, such as connections & credentials. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments). */
     description?: string;
-    /** Select an organization in which you want to create this new environment. Keep in mind that the organization cannot be changed after creation. */
-    organizationId: string;
+    /** The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update. */
+    organizationId?: string;
   };
 };
 export type DeleteEnvironmentApiResponse = unknown;

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -15705,7 +15705,7 @@ export type CreateEnvironmentApiResponse = /** status 201 Created environment */
   purpose?: "user" | "administrative";
 };
 export type CreateEnvironmentApiArg = {
-  /** Body for creating environment */
+  /** Body for creating an environment */
   body: {
     /** An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation. */
     name: string;
@@ -15861,14 +15861,14 @@ export type UpdateEnvironmentApiResponse = /** status 200 Environment page */ {
 export type UpdateEnvironmentApiArg = {
   /** Environment ID */
   environmentId: string;
-  /** Body for creating environment */
+  /** Body for partially updating an environment. Omitted properties retain their stored value. */
   body: {
     /** An environment is a collection of resources. Provide a name that meaningfully represents these resources. You can change the name of the environment even after its creation. */
-    name: string;
+    name?: string;
     /** An environment is a collection of resources, such as connections & credentials. Provide a detailed description to clarify the purpose of this environment and the types of resources it encompasses. You can modify the description at any time. Learn more about environments [here](https://docs.meshery.io/concepts/logical/environments). */
     description?: string;
-    /** Select an organization in which you want to create this new environment. Keep in mind that the organization cannot be changed after creation. */
-    organizationId: string;
+    /** The organization cannot be changed after creation. Accepted here only so a client that already has this value does not have to strip it before sending a partial update. */
+    organizationId?: string;
   };
 };
 export type DeleteEnvironmentApiResponse = unknown;


### PR DESCRIPTION
This is the sibling defect #1147 itself flagged as an obvious next place to check: "updateWorkspace, updateEnvironment and updateOrg are the obvious candidates" for the same "PUT reuses a create-shaped required-something payload" pattern.

Checked all three against current master before writing anything:
- `updateWorkspace` already has its own `WorkspaceUpdatePayload` (only `organizationId` required there, not `name`). Not affected.
- `updateOrg`'s `OrganizationPayload` has no `required` list at all. Not affected.
- `updateEnvironment` (both v1beta1 and v1beta3) reuses the create-shaped `EnvironmentPayload`, which requires both `name` and `organizationId`/`organization_id` on every request. **Affected.**

`organizationId`'s own description states it "cannot be changed after creation," so requiring it on update forces a client to resend an immutable value just to change anything else. There was also no schema-valid way to send a description-only update without resending `name` too — a write that can silently revert a concurrent rename, the same risk class already fixed for `updateView` in #1147.

## What I changed

Added `EnvironmentUpdatePayload` (every property optional, `organizationId` accepted but not required) in both `v1beta1` and `v1beta3`, and pointed `updateEnvironment`'s requestBody at it instead of the create payload. Kept `organizationId` in the update payload for now, since I can't verify from this repo alone whether the private handler does anything with it on update — whether it should be dropped entirely given it's immutable is a separate design question I'm leaving to maintainers rather than deciding unilaterally.

Regenerated the Go models, TypeScript types, and RTK client so nothing is left stale.

## Test plan
- [x] `make generate-golang`, `make generate-ts`, `make generate-rtk` — confirmed `EnvironmentUpdatePayload.Name` generates as optional vs. `EnvironmentPayload.Name` required
- [x] `make validate-schemas` — no blocking violations
- [x] Existing gofmt/RTK regression suites pass

Unlike #1147, I don't have a confirmed live incident for this one (no equivalent to the Kanvas Share-modal bug that motivated #1147) — flagging that distinction honestly since it's asked for in review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Environment updates now support partial changes, allowing users to modify only the name and/or description.
  * Organization identifiers are accepted during updates but remain unchanged after environment creation.
  * Updated API definitions and client types consistently support the new partial-update behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->