### PR TITLE
[Design] Introduce CatalogAuthor projection to resolve User.email contract drift

### DIFF
--- a/models/v1beta3/design/design.go
+++ b/models/v1beta3/design/design.go
@@ -89,6 +89,24 @@ type DesignPreferences struct {
 	Layers map[string]interface{} `json:"layers" yaml:"layers"`
 }
 
+// CatalogAuthor Public projection of a user as served on unauthenticated catalog endpoints (e.g. GET /api/catalog/content/{type}). Carries only the fields the Cloud privacy ruling permits an anonymous caller to see: identity, display names, and avatar URL. Email and every other personally-identifying or account-internal field are deliberately absent (meshery/schemas#1106). For the full authenticated user record see User in v1beta2/user/api.yml.
+type CatalogAuthor struct {
+	// AvatarUrl URL to the user's avatar image.
+	AvatarUrl string `db:"avatar_url" json:"avatarUrl,omitempty" yaml:"avatarUrl,omitempty"`
+
+	// FirstName User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling.
+	FirstName string `db:"first_name" json:"firstName,omitempty" yaml:"firstName,omitempty"`
+
+	// Id A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	ID core.Uuid `db:"id" json:"id" yaml:"id"`
+
+	// LastName User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling.
+	LastName string `db:"last_name" json:"lastName,omitempty" yaml:"lastName,omitempty"`
+
+	// UserId A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
+	UserID *core.Uuid `db:"user_id" json:"userId,omitempty" yaml:"userId,omitempty"`
+}
+
 // CatalogContentClass defines model for CatalogContentClass.
 type CatalogContentClass struct {
 	// Class The class of the catalogcontentclass.
@@ -265,9 +283,9 @@ type MesheryPattern struct {
 	SourceContent *[]byte   `db:"source_content" json:"sourceContent,omitempty" yaml:"sourceContent,omitempty"`
 	UpdatedAt     core.Time `db:"updated_at" json:"updatedAt,omitempty" yaml:"updatedAt,omitempty"`
 
-	// User Represents a user
-	User   *userV1beta.User `db:"-" json:"user,omitempty" yaml:"user,omitempty"`
-	UserId core.Id          `db:"owner" json:"userId,omitempty" yaml:"userId,omitempty"`
+	// User Public projection of a user as served on unauthenticated catalog endpoints (e.g. GET /api/catalog/content/{type}). Carries only the fields the Cloud privacy ruling permits an anonymous caller to see: identity, display names, and avatar URL. Email and every other personally-identifying or account-internal field are deliberately absent (meshery/schemas#1106). For the full authenticated user record see User in v1beta2/user/api.yml.
+	User   *CatalogAuthor `db:"-" json:"user,omitempty" yaml:"user,omitempty"`
+	UserId core.Id        `db:"owner" json:"userId,omitempty" yaml:"userId,omitempty"`
 
 	// ViewCount Server-aggregated count of views on this design in the catalog. Present on list/catalog responses; server-managed and ignored on writes.
 	ViewCount *int `db:"view_count" json:"viewCount,omitempty" yaml:"viewCount,omitempty"`

--- a/schemas/constructs/v1beta3/design/api.yml
+++ b/schemas/constructs/v1beta3/design/api.yml
@@ -694,6 +694,67 @@ components:
         format: uuid
 
   schemas:
+    CatalogAuthor:
+      type: object
+      additionalProperties: false
+      description: >-
+        Public projection of a user as served on unauthenticated catalog
+        endpoints (e.g. GET /api/catalog/content/{type}). Carries only the
+        fields the Cloud privacy ruling permits an anonymous caller to see:
+        identity, display names, and avatar URL. Email and every other
+        personally-identifying or account-internal field are deliberately
+        absent (meshery/schemas#1106). For the full authenticated user record
+        see User in v1beta2/user/api.yml.
+      required:
+        - id
+      properties:
+        id:
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/Uuid"
+          description: Unique identifier for the user.
+          x-go-name: ID
+          x-oapi-codegen-extra-tags:
+            db: "id"
+            json: "id"
+        userId:
+          $ref: "../../v1beta2/core/api.yml#/components/schemas/Uuid"
+          deprecated: true
+          description: >-
+            Deprecated duplicate of id kept for consumers that predate the
+            retirement of the legacy user_id column; always equals id.
+          x-go-name: UserID
+          x-oapi-codegen-extra-tags:
+            db: "user_id"
+            json: "userId,omitempty"
+        firstName:
+          type: string
+          maxLength: 200
+          description: >-
+            User's first name. Real names are permitted on public catalog
+            responses under the Cloud privacy ruling.
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            db: "first_name"
+            json: "firstName,omitempty"
+        lastName:
+          type: string
+          maxLength: 300
+          description: >-
+            User's last name. Real names are permitted on public catalog
+            responses under the Cloud privacy ruling.
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            db: "last_name"
+            json: "lastName,omitempty"
+        avatarUrl:
+          type: string
+          format: uri
+          maxLength: 500
+          description: URL to the user's avatar image.
+          x-go-type-skip-optional-pointer: true
+          x-oapi-codegen-extra-tags:
+            db: "avatar_url"
+            json: "avatarUrl,omitempty"
+
     DeletePatternModel:
       type: object
       description: Reference to a design for bulk deletion by ID.
@@ -731,18 +792,18 @@ components:
           x-oapi-codegen-extra-tags:
             db: owner
         user:
-          $ref: "../../v1beta2/user/api.yml#/components/schemas/User"
+          $ref: "#/components/schemas/CatalogAuthor"
           description: >
-            Owning user record, joined inline by the catalog list/get
-            handlers when shaping responses. Server-projected from the
-            users table via the design's userId; not a column on the
+            Public projection of the owning user joined inline by the catalog
+            list/get handlers when shaping responses. Uses CatalogAuthor
+            instead of the full User schema because catalog endpoints are
+            served to unauthenticated callers and may not expose email
+            addresses (meshery/schemas#1106). Server-projected from the users
+            table via the design's userId; not a column on the
             meshery_patterns table itself, so the generated Go field is
             tagged `db:"-"` to keep it out of ORM column scans.
           nullable: true
-          x-go-type: "*userV1beta.User"
-          x-go-type-import:
-            path: github.com/meshery/schemas/models/v1beta2/user
-            name: userV1beta
+          x-go-type: "*CatalogAuthor"
           x-oapi-codegen-extra-tags:
             db: "-"
         location:

--- a/typescript/generated/v1beta3/design/Design.ts
+++ b/typescript/generated/v1beta3/design/Design.ts
@@ -317,6 +317,29 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        /** @description Public projection of a user as served on unauthenticated catalog endpoints (e.g. GET /api/catalog/content/{type}). Carries only the fields the Cloud privacy ruling permits an anonymous caller to see: identity, display names, and avatar URL. Email and every other personally-identifying or account-internal field are deliberately absent (meshery/schemas#1106). For the full authenticated user record see User in v1beta2/user/api.yml. */
+        CatalogAuthor: {
+            /**
+             * Format: uuid
+             * @description Unique identifier for the user.
+             */
+            id: string;
+            /**
+             * Format: uuid
+             * @deprecated
+             * @description Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.
+             */
+            userId?: string;
+            /** @description User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+            firstName?: string;
+            /** @description User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+            lastName?: string;
+            /**
+             * Format: uri
+             * @description URL to the user's avatar image.
+             */
+            avatarUrl?: string;
+        };
         /** @description Reference to a design for bulk deletion by ID. */
         DeletePatternModel: {
             /**
@@ -1796,267 +1819,28 @@ export interface components {
              * @description Owning user ID.
              */
             userId?: string;
-            /** @description Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
+            /** @description Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
             user?: {
                 /**
                  * Format: uuid
-                 * @description Unique identifier for the user
+                 * @description Unique identifier for the user.
                  */
                 id: string;
                 /**
+                 * Format: uuid
                  * @deprecated
-                 * @description Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.
+                 * @description Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.
                  */
-                userId: string;
-                /**
-                 * @description Authentication provider (e.g., Google, Github)
-                 * @example [
-                 *       "local",
-                 *       "github",
-                 *       "google",
-                 *       "twitter"
-                 *     ]
-                 */
-                provider: string;
-                /**
-                 * Format: email
-                 * @description User's email address
-                 */
-                email: string;
-                /** @description User's first name */
-                firstName: string;
-                /** @description User's last name */
-                lastName: string;
+                userId?: string;
+                /** @description User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                firstName?: string;
+                /** @description User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                lastName?: string;
                 /**
                  * Format: uri
-                 * @description URL to user's avatar image
+                 * @description URL to the user's avatar image.
                  */
                 avatarUrl?: string;
-                /**
-                 * @description User account status
-                 * @enum {string}
-                 */
-                status: "active" | "inactive" | "pending" | "anonymous";
-                /**
-                 * @description User's biography or description
-                 * @default
-                 */
-                bio: string;
-                /** @description User's country information stored as JSONB */
-                country?: {
-                    [key: string]: unknown;
-                };
-                /** @description User's region information stored as JSONB */
-                region?: {
-                    [key: string]: unknown;
-                };
-                /** @description User preferences stored as JSONB */
-                preferences?: {
-                    /** @description The mesh adapters of the preference. */
-                    meshAdapters?: Record<string, never>[];
-                    grafana?: {
-                        /** @description Grafana URL for the user configuration. */
-                        grafanaUrl?: string;
-                        /** @description Grafana API key for the user configuration. */
-                        grafanaApiKey?: string;
-                        /** @description Selected Grafana board configurations for the user. */
-                        selectedBoardsConfigs?: {
-                            /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                            board?: Record<string, never>;
-                            /** @description Panels selected for the Grafana board configuration. */
-                            panels?: Record<string, never>[];
-                            /** @description Template variables applied to the selected Grafana board configuration. */
-                            templateVars?: string[];
-                        }[];
-                    };
-                    prometheus?: {
-                        /** @description The prometheus URL of the prometheus. */
-                        prometheusUrl?: string;
-                        /** @description The selected prometheus boards configs of the prometheus. */
-                        selectedPrometheusBoardsConfigs?: {
-                            /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                            board?: Record<string, never>;
-                            /** @description Panels selected for the Grafana board configuration. */
-                            panels?: Record<string, never>[];
-                            /** @description Template variables applied to the selected Grafana board configuration. */
-                            templateVars?: string[];
-                        }[];
-                    };
-                    loadTestPrefs?: {
-                        /** @description Concurrent requests */
-                        c?: number;
-                        /** @description Queries per second */
-                        qps?: number;
-                        /** @description Duration */
-                        t?: string;
-                        /** @description Load generator */
-                        gen?: string;
-                    };
-                    /** @description The anonymous usage stats of the preference. */
-                    anonymousUsageStats: boolean;
-                    /** @description The anonymous perf results of the preference. */
-                    anonymousPerfResults: boolean;
-                    /**
-                     * Format: date-time
-                     * @description Timestamp of when the resource was last updated.
-                     */
-                    updatedAt: string;
-                    /** @description The dashboard preferences of the preference. */
-                    dashboardPreferences: {
-                        [key: string]: unknown;
-                    };
-                    /**
-                     * Format: uuid
-                     * @description ID of the associated selectedOrganization.
-                     */
-                    selectedOrganizationId: string;
-                    /** @description The selected workspace for organizations of the preference. */
-                    selectedWorkspaceForOrganizations: {
-                        [key: string]: string;
-                    };
-                    /** @description The users extension preferences of the preference. */
-                    usersExtensionPreferences: {
-                        [key: string]: unknown;
-                    };
-                    /** @description The remote provider preferences of the preference. */
-                    remoteProviderPreferences: {
-                        [key: string]: unknown;
-                    };
-                };
-                /**
-                 * Format: date-time
-                 * @description Timestamp when user accepted terms and conditions
-                 */
-                acceptedTermsAt?: string;
-                /**
-                 * Format: date-time
-                 * @description Timestamp of user's first login
-                 */
-                firstLoginTime?: string;
-                /**
-                 * Format: date-time
-                 * @description Timestamp of user's most recent login
-                 */
-                lastLoginTime: string;
-                /**
-                 * Format: date-time
-                 * @description Timestamp when the user record was created
-                 */
-                createdAt: string;
-                /**
-                 * Format: date-time
-                 * @description Timestamp when the user record was last updated
-                 */
-                updatedAt: string;
-                /** @description Various online profiles associated with the user account */
-                socials?: {
-                    /** @description The site of the social. */
-                    site: string;
-                    /**
-                     * Format: uri
-                     * @description The link of the social.
-                     */
-                    link: string;
-                }[];
-                /**
-                 * Format: date-time
-                 * @description Timestamp when the user record was soft-deleted (null if not deleted)
-                 */
-                deletedAt: string | null;
-                /**
-                 * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
-                 * @example [
-                 *       "organization admin",
-                 *       "user"
-                 *     ]
-                 */
-                roleNames?: string[];
-                /** @description Teams the user belongs to with role information */
-                teams?: {
-                    /** @description Team memberships for the user with their assigned roles. */
-                    teamsWithRoles?: {
-                        /**
-                         * Format: uuid
-                         * @description Unique identifier of the team.
-                         */
-                        id: string;
-                        /** @description Name of the team. */
-                        name: string;
-                        /** @description Human readable description of the team. */
-                        description?: string;
-                        /**
-                         * Format: uuid
-                         * @description Identifier of the team owner.
-                         */
-                        owner?: string;
-                        /** @description Free-form metadata associated with the team. */
-                        metadata?: {
-                            [key: string]: unknown;
-                        };
-                        /**
-                         * Format: date-time
-                         * @description Timestamp when the team was created.
-                         */
-                        createdAt?: string;
-                        /**
-                         * Format: date-time
-                         * @description Timestamp when the team was last updated.
-                         */
-                        updatedAt?: string;
-                        /**
-                         * Format: date-time
-                         * @description Timestamp when the team was soft-deleted (null if not deleted).
-                         */
-                        deletedAt?: string | null;
-                        /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-                        roleNames: string[];
-                    }[];
-                    /** @description Total number of team memberships returned for the user. */
-                    totalCount?: number;
-                };
-                /** @description Organizations the user belongs to with role information */
-                organizations?: {
-                    /** @description Organization memberships for the user with their assigned roles. */
-                    organizationsWithRoles?: {
-                        /**
-                         * Format: uuid
-                         * @description Unique identifier of the organization.
-                         */
-                        id: string;
-                        /** @description Name of the organization. */
-                        name: string;
-                        /** @description Human readable description of the organization. */
-                        description?: string;
-                        /** @description Country associated with the organization. */
-                        country?: string;
-                        /** @description Region associated with the organization. */
-                        region?: string;
-                        /**
-                         * Format: uuid
-                         * @description Identifier of the organization owner.
-                         */
-                        owner?: string;
-                        /**
-                         * Format: date-time
-                         * @description Timestamp when the organization was created.
-                         */
-                        createdAt?: string;
-                        /**
-                         * Format: date-time
-                         * @description Timestamp when the organization was last updated.
-                         */
-                        updatedAt?: string;
-                        /**
-                         * Format: date-time
-                         * @description Timestamp when the organization was soft-deleted (null if not deleted).
-                         */
-                        deletedAt?: string | null;
-                        /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-                        roleNames: string[];
-                    }[];
-                    /** @description Total number of organization memberships returned for the user. */
-                    totalCount?: number;
-                };
             } | null;
             /** @description Optional structured location metadata (branch, host, path, ...). */
             location?: {
@@ -2168,267 +1952,28 @@ export interface components {
                  * @description Owning user ID.
                  */
                 userId?: string;
-                /** @description Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
+                /** @description Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
                 user?: {
                     /**
                      * Format: uuid
-                     * @description Unique identifier for the user
+                     * @description Unique identifier for the user.
                      */
                     id: string;
                     /**
+                     * Format: uuid
                      * @deprecated
-                     * @description Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.
+                     * @description Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.
                      */
-                    userId: string;
-                    /**
-                     * @description Authentication provider (e.g., Google, Github)
-                     * @example [
-                     *       "local",
-                     *       "github",
-                     *       "google",
-                     *       "twitter"
-                     *     ]
-                     */
-                    provider: string;
-                    /**
-                     * Format: email
-                     * @description User's email address
-                     */
-                    email: string;
-                    /** @description User's first name */
-                    firstName: string;
-                    /** @description User's last name */
-                    lastName: string;
+                    userId?: string;
+                    /** @description User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                    firstName?: string;
+                    /** @description User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                    lastName?: string;
                     /**
                      * Format: uri
-                     * @description URL to user's avatar image
+                     * @description URL to the user's avatar image.
                      */
                     avatarUrl?: string;
-                    /**
-                     * @description User account status
-                     * @enum {string}
-                     */
-                    status: "active" | "inactive" | "pending" | "anonymous";
-                    /**
-                     * @description User's biography or description
-                     * @default
-                     */
-                    bio: string;
-                    /** @description User's country information stored as JSONB */
-                    country?: {
-                        [key: string]: unknown;
-                    };
-                    /** @description User's region information stored as JSONB */
-                    region?: {
-                        [key: string]: unknown;
-                    };
-                    /** @description User preferences stored as JSONB */
-                    preferences?: {
-                        /** @description The mesh adapters of the preference. */
-                        meshAdapters?: Record<string, never>[];
-                        grafana?: {
-                            /** @description Grafana URL for the user configuration. */
-                            grafanaUrl?: string;
-                            /** @description Grafana API key for the user configuration. */
-                            grafanaApiKey?: string;
-                            /** @description Selected Grafana board configurations for the user. */
-                            selectedBoardsConfigs?: {
-                                /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                board?: Record<string, never>;
-                                /** @description Panels selected for the Grafana board configuration. */
-                                panels?: Record<string, never>[];
-                                /** @description Template variables applied to the selected Grafana board configuration. */
-                                templateVars?: string[];
-                            }[];
-                        };
-                        prometheus?: {
-                            /** @description The prometheus URL of the prometheus. */
-                            prometheusUrl?: string;
-                            /** @description The selected prometheus boards configs of the prometheus. */
-                            selectedPrometheusBoardsConfigs?: {
-                                /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                board?: Record<string, never>;
-                                /** @description Panels selected for the Grafana board configuration. */
-                                panels?: Record<string, never>[];
-                                /** @description Template variables applied to the selected Grafana board configuration. */
-                                templateVars?: string[];
-                            }[];
-                        };
-                        loadTestPrefs?: {
-                            /** @description Concurrent requests */
-                            c?: number;
-                            /** @description Queries per second */
-                            qps?: number;
-                            /** @description Duration */
-                            t?: string;
-                            /** @description Load generator */
-                            gen?: string;
-                        };
-                        /** @description The anonymous usage stats of the preference. */
-                        anonymousUsageStats: boolean;
-                        /** @description The anonymous perf results of the preference. */
-                        anonymousPerfResults: boolean;
-                        /**
-                         * Format: date-time
-                         * @description Timestamp of when the resource was last updated.
-                         */
-                        updatedAt: string;
-                        /** @description The dashboard preferences of the preference. */
-                        dashboardPreferences: {
-                            [key: string]: unknown;
-                        };
-                        /**
-                         * Format: uuid
-                         * @description ID of the associated selectedOrganization.
-                         */
-                        selectedOrganizationId: string;
-                        /** @description The selected workspace for organizations of the preference. */
-                        selectedWorkspaceForOrganizations: {
-                            [key: string]: string;
-                        };
-                        /** @description The users extension preferences of the preference. */
-                        usersExtensionPreferences: {
-                            [key: string]: unknown;
-                        };
-                        /** @description The remote provider preferences of the preference. */
-                        remoteProviderPreferences: {
-                            [key: string]: unknown;
-                        };
-                    };
-                    /**
-                     * Format: date-time
-                     * @description Timestamp when user accepted terms and conditions
-                     */
-                    acceptedTermsAt?: string;
-                    /**
-                     * Format: date-time
-                     * @description Timestamp of user's first login
-                     */
-                    firstLoginTime?: string;
-                    /**
-                     * Format: date-time
-                     * @description Timestamp of user's most recent login
-                     */
-                    lastLoginTime: string;
-                    /**
-                     * Format: date-time
-                     * @description Timestamp when the user record was created
-                     */
-                    createdAt: string;
-                    /**
-                     * Format: date-time
-                     * @description Timestamp when the user record was last updated
-                     */
-                    updatedAt: string;
-                    /** @description Various online profiles associated with the user account */
-                    socials?: {
-                        /** @description The site of the social. */
-                        site: string;
-                        /**
-                         * Format: uri
-                         * @description The link of the social.
-                         */
-                        link: string;
-                    }[];
-                    /**
-                     * Format: date-time
-                     * @description Timestamp when the user record was soft-deleted (null if not deleted)
-                     */
-                    deletedAt: string | null;
-                    /**
-                     * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
-                     * @example [
-                     *       "organization admin",
-                     *       "user"
-                     *     ]
-                     */
-                    roleNames?: string[];
-                    /** @description Teams the user belongs to with role information */
-                    teams?: {
-                        /** @description Team memberships for the user with their assigned roles. */
-                        teamsWithRoles?: {
-                            /**
-                             * Format: uuid
-                             * @description Unique identifier of the team.
-                             */
-                            id: string;
-                            /** @description Name of the team. */
-                            name: string;
-                            /** @description Human readable description of the team. */
-                            description?: string;
-                            /**
-                             * Format: uuid
-                             * @description Identifier of the team owner.
-                             */
-                            owner?: string;
-                            /** @description Free-form metadata associated with the team. */
-                            metadata?: {
-                                [key: string]: unknown;
-                            };
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the team was created.
-                             */
-                            createdAt?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the team was last updated.
-                             */
-                            updatedAt?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the team was soft-deleted (null if not deleted).
-                             */
-                            deletedAt?: string | null;
-                            /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-                            roleNames: string[];
-                        }[];
-                        /** @description Total number of team memberships returned for the user. */
-                        totalCount?: number;
-                    };
-                    /** @description Organizations the user belongs to with role information */
-                    organizations?: {
-                        /** @description Organization memberships for the user with their assigned roles. */
-                        organizationsWithRoles?: {
-                            /**
-                             * Format: uuid
-                             * @description Unique identifier of the organization.
-                             */
-                            id: string;
-                            /** @description Name of the organization. */
-                            name: string;
-                            /** @description Human readable description of the organization. */
-                            description?: string;
-                            /** @description Country associated with the organization. */
-                            country?: string;
-                            /** @description Region associated with the organization. */
-                            region?: string;
-                            /**
-                             * Format: uuid
-                             * @description Identifier of the organization owner.
-                             */
-                            owner?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the organization was created.
-                             */
-                            createdAt?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the organization was last updated.
-                             */
-                            updatedAt?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the organization was soft-deleted (null if not deleted).
-                             */
-                            deletedAt?: string | null;
-                            /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-                            roleNames: string[];
-                        }[];
-                        /** @description Total number of organization memberships returned for the user. */
-                        totalCount?: number;
-                    };
                 } | null;
                 /** @description Optional structured location metadata (branch, host, path, ...). */
                 location?: {
@@ -2786,267 +2331,28 @@ export interface components {
                  * @description Owning user ID.
                  */
                 userId?: string;
-                /** @description Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
+                /** @description Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
                 user?: {
                     /**
                      * Format: uuid
-                     * @description Unique identifier for the user
+                     * @description Unique identifier for the user.
                      */
                     id: string;
                     /**
+                     * Format: uuid
                      * @deprecated
-                     * @description Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.
+                     * @description Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.
                      */
-                    userId: string;
-                    /**
-                     * @description Authentication provider (e.g., Google, Github)
-                     * @example [
-                     *       "local",
-                     *       "github",
-                     *       "google",
-                     *       "twitter"
-                     *     ]
-                     */
-                    provider: string;
-                    /**
-                     * Format: email
-                     * @description User's email address
-                     */
-                    email: string;
-                    /** @description User's first name */
-                    firstName: string;
-                    /** @description User's last name */
-                    lastName: string;
+                    userId?: string;
+                    /** @description User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                    firstName?: string;
+                    /** @description User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                    lastName?: string;
                     /**
                      * Format: uri
-                     * @description URL to user's avatar image
+                     * @description URL to the user's avatar image.
                      */
                     avatarUrl?: string;
-                    /**
-                     * @description User account status
-                     * @enum {string}
-                     */
-                    status: "active" | "inactive" | "pending" | "anonymous";
-                    /**
-                     * @description User's biography or description
-                     * @default
-                     */
-                    bio: string;
-                    /** @description User's country information stored as JSONB */
-                    country?: {
-                        [key: string]: unknown;
-                    };
-                    /** @description User's region information stored as JSONB */
-                    region?: {
-                        [key: string]: unknown;
-                    };
-                    /** @description User preferences stored as JSONB */
-                    preferences?: {
-                        /** @description The mesh adapters of the preference. */
-                        meshAdapters?: Record<string, never>[];
-                        grafana?: {
-                            /** @description Grafana URL for the user configuration. */
-                            grafanaUrl?: string;
-                            /** @description Grafana API key for the user configuration. */
-                            grafanaApiKey?: string;
-                            /** @description Selected Grafana board configurations for the user. */
-                            selectedBoardsConfigs?: {
-                                /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                board?: Record<string, never>;
-                                /** @description Panels selected for the Grafana board configuration. */
-                                panels?: Record<string, never>[];
-                                /** @description Template variables applied to the selected Grafana board configuration. */
-                                templateVars?: string[];
-                            }[];
-                        };
-                        prometheus?: {
-                            /** @description The prometheus URL of the prometheus. */
-                            prometheusUrl?: string;
-                            /** @description The selected prometheus boards configs of the prometheus. */
-                            selectedPrometheusBoardsConfigs?: {
-                                /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                board?: Record<string, never>;
-                                /** @description Panels selected for the Grafana board configuration. */
-                                panels?: Record<string, never>[];
-                                /** @description Template variables applied to the selected Grafana board configuration. */
-                                templateVars?: string[];
-                            }[];
-                        };
-                        loadTestPrefs?: {
-                            /** @description Concurrent requests */
-                            c?: number;
-                            /** @description Queries per second */
-                            qps?: number;
-                            /** @description Duration */
-                            t?: string;
-                            /** @description Load generator */
-                            gen?: string;
-                        };
-                        /** @description The anonymous usage stats of the preference. */
-                        anonymousUsageStats: boolean;
-                        /** @description The anonymous perf results of the preference. */
-                        anonymousPerfResults: boolean;
-                        /**
-                         * Format: date-time
-                         * @description Timestamp of when the resource was last updated.
-                         */
-                        updatedAt: string;
-                        /** @description The dashboard preferences of the preference. */
-                        dashboardPreferences: {
-                            [key: string]: unknown;
-                        };
-                        /**
-                         * Format: uuid
-                         * @description ID of the associated selectedOrganization.
-                         */
-                        selectedOrganizationId: string;
-                        /** @description The selected workspace for organizations of the preference. */
-                        selectedWorkspaceForOrganizations: {
-                            [key: string]: string;
-                        };
-                        /** @description The users extension preferences of the preference. */
-                        usersExtensionPreferences: {
-                            [key: string]: unknown;
-                        };
-                        /** @description The remote provider preferences of the preference. */
-                        remoteProviderPreferences: {
-                            [key: string]: unknown;
-                        };
-                    };
-                    /**
-                     * Format: date-time
-                     * @description Timestamp when user accepted terms and conditions
-                     */
-                    acceptedTermsAt?: string;
-                    /**
-                     * Format: date-time
-                     * @description Timestamp of user's first login
-                     */
-                    firstLoginTime?: string;
-                    /**
-                     * Format: date-time
-                     * @description Timestamp of user's most recent login
-                     */
-                    lastLoginTime: string;
-                    /**
-                     * Format: date-time
-                     * @description Timestamp when the user record was created
-                     */
-                    createdAt: string;
-                    /**
-                     * Format: date-time
-                     * @description Timestamp when the user record was last updated
-                     */
-                    updatedAt: string;
-                    /** @description Various online profiles associated with the user account */
-                    socials?: {
-                        /** @description The site of the social. */
-                        site: string;
-                        /**
-                         * Format: uri
-                         * @description The link of the social.
-                         */
-                        link: string;
-                    }[];
-                    /**
-                     * Format: date-time
-                     * @description Timestamp when the user record was soft-deleted (null if not deleted)
-                     */
-                    deletedAt: string | null;
-                    /**
-                     * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
-                     * @example [
-                     *       "organization admin",
-                     *       "user"
-                     *     ]
-                     */
-                    roleNames?: string[];
-                    /** @description Teams the user belongs to with role information */
-                    teams?: {
-                        /** @description Team memberships for the user with their assigned roles. */
-                        teamsWithRoles?: {
-                            /**
-                             * Format: uuid
-                             * @description Unique identifier of the team.
-                             */
-                            id: string;
-                            /** @description Name of the team. */
-                            name: string;
-                            /** @description Human readable description of the team. */
-                            description?: string;
-                            /**
-                             * Format: uuid
-                             * @description Identifier of the team owner.
-                             */
-                            owner?: string;
-                            /** @description Free-form metadata associated with the team. */
-                            metadata?: {
-                                [key: string]: unknown;
-                            };
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the team was created.
-                             */
-                            createdAt?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the team was last updated.
-                             */
-                            updatedAt?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the team was soft-deleted (null if not deleted).
-                             */
-                            deletedAt?: string | null;
-                            /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-                            roleNames: string[];
-                        }[];
-                        /** @description Total number of team memberships returned for the user. */
-                        totalCount?: number;
-                    };
-                    /** @description Organizations the user belongs to with role information */
-                    organizations?: {
-                        /** @description Organization memberships for the user with their assigned roles. */
-                        organizationsWithRoles?: {
-                            /**
-                             * Format: uuid
-                             * @description Unique identifier of the organization.
-                             */
-                            id: string;
-                            /** @description Name of the organization. */
-                            name: string;
-                            /** @description Human readable description of the organization. */
-                            description?: string;
-                            /** @description Country associated with the organization. */
-                            country?: string;
-                            /** @description Region associated with the organization. */
-                            region?: string;
-                            /**
-                             * Format: uuid
-                             * @description Identifier of the organization owner.
-                             */
-                            owner?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the organization was created.
-                             */
-                            createdAt?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the organization was last updated.
-                             */
-                            updatedAt?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the organization was soft-deleted (null if not deleted).
-                             */
-                            deletedAt?: string | null;
-                            /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-                            roleNames: string[];
-                        }[];
-                        /** @description Total number of organization memberships returned for the user. */
-                        totalCount?: number;
-                    };
                 } | null;
                 /** @description Optional structured location metadata (branch, host, path, ...). */
                 location?: {
@@ -3251,7 +2557,7 @@ export interface components {
             user?: {
                 /**
                  * Format: uuid
-                 * @description Unique identifier for the user
+                 * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                  */
                 id: string;
                 /**
@@ -3428,7 +2734,7 @@ export interface components {
                     teamsWithRoles?: {
                         /**
                          * Format: uuid
-                         * @description Unique identifier of the team.
+                         * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                          */
                         id: string;
                         /** @description Name of the team. */
@@ -3437,7 +2743,7 @@ export interface components {
                         description?: string;
                         /**
                          * Format: uuid
-                         * @description Identifier of the team owner.
+                         * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                          */
                         owner?: string;
                         /** @description Free-form metadata associated with the team. */
@@ -3471,7 +2777,7 @@ export interface components {
                     organizationsWithRoles?: {
                         /**
                          * Format: uuid
-                         * @description Unique identifier of the organization.
+                         * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                          */
                         id: string;
                         /** @description Name of the organization. */
@@ -3484,7 +2790,7 @@ export interface components {
                         region?: string;
                         /**
                          * Format: uuid
-                         * @description Identifier of the organization owner.
+                         * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                          */
                         owner?: string;
                         /**
@@ -3572,7 +2878,7 @@ export interface components {
                 user?: {
                     /**
                      * Format: uuid
-                     * @description Unique identifier for the user
+                     * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                      */
                     id: string;
                     /**
@@ -3749,7 +3055,7 @@ export interface components {
                         teamsWithRoles?: {
                             /**
                              * Format: uuid
-                             * @description Unique identifier of the team.
+                             * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                              */
                             id: string;
                             /** @description Name of the team. */
@@ -3758,7 +3064,7 @@ export interface components {
                             description?: string;
                             /**
                              * Format: uuid
-                             * @description Identifier of the team owner.
+                             * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                              */
                             owner?: string;
                             /** @description Free-form metadata associated with the team. */
@@ -3792,7 +3098,7 @@ export interface components {
                         organizationsWithRoles?: {
                             /**
                              * Format: uuid
-                             * @description Unique identifier of the organization.
+                             * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                              */
                             id: string;
                             /** @description Name of the organization. */
@@ -3805,7 +3111,7 @@ export interface components {
                             region?: string;
                             /**
                              * Format: uuid
-                             * @description Identifier of the organization owner.
+                             * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                              */
                             owner?: string;
                             /**
@@ -4081,267 +3387,28 @@ export interface operations {
                              * @description Owning user ID.
                              */
                             userId?: string;
-                            /** @description Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
+                            /** @description Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
                             user?: {
                                 /**
                                  * Format: uuid
-                                 * @description Unique identifier for the user
+                                 * @description Unique identifier for the user.
                                  */
                                 id: string;
                                 /**
+                                 * Format: uuid
                                  * @deprecated
-                                 * @description Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.
+                                 * @description Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.
                                  */
-                                userId: string;
-                                /**
-                                 * @description Authentication provider (e.g., Google, Github)
-                                 * @example [
-                                 *       "local",
-                                 *       "github",
-                                 *       "google",
-                                 *       "twitter"
-                                 *     ]
-                                 */
-                                provider: string;
-                                /**
-                                 * Format: email
-                                 * @description User's email address
-                                 */
-                                email: string;
-                                /** @description User's first name */
-                                firstName: string;
-                                /** @description User's last name */
-                                lastName: string;
+                                userId?: string;
+                                /** @description User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                                firstName?: string;
+                                /** @description User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                                lastName?: string;
                                 /**
                                  * Format: uri
-                                 * @description URL to user's avatar image
+                                 * @description URL to the user's avatar image.
                                  */
                                 avatarUrl?: string;
-                                /**
-                                 * @description User account status
-                                 * @enum {string}
-                                 */
-                                status: "active" | "inactive" | "pending" | "anonymous";
-                                /**
-                                 * @description User's biography or description
-                                 * @default
-                                 */
-                                bio: string;
-                                /** @description User's country information stored as JSONB */
-                                country?: {
-                                    [key: string]: unknown;
-                                };
-                                /** @description User's region information stored as JSONB */
-                                region?: {
-                                    [key: string]: unknown;
-                                };
-                                /** @description User preferences stored as JSONB */
-                                preferences?: {
-                                    /** @description The mesh adapters of the preference. */
-                                    meshAdapters?: Record<string, never>[];
-                                    grafana?: {
-                                        /** @description Grafana URL for the user configuration. */
-                                        grafanaUrl?: string;
-                                        /** @description Grafana API key for the user configuration. */
-                                        grafanaApiKey?: string;
-                                        /** @description Selected Grafana board configurations for the user. */
-                                        selectedBoardsConfigs?: {
-                                            /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                            board?: Record<string, never>;
-                                            /** @description Panels selected for the Grafana board configuration. */
-                                            panels?: Record<string, never>[];
-                                            /** @description Template variables applied to the selected Grafana board configuration. */
-                                            templateVars?: string[];
-                                        }[];
-                                    };
-                                    prometheus?: {
-                                        /** @description The prometheus URL of the prometheus. */
-                                        prometheusUrl?: string;
-                                        /** @description The selected prometheus boards configs of the prometheus. */
-                                        selectedPrometheusBoardsConfigs?: {
-                                            /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                            board?: Record<string, never>;
-                                            /** @description Panels selected for the Grafana board configuration. */
-                                            panels?: Record<string, never>[];
-                                            /** @description Template variables applied to the selected Grafana board configuration. */
-                                            templateVars?: string[];
-                                        }[];
-                                    };
-                                    loadTestPrefs?: {
-                                        /** @description Concurrent requests */
-                                        c?: number;
-                                        /** @description Queries per second */
-                                        qps?: number;
-                                        /** @description Duration */
-                                        t?: string;
-                                        /** @description Load generator */
-                                        gen?: string;
-                                    };
-                                    /** @description The anonymous usage stats of the preference. */
-                                    anonymousUsageStats: boolean;
-                                    /** @description The anonymous perf results of the preference. */
-                                    anonymousPerfResults: boolean;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp of when the resource was last updated.
-                                     */
-                                    updatedAt: string;
-                                    /** @description The dashboard preferences of the preference. */
-                                    dashboardPreferences: {
-                                        [key: string]: unknown;
-                                    };
-                                    /**
-                                     * Format: uuid
-                                     * @description ID of the associated selectedOrganization.
-                                     */
-                                    selectedOrganizationId: string;
-                                    /** @description The selected workspace for organizations of the preference. */
-                                    selectedWorkspaceForOrganizations: {
-                                        [key: string]: string;
-                                    };
-                                    /** @description The users extension preferences of the preference. */
-                                    usersExtensionPreferences: {
-                                        [key: string]: unknown;
-                                    };
-                                    /** @description The remote provider preferences of the preference. */
-                                    remoteProviderPreferences: {
-                                        [key: string]: unknown;
-                                    };
-                                };
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp when user accepted terms and conditions
-                                 */
-                                acceptedTermsAt?: string;
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp of user's first login
-                                 */
-                                firstLoginTime?: string;
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp of user's most recent login
-                                 */
-                                lastLoginTime: string;
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp when the user record was created
-                                 */
-                                createdAt: string;
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp when the user record was last updated
-                                 */
-                                updatedAt: string;
-                                /** @description Various online profiles associated with the user account */
-                                socials?: {
-                                    /** @description The site of the social. */
-                                    site: string;
-                                    /**
-                                     * Format: uri
-                                     * @description The link of the social.
-                                     */
-                                    link: string;
-                                }[];
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp when the user record was soft-deleted (null if not deleted)
-                                 */
-                                deletedAt: string | null;
-                                /**
-                                 * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
-                                 * @example [
-                                 *       "organization admin",
-                                 *       "user"
-                                 *     ]
-                                 */
-                                roleNames?: string[];
-                                /** @description Teams the user belongs to with role information */
-                                teams?: {
-                                    /** @description Team memberships for the user with their assigned roles. */
-                                    teamsWithRoles?: {
-                                        /**
-                                         * Format: uuid
-                                         * @description Unique identifier of the team.
-                                         */
-                                        id: string;
-                                        /** @description Name of the team. */
-                                        name: string;
-                                        /** @description Human readable description of the team. */
-                                        description?: string;
-                                        /**
-                                         * Format: uuid
-                                         * @description Identifier of the team owner.
-                                         */
-                                        owner?: string;
-                                        /** @description Free-form metadata associated with the team. */
-                                        metadata?: {
-                                            [key: string]: unknown;
-                                        };
-                                        /**
-                                         * Format: date-time
-                                         * @description Timestamp when the team was created.
-                                         */
-                                        createdAt?: string;
-                                        /**
-                                         * Format: date-time
-                                         * @description Timestamp when the team was last updated.
-                                         */
-                                        updatedAt?: string;
-                                        /**
-                                         * Format: date-time
-                                         * @description Timestamp when the team was soft-deleted (null if not deleted).
-                                         */
-                                        deletedAt?: string | null;
-                                        /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-                                        roleNames: string[];
-                                    }[];
-                                    /** @description Total number of team memberships returned for the user. */
-                                    totalCount?: number;
-                                };
-                                /** @description Organizations the user belongs to with role information */
-                                organizations?: {
-                                    /** @description Organization memberships for the user with their assigned roles. */
-                                    organizationsWithRoles?: {
-                                        /**
-                                         * Format: uuid
-                                         * @description Unique identifier of the organization.
-                                         */
-                                        id: string;
-                                        /** @description Name of the organization. */
-                                        name: string;
-                                        /** @description Human readable description of the organization. */
-                                        description?: string;
-                                        /** @description Country associated with the organization. */
-                                        country?: string;
-                                        /** @description Region associated with the organization. */
-                                        region?: string;
-                                        /**
-                                         * Format: uuid
-                                         * @description Identifier of the organization owner.
-                                         */
-                                        owner?: string;
-                                        /**
-                                         * Format: date-time
-                                         * @description Timestamp when the organization was created.
-                                         */
-                                        createdAt?: string;
-                                        /**
-                                         * Format: date-time
-                                         * @description Timestamp when the organization was last updated.
-                                         */
-                                        updatedAt?: string;
-                                        /**
-                                         * Format: date-time
-                                         * @description Timestamp when the organization was soft-deleted (null if not deleted).
-                                         */
-                                        deletedAt?: string | null;
-                                        /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-                                        roleNames: string[];
-                                    }[];
-                                    /** @description Total number of organization memberships returned for the user. */
-                                    totalCount?: number;
-                                };
                             } | null;
                             /** @description Optional structured location metadata (branch, host, path, ...). */
                             location?: {
@@ -4562,267 +3629,28 @@ export interface operations {
                          * @description Owning user ID.
                          */
                         userId?: string;
-                        /** @description Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
+                        /** @description Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
                         user?: {
                             /**
                              * Format: uuid
-                             * @description Unique identifier for the user
+                             * @description Unique identifier for the user.
                              */
                             id: string;
                             /**
+                             * Format: uuid
                              * @deprecated
-                             * @description Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.
+                             * @description Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.
                              */
-                            userId: string;
-                            /**
-                             * @description Authentication provider (e.g., Google, Github)
-                             * @example [
-                             *       "local",
-                             *       "github",
-                             *       "google",
-                             *       "twitter"
-                             *     ]
-                             */
-                            provider: string;
-                            /**
-                             * Format: email
-                             * @description User's email address
-                             */
-                            email: string;
-                            /** @description User's first name */
-                            firstName: string;
-                            /** @description User's last name */
-                            lastName: string;
+                            userId?: string;
+                            /** @description User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                            firstName?: string;
+                            /** @description User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                            lastName?: string;
                             /**
                              * Format: uri
-                             * @description URL to user's avatar image
+                             * @description URL to the user's avatar image.
                              */
                             avatarUrl?: string;
-                            /**
-                             * @description User account status
-                             * @enum {string}
-                             */
-                            status: "active" | "inactive" | "pending" | "anonymous";
-                            /**
-                             * @description User's biography or description
-                             * @default
-                             */
-                            bio: string;
-                            /** @description User's country information stored as JSONB */
-                            country?: {
-                                [key: string]: unknown;
-                            };
-                            /** @description User's region information stored as JSONB */
-                            region?: {
-                                [key: string]: unknown;
-                            };
-                            /** @description User preferences stored as JSONB */
-                            preferences?: {
-                                /** @description The mesh adapters of the preference. */
-                                meshAdapters?: Record<string, never>[];
-                                grafana?: {
-                                    /** @description Grafana URL for the user configuration. */
-                                    grafanaUrl?: string;
-                                    /** @description Grafana API key for the user configuration. */
-                                    grafanaApiKey?: string;
-                                    /** @description Selected Grafana board configurations for the user. */
-                                    selectedBoardsConfigs?: {
-                                        /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                        board?: Record<string, never>;
-                                        /** @description Panels selected for the Grafana board configuration. */
-                                        panels?: Record<string, never>[];
-                                        /** @description Template variables applied to the selected Grafana board configuration. */
-                                        templateVars?: string[];
-                                    }[];
-                                };
-                                prometheus?: {
-                                    /** @description The prometheus URL of the prometheus. */
-                                    prometheusUrl?: string;
-                                    /** @description The selected prometheus boards configs of the prometheus. */
-                                    selectedPrometheusBoardsConfigs?: {
-                                        /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                        board?: Record<string, never>;
-                                        /** @description Panels selected for the Grafana board configuration. */
-                                        panels?: Record<string, never>[];
-                                        /** @description Template variables applied to the selected Grafana board configuration. */
-                                        templateVars?: string[];
-                                    }[];
-                                };
-                                loadTestPrefs?: {
-                                    /** @description Concurrent requests */
-                                    c?: number;
-                                    /** @description Queries per second */
-                                    qps?: number;
-                                    /** @description Duration */
-                                    t?: string;
-                                    /** @description Load generator */
-                                    gen?: string;
-                                };
-                                /** @description The anonymous usage stats of the preference. */
-                                anonymousUsageStats: boolean;
-                                /** @description The anonymous perf results of the preference. */
-                                anonymousPerfResults: boolean;
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp of when the resource was last updated.
-                                 */
-                                updatedAt: string;
-                                /** @description The dashboard preferences of the preference. */
-                                dashboardPreferences: {
-                                    [key: string]: unknown;
-                                };
-                                /**
-                                 * Format: uuid
-                                 * @description ID of the associated selectedOrganization.
-                                 */
-                                selectedOrganizationId: string;
-                                /** @description The selected workspace for organizations of the preference. */
-                                selectedWorkspaceForOrganizations: {
-                                    [key: string]: string;
-                                };
-                                /** @description The users extension preferences of the preference. */
-                                usersExtensionPreferences: {
-                                    [key: string]: unknown;
-                                };
-                                /** @description The remote provider preferences of the preference. */
-                                remoteProviderPreferences: {
-                                    [key: string]: unknown;
-                                };
-                            };
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when user accepted terms and conditions
-                             */
-                            acceptedTermsAt?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp of user's first login
-                             */
-                            firstLoginTime?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp of user's most recent login
-                             */
-                            lastLoginTime: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the user record was created
-                             */
-                            createdAt: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the user record was last updated
-                             */
-                            updatedAt: string;
-                            /** @description Various online profiles associated with the user account */
-                            socials?: {
-                                /** @description The site of the social. */
-                                site: string;
-                                /**
-                                 * Format: uri
-                                 * @description The link of the social.
-                                 */
-                                link: string;
-                            }[];
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the user record was soft-deleted (null if not deleted)
-                             */
-                            deletedAt: string | null;
-                            /**
-                             * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
-                             * @example [
-                             *       "organization admin",
-                             *       "user"
-                             *     ]
-                             */
-                            roleNames?: string[];
-                            /** @description Teams the user belongs to with role information */
-                            teams?: {
-                                /** @description Team memberships for the user with their assigned roles. */
-                                teamsWithRoles?: {
-                                    /**
-                                     * Format: uuid
-                                     * @description Unique identifier of the team.
-                                     */
-                                    id: string;
-                                    /** @description Name of the team. */
-                                    name: string;
-                                    /** @description Human readable description of the team. */
-                                    description?: string;
-                                    /**
-                                     * Format: uuid
-                                     * @description Identifier of the team owner.
-                                     */
-                                    owner?: string;
-                                    /** @description Free-form metadata associated with the team. */
-                                    metadata?: {
-                                        [key: string]: unknown;
-                                    };
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the team was created.
-                                     */
-                                    createdAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the team was last updated.
-                                     */
-                                    updatedAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the team was soft-deleted (null if not deleted).
-                                     */
-                                    deletedAt?: string | null;
-                                    /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-                                    roleNames: string[];
-                                }[];
-                                /** @description Total number of team memberships returned for the user. */
-                                totalCount?: number;
-                            };
-                            /** @description Organizations the user belongs to with role information */
-                            organizations?: {
-                                /** @description Organization memberships for the user with their assigned roles. */
-                                organizationsWithRoles?: {
-                                    /**
-                                     * Format: uuid
-                                     * @description Unique identifier of the organization.
-                                     */
-                                    id: string;
-                                    /** @description Name of the organization. */
-                                    name: string;
-                                    /** @description Human readable description of the organization. */
-                                    description?: string;
-                                    /** @description Country associated with the organization. */
-                                    country?: string;
-                                    /** @description Region associated with the organization. */
-                                    region?: string;
-                                    /**
-                                     * Format: uuid
-                                     * @description Identifier of the organization owner.
-                                     */
-                                    owner?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the organization was created.
-                                     */
-                                    createdAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the organization was last updated.
-                                     */
-                                    updatedAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the organization was soft-deleted (null if not deleted).
-                                     */
-                                    deletedAt?: string | null;
-                                    /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-                                    roleNames: string[];
-                                }[];
-                                /** @description Total number of organization memberships returned for the user. */
-                                totalCount?: number;
-                            };
                         } | null;
                         /** @description Optional structured location metadata (branch, host, path, ...). */
                         location?: {
@@ -5037,267 +3865,28 @@ export interface operations {
                          * @description Owning user ID.
                          */
                         userId?: string;
-                        /** @description Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
+                        /** @description Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
                         user?: {
                             /**
                              * Format: uuid
-                             * @description Unique identifier for the user
+                             * @description Unique identifier for the user.
                              */
                             id: string;
                             /**
+                             * Format: uuid
                              * @deprecated
-                             * @description Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.
+                             * @description Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.
                              */
-                            userId: string;
-                            /**
-                             * @description Authentication provider (e.g., Google, Github)
-                             * @example [
-                             *       "local",
-                             *       "github",
-                             *       "google",
-                             *       "twitter"
-                             *     ]
-                             */
-                            provider: string;
-                            /**
-                             * Format: email
-                             * @description User's email address
-                             */
-                            email: string;
-                            /** @description User's first name */
-                            firstName: string;
-                            /** @description User's last name */
-                            lastName: string;
+                            userId?: string;
+                            /** @description User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                            firstName?: string;
+                            /** @description User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                            lastName?: string;
                             /**
                              * Format: uri
-                             * @description URL to user's avatar image
+                             * @description URL to the user's avatar image.
                              */
                             avatarUrl?: string;
-                            /**
-                             * @description User account status
-                             * @enum {string}
-                             */
-                            status: "active" | "inactive" | "pending" | "anonymous";
-                            /**
-                             * @description User's biography or description
-                             * @default
-                             */
-                            bio: string;
-                            /** @description User's country information stored as JSONB */
-                            country?: {
-                                [key: string]: unknown;
-                            };
-                            /** @description User's region information stored as JSONB */
-                            region?: {
-                                [key: string]: unknown;
-                            };
-                            /** @description User preferences stored as JSONB */
-                            preferences?: {
-                                /** @description The mesh adapters of the preference. */
-                                meshAdapters?: Record<string, never>[];
-                                grafana?: {
-                                    /** @description Grafana URL for the user configuration. */
-                                    grafanaUrl?: string;
-                                    /** @description Grafana API key for the user configuration. */
-                                    grafanaApiKey?: string;
-                                    /** @description Selected Grafana board configurations for the user. */
-                                    selectedBoardsConfigs?: {
-                                        /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                        board?: Record<string, never>;
-                                        /** @description Panels selected for the Grafana board configuration. */
-                                        panels?: Record<string, never>[];
-                                        /** @description Template variables applied to the selected Grafana board configuration. */
-                                        templateVars?: string[];
-                                    }[];
-                                };
-                                prometheus?: {
-                                    /** @description The prometheus URL of the prometheus. */
-                                    prometheusUrl?: string;
-                                    /** @description The selected prometheus boards configs of the prometheus. */
-                                    selectedPrometheusBoardsConfigs?: {
-                                        /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                        board?: Record<string, never>;
-                                        /** @description Panels selected for the Grafana board configuration. */
-                                        panels?: Record<string, never>[];
-                                        /** @description Template variables applied to the selected Grafana board configuration. */
-                                        templateVars?: string[];
-                                    }[];
-                                };
-                                loadTestPrefs?: {
-                                    /** @description Concurrent requests */
-                                    c?: number;
-                                    /** @description Queries per second */
-                                    qps?: number;
-                                    /** @description Duration */
-                                    t?: string;
-                                    /** @description Load generator */
-                                    gen?: string;
-                                };
-                                /** @description The anonymous usage stats of the preference. */
-                                anonymousUsageStats: boolean;
-                                /** @description The anonymous perf results of the preference. */
-                                anonymousPerfResults: boolean;
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp of when the resource was last updated.
-                                 */
-                                updatedAt: string;
-                                /** @description The dashboard preferences of the preference. */
-                                dashboardPreferences: {
-                                    [key: string]: unknown;
-                                };
-                                /**
-                                 * Format: uuid
-                                 * @description ID of the associated selectedOrganization.
-                                 */
-                                selectedOrganizationId: string;
-                                /** @description The selected workspace for organizations of the preference. */
-                                selectedWorkspaceForOrganizations: {
-                                    [key: string]: string;
-                                };
-                                /** @description The users extension preferences of the preference. */
-                                usersExtensionPreferences: {
-                                    [key: string]: unknown;
-                                };
-                                /** @description The remote provider preferences of the preference. */
-                                remoteProviderPreferences: {
-                                    [key: string]: unknown;
-                                };
-                            };
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when user accepted terms and conditions
-                             */
-                            acceptedTermsAt?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp of user's first login
-                             */
-                            firstLoginTime?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp of user's most recent login
-                             */
-                            lastLoginTime: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the user record was created
-                             */
-                            createdAt: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the user record was last updated
-                             */
-                            updatedAt: string;
-                            /** @description Various online profiles associated with the user account */
-                            socials?: {
-                                /** @description The site of the social. */
-                                site: string;
-                                /**
-                                 * Format: uri
-                                 * @description The link of the social.
-                                 */
-                                link: string;
-                            }[];
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the user record was soft-deleted (null if not deleted)
-                             */
-                            deletedAt: string | null;
-                            /**
-                             * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
-                             * @example [
-                             *       "organization admin",
-                             *       "user"
-                             *     ]
-                             */
-                            roleNames?: string[];
-                            /** @description Teams the user belongs to with role information */
-                            teams?: {
-                                /** @description Team memberships for the user with their assigned roles. */
-                                teamsWithRoles?: {
-                                    /**
-                                     * Format: uuid
-                                     * @description Unique identifier of the team.
-                                     */
-                                    id: string;
-                                    /** @description Name of the team. */
-                                    name: string;
-                                    /** @description Human readable description of the team. */
-                                    description?: string;
-                                    /**
-                                     * Format: uuid
-                                     * @description Identifier of the team owner.
-                                     */
-                                    owner?: string;
-                                    /** @description Free-form metadata associated with the team. */
-                                    metadata?: {
-                                        [key: string]: unknown;
-                                    };
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the team was created.
-                                     */
-                                    createdAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the team was last updated.
-                                     */
-                                    updatedAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the team was soft-deleted (null if not deleted).
-                                     */
-                                    deletedAt?: string | null;
-                                    /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-                                    roleNames: string[];
-                                }[];
-                                /** @description Total number of team memberships returned for the user. */
-                                totalCount?: number;
-                            };
-                            /** @description Organizations the user belongs to with role information */
-                            organizations?: {
-                                /** @description Organization memberships for the user with their assigned roles. */
-                                organizationsWithRoles?: {
-                                    /**
-                                     * Format: uuid
-                                     * @description Unique identifier of the organization.
-                                     */
-                                    id: string;
-                                    /** @description Name of the organization. */
-                                    name: string;
-                                    /** @description Human readable description of the organization. */
-                                    description?: string;
-                                    /** @description Country associated with the organization. */
-                                    country?: string;
-                                    /** @description Region associated with the organization. */
-                                    region?: string;
-                                    /**
-                                     * Format: uuid
-                                     * @description Identifier of the organization owner.
-                                     */
-                                    owner?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the organization was created.
-                                     */
-                                    createdAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the organization was last updated.
-                                     */
-                                    updatedAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the organization was soft-deleted (null if not deleted).
-                                     */
-                                    deletedAt?: string | null;
-                                    /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-                                    roleNames: string[];
-                                }[];
-                                /** @description Total number of organization memberships returned for the user. */
-                                totalCount?: number;
-                            };
                         } | null;
                         /** @description Optional structured location metadata (branch, host, path, ...). */
                         location?: {
@@ -5497,267 +4086,28 @@ export interface operations {
                          * @description Owning user ID.
                          */
                         userId?: string;
-                        /** @description Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
+                        /** @description Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
                         user?: {
                             /**
                              * Format: uuid
-                             * @description Unique identifier for the user
+                             * @description Unique identifier for the user.
                              */
                             id: string;
                             /**
+                             * Format: uuid
                              * @deprecated
-                             * @description Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.
+                             * @description Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.
                              */
-                            userId: string;
-                            /**
-                             * @description Authentication provider (e.g., Google, Github)
-                             * @example [
-                             *       "local",
-                             *       "github",
-                             *       "google",
-                             *       "twitter"
-                             *     ]
-                             */
-                            provider: string;
-                            /**
-                             * Format: email
-                             * @description User's email address
-                             */
-                            email: string;
-                            /** @description User's first name */
-                            firstName: string;
-                            /** @description User's last name */
-                            lastName: string;
+                            userId?: string;
+                            /** @description User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                            firstName?: string;
+                            /** @description User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                            lastName?: string;
                             /**
                              * Format: uri
-                             * @description URL to user's avatar image
+                             * @description URL to the user's avatar image.
                              */
                             avatarUrl?: string;
-                            /**
-                             * @description User account status
-                             * @enum {string}
-                             */
-                            status: "active" | "inactive" | "pending" | "anonymous";
-                            /**
-                             * @description User's biography or description
-                             * @default
-                             */
-                            bio: string;
-                            /** @description User's country information stored as JSONB */
-                            country?: {
-                                [key: string]: unknown;
-                            };
-                            /** @description User's region information stored as JSONB */
-                            region?: {
-                                [key: string]: unknown;
-                            };
-                            /** @description User preferences stored as JSONB */
-                            preferences?: {
-                                /** @description The mesh adapters of the preference. */
-                                meshAdapters?: Record<string, never>[];
-                                grafana?: {
-                                    /** @description Grafana URL for the user configuration. */
-                                    grafanaUrl?: string;
-                                    /** @description Grafana API key for the user configuration. */
-                                    grafanaApiKey?: string;
-                                    /** @description Selected Grafana board configurations for the user. */
-                                    selectedBoardsConfigs?: {
-                                        /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                        board?: Record<string, never>;
-                                        /** @description Panels selected for the Grafana board configuration. */
-                                        panels?: Record<string, never>[];
-                                        /** @description Template variables applied to the selected Grafana board configuration. */
-                                        templateVars?: string[];
-                                    }[];
-                                };
-                                prometheus?: {
-                                    /** @description The prometheus URL of the prometheus. */
-                                    prometheusUrl?: string;
-                                    /** @description The selected prometheus boards configs of the prometheus. */
-                                    selectedPrometheusBoardsConfigs?: {
-                                        /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                        board?: Record<string, never>;
-                                        /** @description Panels selected for the Grafana board configuration. */
-                                        panels?: Record<string, never>[];
-                                        /** @description Template variables applied to the selected Grafana board configuration. */
-                                        templateVars?: string[];
-                                    }[];
-                                };
-                                loadTestPrefs?: {
-                                    /** @description Concurrent requests */
-                                    c?: number;
-                                    /** @description Queries per second */
-                                    qps?: number;
-                                    /** @description Duration */
-                                    t?: string;
-                                    /** @description Load generator */
-                                    gen?: string;
-                                };
-                                /** @description The anonymous usage stats of the preference. */
-                                anonymousUsageStats: boolean;
-                                /** @description The anonymous perf results of the preference. */
-                                anonymousPerfResults: boolean;
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp of when the resource was last updated.
-                                 */
-                                updatedAt: string;
-                                /** @description The dashboard preferences of the preference. */
-                                dashboardPreferences: {
-                                    [key: string]: unknown;
-                                };
-                                /**
-                                 * Format: uuid
-                                 * @description ID of the associated selectedOrganization.
-                                 */
-                                selectedOrganizationId: string;
-                                /** @description The selected workspace for organizations of the preference. */
-                                selectedWorkspaceForOrganizations: {
-                                    [key: string]: string;
-                                };
-                                /** @description The users extension preferences of the preference. */
-                                usersExtensionPreferences: {
-                                    [key: string]: unknown;
-                                };
-                                /** @description The remote provider preferences of the preference. */
-                                remoteProviderPreferences: {
-                                    [key: string]: unknown;
-                                };
-                            };
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when user accepted terms and conditions
-                             */
-                            acceptedTermsAt?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp of user's first login
-                             */
-                            firstLoginTime?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp of user's most recent login
-                             */
-                            lastLoginTime: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the user record was created
-                             */
-                            createdAt: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the user record was last updated
-                             */
-                            updatedAt: string;
-                            /** @description Various online profiles associated with the user account */
-                            socials?: {
-                                /** @description The site of the social. */
-                                site: string;
-                                /**
-                                 * Format: uri
-                                 * @description The link of the social.
-                                 */
-                                link: string;
-                            }[];
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the user record was soft-deleted (null if not deleted)
-                             */
-                            deletedAt: string | null;
-                            /**
-                             * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
-                             * @example [
-                             *       "organization admin",
-                             *       "user"
-                             *     ]
-                             */
-                            roleNames?: string[];
-                            /** @description Teams the user belongs to with role information */
-                            teams?: {
-                                /** @description Team memberships for the user with their assigned roles. */
-                                teamsWithRoles?: {
-                                    /**
-                                     * Format: uuid
-                                     * @description Unique identifier of the team.
-                                     */
-                                    id: string;
-                                    /** @description Name of the team. */
-                                    name: string;
-                                    /** @description Human readable description of the team. */
-                                    description?: string;
-                                    /**
-                                     * Format: uuid
-                                     * @description Identifier of the team owner.
-                                     */
-                                    owner?: string;
-                                    /** @description Free-form metadata associated with the team. */
-                                    metadata?: {
-                                        [key: string]: unknown;
-                                    };
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the team was created.
-                                     */
-                                    createdAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the team was last updated.
-                                     */
-                                    updatedAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the team was soft-deleted (null if not deleted).
-                                     */
-                                    deletedAt?: string | null;
-                                    /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-                                    roleNames: string[];
-                                }[];
-                                /** @description Total number of team memberships returned for the user. */
-                                totalCount?: number;
-                            };
-                            /** @description Organizations the user belongs to with role information */
-                            organizations?: {
-                                /** @description Organization memberships for the user with their assigned roles. */
-                                organizationsWithRoles?: {
-                                    /**
-                                     * Format: uuid
-                                     * @description Unique identifier of the organization.
-                                     */
-                                    id: string;
-                                    /** @description Name of the organization. */
-                                    name: string;
-                                    /** @description Human readable description of the organization. */
-                                    description?: string;
-                                    /** @description Country associated with the organization. */
-                                    country?: string;
-                                    /** @description Region associated with the organization. */
-                                    region?: string;
-                                    /**
-                                     * Format: uuid
-                                     * @description Identifier of the organization owner.
-                                     */
-                                    owner?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the organization was created.
-                                     */
-                                    createdAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the organization was last updated.
-                                     */
-                                    updatedAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the organization was soft-deleted (null if not deleted).
-                                     */
-                                    deletedAt?: string | null;
-                                    /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-                                    roleNames: string[];
-                                }[];
-                                /** @description Total number of organization memberships returned for the user. */
-                                totalCount?: number;
-                            };
                         } | null;
                         /** @description Optional structured location metadata (branch, host, path, ...). */
                         location?: {
@@ -6054,267 +4404,28 @@ export interface operations {
                          * @description Owning user ID.
                          */
                         userId?: string;
-                        /** @description Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
+                        /** @description Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
                         user?: {
                             /**
                              * Format: uuid
-                             * @description Unique identifier for the user
+                             * @description Unique identifier for the user.
                              */
                             id: string;
                             /**
+                             * Format: uuid
                              * @deprecated
-                             * @description Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.
+                             * @description Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.
                              */
-                            userId: string;
-                            /**
-                             * @description Authentication provider (e.g., Google, Github)
-                             * @example [
-                             *       "local",
-                             *       "github",
-                             *       "google",
-                             *       "twitter"
-                             *     ]
-                             */
-                            provider: string;
-                            /**
-                             * Format: email
-                             * @description User's email address
-                             */
-                            email: string;
-                            /** @description User's first name */
-                            firstName: string;
-                            /** @description User's last name */
-                            lastName: string;
+                            userId?: string;
+                            /** @description User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                            firstName?: string;
+                            /** @description User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                            lastName?: string;
                             /**
                              * Format: uri
-                             * @description URL to user's avatar image
+                             * @description URL to the user's avatar image.
                              */
                             avatarUrl?: string;
-                            /**
-                             * @description User account status
-                             * @enum {string}
-                             */
-                            status: "active" | "inactive" | "pending" | "anonymous";
-                            /**
-                             * @description User's biography or description
-                             * @default
-                             */
-                            bio: string;
-                            /** @description User's country information stored as JSONB */
-                            country?: {
-                                [key: string]: unknown;
-                            };
-                            /** @description User's region information stored as JSONB */
-                            region?: {
-                                [key: string]: unknown;
-                            };
-                            /** @description User preferences stored as JSONB */
-                            preferences?: {
-                                /** @description The mesh adapters of the preference. */
-                                meshAdapters?: Record<string, never>[];
-                                grafana?: {
-                                    /** @description Grafana URL for the user configuration. */
-                                    grafanaUrl?: string;
-                                    /** @description Grafana API key for the user configuration. */
-                                    grafanaApiKey?: string;
-                                    /** @description Selected Grafana board configurations for the user. */
-                                    selectedBoardsConfigs?: {
-                                        /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                        board?: Record<string, never>;
-                                        /** @description Panels selected for the Grafana board configuration. */
-                                        panels?: Record<string, never>[];
-                                        /** @description Template variables applied to the selected Grafana board configuration. */
-                                        templateVars?: string[];
-                                    }[];
-                                };
-                                prometheus?: {
-                                    /** @description The prometheus URL of the prometheus. */
-                                    prometheusUrl?: string;
-                                    /** @description The selected prometheus boards configs of the prometheus. */
-                                    selectedPrometheusBoardsConfigs?: {
-                                        /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                        board?: Record<string, never>;
-                                        /** @description Panels selected for the Grafana board configuration. */
-                                        panels?: Record<string, never>[];
-                                        /** @description Template variables applied to the selected Grafana board configuration. */
-                                        templateVars?: string[];
-                                    }[];
-                                };
-                                loadTestPrefs?: {
-                                    /** @description Concurrent requests */
-                                    c?: number;
-                                    /** @description Queries per second */
-                                    qps?: number;
-                                    /** @description Duration */
-                                    t?: string;
-                                    /** @description Load generator */
-                                    gen?: string;
-                                };
-                                /** @description The anonymous usage stats of the preference. */
-                                anonymousUsageStats: boolean;
-                                /** @description The anonymous perf results of the preference. */
-                                anonymousPerfResults: boolean;
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp of when the resource was last updated.
-                                 */
-                                updatedAt: string;
-                                /** @description The dashboard preferences of the preference. */
-                                dashboardPreferences: {
-                                    [key: string]: unknown;
-                                };
-                                /**
-                                 * Format: uuid
-                                 * @description ID of the associated selectedOrganization.
-                                 */
-                                selectedOrganizationId: string;
-                                /** @description The selected workspace for organizations of the preference. */
-                                selectedWorkspaceForOrganizations: {
-                                    [key: string]: string;
-                                };
-                                /** @description The users extension preferences of the preference. */
-                                usersExtensionPreferences: {
-                                    [key: string]: unknown;
-                                };
-                                /** @description The remote provider preferences of the preference. */
-                                remoteProviderPreferences: {
-                                    [key: string]: unknown;
-                                };
-                            };
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when user accepted terms and conditions
-                             */
-                            acceptedTermsAt?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp of user's first login
-                             */
-                            firstLoginTime?: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp of user's most recent login
-                             */
-                            lastLoginTime: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the user record was created
-                             */
-                            createdAt: string;
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the user record was last updated
-                             */
-                            updatedAt: string;
-                            /** @description Various online profiles associated with the user account */
-                            socials?: {
-                                /** @description The site of the social. */
-                                site: string;
-                                /**
-                                 * Format: uri
-                                 * @description The link of the social.
-                                 */
-                                link: string;
-                            }[];
-                            /**
-                             * Format: date-time
-                             * @description Timestamp when the user record was soft-deleted (null if not deleted)
-                             */
-                            deletedAt: string | null;
-                            /**
-                             * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
-                             * @example [
-                             *       "organization admin",
-                             *       "user"
-                             *     ]
-                             */
-                            roleNames?: string[];
-                            /** @description Teams the user belongs to with role information */
-                            teams?: {
-                                /** @description Team memberships for the user with their assigned roles. */
-                                teamsWithRoles?: {
-                                    /**
-                                     * Format: uuid
-                                     * @description Unique identifier of the team.
-                                     */
-                                    id: string;
-                                    /** @description Name of the team. */
-                                    name: string;
-                                    /** @description Human readable description of the team. */
-                                    description?: string;
-                                    /**
-                                     * Format: uuid
-                                     * @description Identifier of the team owner.
-                                     */
-                                    owner?: string;
-                                    /** @description Free-form metadata associated with the team. */
-                                    metadata?: {
-                                        [key: string]: unknown;
-                                    };
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the team was created.
-                                     */
-                                    createdAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the team was last updated.
-                                     */
-                                    updatedAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the team was soft-deleted (null if not deleted).
-                                     */
-                                    deletedAt?: string | null;
-                                    /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-                                    roleNames: string[];
-                                }[];
-                                /** @description Total number of team memberships returned for the user. */
-                                totalCount?: number;
-                            };
-                            /** @description Organizations the user belongs to with role information */
-                            organizations?: {
-                                /** @description Organization memberships for the user with their assigned roles. */
-                                organizationsWithRoles?: {
-                                    /**
-                                     * Format: uuid
-                                     * @description Unique identifier of the organization.
-                                     */
-                                    id: string;
-                                    /** @description Name of the organization. */
-                                    name: string;
-                                    /** @description Human readable description of the organization. */
-                                    description?: string;
-                                    /** @description Country associated with the organization. */
-                                    country?: string;
-                                    /** @description Region associated with the organization. */
-                                    region?: string;
-                                    /**
-                                     * Format: uuid
-                                     * @description Identifier of the organization owner.
-                                     */
-                                    owner?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the organization was created.
-                                     */
-                                    createdAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the organization was last updated.
-                                     */
-                                    updatedAt?: string;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp when the organization was soft-deleted (null if not deleted).
-                                     */
-                                    deletedAt?: string | null;
-                                    /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-                                    roleNames: string[];
-                                }[];
-                                /** @description Total number of organization memberships returned for the user. */
-                                totalCount?: number;
-                            };
                         } | null;
                         /** @description Optional structured location metadata (branch, host, path, ...). */
                         location?: {
@@ -6487,267 +4598,28 @@ export interface operations {
                              * @description Owning user ID.
                              */
                             userId?: string;
-                            /** @description Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
+                            /** @description Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans. */
                             user?: {
                                 /**
                                  * Format: uuid
-                                 * @description Unique identifier for the user
+                                 * @description Unique identifier for the user.
                                  */
                                 id: string;
                                 /**
+                                 * Format: uuid
                                  * @deprecated
-                                 * @description Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.
+                                 * @description Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.
                                  */
-                                userId: string;
-                                /**
-                                 * @description Authentication provider (e.g., Google, Github)
-                                 * @example [
-                                 *       "local",
-                                 *       "github",
-                                 *       "google",
-                                 *       "twitter"
-                                 *     ]
-                                 */
-                                provider: string;
-                                /**
-                                 * Format: email
-                                 * @description User's email address
-                                 */
-                                email: string;
-                                /** @description User's first name */
-                                firstName: string;
-                                /** @description User's last name */
-                                lastName: string;
+                                userId?: string;
+                                /** @description User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                                firstName?: string;
+                                /** @description User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+                                lastName?: string;
                                 /**
                                  * Format: uri
-                                 * @description URL to user's avatar image
+                                 * @description URL to the user's avatar image.
                                  */
                                 avatarUrl?: string;
-                                /**
-                                 * @description User account status
-                                 * @enum {string}
-                                 */
-                                status: "active" | "inactive" | "pending" | "anonymous";
-                                /**
-                                 * @description User's biography or description
-                                 * @default
-                                 */
-                                bio: string;
-                                /** @description User's country information stored as JSONB */
-                                country?: {
-                                    [key: string]: unknown;
-                                };
-                                /** @description User's region information stored as JSONB */
-                                region?: {
-                                    [key: string]: unknown;
-                                };
-                                /** @description User preferences stored as JSONB */
-                                preferences?: {
-                                    /** @description The mesh adapters of the preference. */
-                                    meshAdapters?: Record<string, never>[];
-                                    grafana?: {
-                                        /** @description Grafana URL for the user configuration. */
-                                        grafanaUrl?: string;
-                                        /** @description Grafana API key for the user configuration. */
-                                        grafanaApiKey?: string;
-                                        /** @description Selected Grafana board configurations for the user. */
-                                        selectedBoardsConfigs?: {
-                                            /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                            board?: Record<string, never>;
-                                            /** @description Panels selected for the Grafana board configuration. */
-                                            panels?: Record<string, never>[];
-                                            /** @description Template variables applied to the selected Grafana board configuration. */
-                                            templateVars?: string[];
-                                        }[];
-                                    };
-                                    prometheus?: {
-                                        /** @description The prometheus URL of the prometheus. */
-                                        prometheusUrl?: string;
-                                        /** @description The selected prometheus boards configs of the prometheus. */
-                                        selectedPrometheusBoardsConfigs?: {
-                                            /** @description Placeholder for GrafanaBoard definition (define fields as needed) */
-                                            board?: Record<string, never>;
-                                            /** @description Panels selected for the Grafana board configuration. */
-                                            panels?: Record<string, never>[];
-                                            /** @description Template variables applied to the selected Grafana board configuration. */
-                                            templateVars?: string[];
-                                        }[];
-                                    };
-                                    loadTestPrefs?: {
-                                        /** @description Concurrent requests */
-                                        c?: number;
-                                        /** @description Queries per second */
-                                        qps?: number;
-                                        /** @description Duration */
-                                        t?: string;
-                                        /** @description Load generator */
-                                        gen?: string;
-                                    };
-                                    /** @description The anonymous usage stats of the preference. */
-                                    anonymousUsageStats: boolean;
-                                    /** @description The anonymous perf results of the preference. */
-                                    anonymousPerfResults: boolean;
-                                    /**
-                                     * Format: date-time
-                                     * @description Timestamp of when the resource was last updated.
-                                     */
-                                    updatedAt: string;
-                                    /** @description The dashboard preferences of the preference. */
-                                    dashboardPreferences: {
-                                        [key: string]: unknown;
-                                    };
-                                    /**
-                                     * Format: uuid
-                                     * @description ID of the associated selectedOrganization.
-                                     */
-                                    selectedOrganizationId: string;
-                                    /** @description The selected workspace for organizations of the preference. */
-                                    selectedWorkspaceForOrganizations: {
-                                        [key: string]: string;
-                                    };
-                                    /** @description The users extension preferences of the preference. */
-                                    usersExtensionPreferences: {
-                                        [key: string]: unknown;
-                                    };
-                                    /** @description The remote provider preferences of the preference. */
-                                    remoteProviderPreferences: {
-                                        [key: string]: unknown;
-                                    };
-                                };
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp when user accepted terms and conditions
-                                 */
-                                acceptedTermsAt?: string;
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp of user's first login
-                                 */
-                                firstLoginTime?: string;
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp of user's most recent login
-                                 */
-                                lastLoginTime: string;
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp when the user record was created
-                                 */
-                                createdAt: string;
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp when the user record was last updated
-                                 */
-                                updatedAt: string;
-                                /** @description Various online profiles associated with the user account */
-                                socials?: {
-                                    /** @description The site of the social. */
-                                    site: string;
-                                    /**
-                                     * Format: uri
-                                     * @description The link of the social.
-                                     */
-                                    link: string;
-                                }[];
-                                /**
-                                 * Format: date-time
-                                 * @description Timestamp when the user record was soft-deleted (null if not deleted)
-                                 */
-                                deletedAt: string | null;
-                                /**
-                                 * @description Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set.
-                                 * @example [
-                                 *       "organization admin",
-                                 *       "user"
-                                 *     ]
-                                 */
-                                roleNames?: string[];
-                                /** @description Teams the user belongs to with role information */
-                                teams?: {
-                                    /** @description Team memberships for the user with their assigned roles. */
-                                    teamsWithRoles?: {
-                                        /**
-                                         * Format: uuid
-                                         * @description Unique identifier of the team.
-                                         */
-                                        id: string;
-                                        /** @description Name of the team. */
-                                        name: string;
-                                        /** @description Human readable description of the team. */
-                                        description?: string;
-                                        /**
-                                         * Format: uuid
-                                         * @description Identifier of the team owner.
-                                         */
-                                        owner?: string;
-                                        /** @description Free-form metadata associated with the team. */
-                                        metadata?: {
-                                            [key: string]: unknown;
-                                        };
-                                        /**
-                                         * Format: date-time
-                                         * @description Timestamp when the team was created.
-                                         */
-                                        createdAt?: string;
-                                        /**
-                                         * Format: date-time
-                                         * @description Timestamp when the team was last updated.
-                                         */
-                                        updatedAt?: string;
-                                        /**
-                                         * Format: date-time
-                                         * @description Timestamp when the team was soft-deleted (null if not deleted).
-                                         */
-                                        deletedAt?: string | null;
-                                        /** @description Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-                                        roleNames: string[];
-                                    }[];
-                                    /** @description Total number of team memberships returned for the user. */
-                                    totalCount?: number;
-                                };
-                                /** @description Organizations the user belongs to with role information */
-                                organizations?: {
-                                    /** @description Organization memberships for the user with their assigned roles. */
-                                    organizationsWithRoles?: {
-                                        /**
-                                         * Format: uuid
-                                         * @description Unique identifier of the organization.
-                                         */
-                                        id: string;
-                                        /** @description Name of the organization. */
-                                        name: string;
-                                        /** @description Human readable description of the organization. */
-                                        description?: string;
-                                        /** @description Country associated with the organization. */
-                                        country?: string;
-                                        /** @description Region associated with the organization. */
-                                        region?: string;
-                                        /**
-                                         * Format: uuid
-                                         * @description Identifier of the organization owner.
-                                         */
-                                        owner?: string;
-                                        /**
-                                         * Format: date-time
-                                         * @description Timestamp when the organization was created.
-                                         */
-                                        createdAt?: string;
-                                        /**
-                                         * Format: date-time
-                                         * @description Timestamp when the organization was last updated.
-                                         */
-                                        updatedAt?: string;
-                                        /**
-                                         * Format: date-time
-                                         * @description Timestamp when the organization was soft-deleted (null if not deleted).
-                                         */
-                                        deletedAt?: string | null;
-                                        /** @description Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-                                        roleNames: string[];
-                                    }[];
-                                    /** @description Total number of organization memberships returned for the user. */
-                                    totalCount?: number;
-                                };
                             } | null;
                             /** @description Optional structured location metadata (branch, host, path, ...). */
                             location?: {
@@ -6975,7 +4847,7 @@ export interface operations {
                         user?: {
                             /**
                              * Format: uuid
-                             * @description Unique identifier for the user
+                             * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                              */
                             id: string;
                             /**
@@ -7152,7 +5024,7 @@ export interface operations {
                                 teamsWithRoles?: {
                                     /**
                                      * Format: uuid
-                                     * @description Unique identifier of the team.
+                                     * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                      */
                                     id: string;
                                     /** @description Name of the team. */
@@ -7161,7 +5033,7 @@ export interface operations {
                                     description?: string;
                                     /**
                                      * Format: uuid
-                                     * @description Identifier of the team owner.
+                                     * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                      */
                                     owner?: string;
                                     /** @description Free-form metadata associated with the team. */
@@ -7195,7 +5067,7 @@ export interface operations {
                                 organizationsWithRoles?: {
                                     /**
                                      * Format: uuid
-                                     * @description Unique identifier of the organization.
+                                     * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                      */
                                     id: string;
                                     /** @description Name of the organization. */
@@ -7208,7 +5080,7 @@ export interface operations {
                                     region?: string;
                                     /**
                                      * Format: uuid
-                                     * @description Identifier of the organization owner.
+                                     * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                      */
                                     owner?: string;
                                     /**
@@ -7357,7 +5229,7 @@ export interface operations {
                         user?: {
                             /**
                              * Format: uuid
-                             * @description Unique identifier for the user
+                             * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                              */
                             id: string;
                             /**
@@ -7534,7 +5406,7 @@ export interface operations {
                                 teamsWithRoles?: {
                                     /**
                                      * Format: uuid
-                                     * @description Unique identifier of the team.
+                                     * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                      */
                                     id: string;
                                     /** @description Name of the team. */
@@ -7543,7 +5415,7 @@ export interface operations {
                                     description?: string;
                                     /**
                                      * Format: uuid
-                                     * @description Identifier of the team owner.
+                                     * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                      */
                                     owner?: string;
                                     /** @description Free-form metadata associated with the team. */
@@ -7577,7 +5449,7 @@ export interface operations {
                                 organizationsWithRoles?: {
                                     /**
                                      * Format: uuid
-                                     * @description Unique identifier of the organization.
+                                     * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                      */
                                     id: string;
                                     /** @description Name of the organization. */
@@ -7590,7 +5462,7 @@ export interface operations {
                                     region?: string;
                                     /**
                                      * Format: uuid
-                                     * @description Identifier of the organization owner.
+                                     * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                      */
                                     owner?: string;
                                     /**
@@ -8132,7 +6004,7 @@ export interface operations {
                             user?: {
                                 /**
                                  * Format: uuid
-                                 * @description Unique identifier for the user
+                                 * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                  */
                                 id: string;
                                 /**
@@ -8309,7 +6181,7 @@ export interface operations {
                                     teamsWithRoles?: {
                                         /**
                                          * Format: uuid
-                                         * @description Unique identifier of the team.
+                                         * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                          */
                                         id: string;
                                         /** @description Name of the team. */
@@ -8318,7 +6190,7 @@ export interface operations {
                                         description?: string;
                                         /**
                                          * Format: uuid
-                                         * @description Identifier of the team owner.
+                                         * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                          */
                                         owner?: string;
                                         /** @description Free-form metadata associated with the team. */
@@ -8352,7 +6224,7 @@ export interface operations {
                                     organizationsWithRoles?: {
                                         /**
                                          * Format: uuid
-                                         * @description Unique identifier of the organization.
+                                         * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                          */
                                         id: string;
                                         /** @description Name of the organization. */
@@ -8365,7 +6237,7 @@ export interface operations {
                                         region?: string;
                                         /**
                                          * Format: uuid
-                                         * @description Identifier of the organization owner.
+                                         * @description A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.
                                          */
                                         owner?: string;
                                         /**

--- a/typescript/generated/v1beta3/design/DesignSchema.ts
+++ b/typescript/generated/v1beta3/design/DesignSchema.ts
@@ -295,33 +295,20 @@ const DesignSchema: Record<string, unknown> = {
                             "x-go-type-skip-optional-pointer": true
                           },
                           "user": {
-                            "description": "Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
+                            "description": "Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
                             "nullable": true,
-                            "x-go-type": "*userV1beta.User",
-                            "x-go-type-import": {
-                              "path": "github.com/meshery/schemas/models/v1beta2/user",
-                              "name": "userV1beta"
-                            },
+                            "x-go-type": "*CatalogAuthor",
                             "x-oapi-codegen-extra-tags": {
                               "db": "-"
                             },
                             "type": "object",
+                            "additionalProperties": false,
                             "required": [
-                              "id",
-                              "userId",
-                              "provider",
-                              "email",
-                              "firstName",
-                              "lastName",
-                              "status",
-                              "createdAt",
-                              "updatedAt",
-                              "lastLoginTime",
-                              "deletedAt"
+                              "id"
                             ],
                             "properties": {
                               "id": {
-                                "description": "Unique identifier for the user",
+                                "description": "Unique identifier for the user.",
                                 "x-go-name": "ID",
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "id",
@@ -335,712 +322,52 @@ const DesignSchema: Record<string, unknown> = {
                                 }
                               },
                               "userId": {
-                                "type": "string",
-                                "maxLength": 200,
                                 "deprecated": true,
-                                "description": "Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.",
+                                "description": "Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.",
+                                "x-go-name": "UserID",
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "user_id",
-                                  "json": "userId"
+                                  "json": "userId,omitempty"
                                 },
-                                "x-id-format": "external"
-                              },
-                              "provider": {
                                 "type": "string",
-                                "maxLength": 100,
-                                "description": "Authentication provider (e.g., Google, Github)",
-                                "example": [
-                                  "local",
-                                  "github",
-                                  "google",
-                                  "twitter"
-                                ],
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "provider",
-                                  "json": "provider"
-                                }
-                              },
-                              "email": {
-                                "type": "string",
-                                "format": "email",
-                                "maxLength": 300,
-                                "description": "User's email address",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "email",
-                                  "json": "email"
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
                                 }
                               },
                               "firstName": {
                                 "type": "string",
                                 "maxLength": 200,
-                                "description": "User's first name",
+                                "description": "User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                                "x-go-type-skip-optional-pointer": true,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "first_name",
-                                  "json": "firstName"
+                                  "json": "firstName,omitempty"
                                 }
                               },
                               "lastName": {
                                 "type": "string",
                                 "maxLength": 300,
-                                "description": "User's last name",
+                                "description": "User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                                "x-go-type-skip-optional-pointer": true,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "last_name",
-                                  "json": "lastName"
+                                  "json": "lastName,omitempty"
                                 }
                               },
                               "avatarUrl": {
                                 "type": "string",
                                 "format": "uri",
                                 "maxLength": 500,
-                                "description": "URL to user's avatar image",
+                                "description": "URL to the user's avatar image.",
+                                "x-go-type-skip-optional-pointer": true,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "avatar_url",
-                                  "json": "avatarUrl"
-                                }
-                              },
-                              "status": {
-                                "type": "string",
-                                "maxLength": 100,
-                                "enum": [
-                                  "active",
-                                  "inactive",
-                                  "pending",
-                                  "anonymous"
-                                ],
-                                "description": "User account status",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "status",
-                                  "json": "status"
-                                }
-                              },
-                              "bio": {
-                                "type": "string",
-                                "maxLength": 1000,
-                                "default": "",
-                                "description": "User's biography or description",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "bio",
-                                  "json": "bio"
-                                }
-                              },
-                              "country": {
-                                "type": "object",
-                                "description": "User's country information stored as JSONB",
-                                "additionalProperties": true,
-                                "x-go-type": "core.Map",
-                                "x-go-type-skip-optional-pointer": true,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "country",
-                                  "json": "country"
-                                }
-                              },
-                              "region": {
-                                "type": "object",
-                                "description": "User's region information stored as JSONB",
-                                "additionalProperties": true,
-                                "x-go-type": "core.Map",
-                                "x-go-type-skip-optional-pointer": true,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "region",
-                                  "json": "region"
-                                }
-                              },
-                              "preferences": {
-                                "x-go-type": "Preference",
-                                "description": "User preferences stored as JSONB",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "preferences",
-                                  "json": "preferences"
-                                },
-                                "x-generate-db-helpers": true,
-                                "type": "object",
-                                "required": [
-                                  "anonymousUsageStats",
-                                  "anonymousPerfResults",
-                                  "updatedAt",
-                                  "dashboardPreferences",
-                                  "selectedOrganizationId",
-                                  "selectedWorkspaceForOrganizations",
-                                  "usersExtensionPreferences",
-                                  "remoteProviderPreferences"
-                                ],
-                                "properties": {
-                                  "meshAdapters": {
-                                    "type": "array",
-                                    "items": {
-                                      "x-go-type": "Adapter",
-                                      "type": "object",
-                                      "description": "Placeholder for Adapter struct definition."
-                                    },
-                                    "description": "The mesh adapters of the preference."
-                                  },
-                                  "grafana": {
-                                    "x-go-type": "Grafana",
-                                    "type": "object",
-                                    "properties": {
-                                      "grafanaUrl": {
-                                        "type": "string",
-                                        "description": "Grafana URL for the user configuration.",
-                                        "maxLength": 500
-                                      },
-                                      "grafanaApiKey": {
-                                        "type": "string",
-                                        "description": "Grafana API key for the user configuration.",
-                                        "maxLength": 500
-                                      },
-                                      "selectedBoardsConfigs": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "properties": {
-                                            "board": {
-                                              "type": "object",
-                                              "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                            },
-                                            "panels": {
-                                              "type": "array",
-                                              "items": {
-                                                "type": "object",
-                                                "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                              },
-                                              "description": "Panels selected for the Grafana board configuration."
-                                            },
-                                            "templateVars": {
-                                              "type": "array",
-                                              "items": {
-                                                "type": "string"
-                                              },
-                                              "description": "Template variables applied to the selected Grafana board configuration."
-                                            }
-                                          }
-                                        },
-                                        "description": "Selected Grafana board configurations for the user."
-                                      }
-                                    }
-                                  },
-                                  "prometheus": {
-                                    "x-go-type": "Prometheus",
-                                    "type": "object",
-                                    "properties": {
-                                      "prometheusUrl": {
-                                        "type": "string",
-                                        "description": "The prometheus URL of the prometheus.",
-                                        "maxLength": 500
-                                      },
-                                      "selectedPrometheusBoardsConfigs": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "properties": {
-                                            "board": {
-                                              "type": "object",
-                                              "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                            },
-                                            "panels": {
-                                              "type": "array",
-                                              "items": {
-                                                "type": "object",
-                                                "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                              },
-                                              "description": "Panels selected for the Grafana board configuration."
-                                            },
-                                            "templateVars": {
-                                              "type": "array",
-                                              "items": {
-                                                "type": "string"
-                                              },
-                                              "description": "Template variables applied to the selected Grafana board configuration."
-                                            }
-                                          }
-                                        },
-                                        "description": "The selected prometheus boards configs of the prometheus."
-                                      }
-                                    }
-                                  },
-                                  "loadTestPrefs": {
-                                    "x-go-type": "LoadTestPreferences",
-                                    "type": "object",
-                                    "properties": {
-                                      "c": {
-                                        "type": "integer",
-                                        "description": "Concurrent requests",
-                                        "minimum": 0
-                                      },
-                                      "qps": {
-                                        "type": "integer",
-                                        "description": "Queries per second",
-                                        "minimum": 0
-                                      },
-                                      "t": {
-                                        "type": "string",
-                                        "description": "Duration",
-                                        "maxLength": 500
-                                      },
-                                      "gen": {
-                                        "type": "string",
-                                        "description": "Load generator",
-                                        "maxLength": 500
-                                      }
-                                    }
-                                  },
-                                  "anonymousUsageStats": {
-                                    "type": "boolean",
-                                    "description": "The anonymous usage stats of the preference."
-                                  },
-                                  "anonymousPerfResults": {
-                                    "type": "boolean",
-                                    "description": "The anonymous perf results of the preference."
-                                  },
-                                  "updatedAt": {
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "description": "Timestamp of when the resource was last updated."
-                                  },
-                                  "dashboardPreferences": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "description": "The dashboard preferences of the preference."
-                                  },
-                                  "selectedOrganizationId": {
-                                    "type": "string",
-                                    "description": "ID of the associated selectedOrganization.",
-                                    "maxLength": 500,
-                                    "format": "uuid"
-                                  },
-                                  "selectedWorkspaceForOrganizations": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                      "type": "string"
-                                    },
-                                    "description": "The selected workspace for organizations of the preference."
-                                  },
-                                  "usersExtensionPreferences": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "description": "The users extension preferences of the preference."
-                                  },
-                                  "remoteProviderPreferences": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "description": "The remote provider preferences of the preference."
-                                  }
-                                }
-                              },
-                              "acceptedTermsAt": {
-                                "description": "Timestamp when user accepted terms and conditions",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "accepted_terms_at",
-                                  "json": "acceptedTermsAt"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "firstLoginTime": {
-                                "description": "Timestamp of user's first login",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "first_login_time",
-                                  "json": "firstLoginTime"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "lastLoginTime": {
-                                "description": "Timestamp of user's most recent login",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "last_login_time",
-                                  "json": "lastLoginTime"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "createdAt": {
-                                "description": "Timestamp when the user record was created",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "created_at",
-                                  "json": "createdAt"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "updatedAt": {
-                                "description": "Timestamp when the user record was last updated",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "updated_at",
-                                  "json": "updatedAt"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "socials": {
-                                "type": "array",
-                                "description": "Various online profiles associated with the user account",
-                                "x-go-type": "UserSocials",
-                                "items": {
-                                  "x-go-type": "Social",
-                                  "description": "Various online profiles associated with the user account, like GitHub, LinkedIn, X, and so on.",
-                                  "type": "object",
-                                  "properties": {
-                                    "site": {
-                                      "type": "string",
-                                      "maxLength": 50,
-                                      "description": "The site of the social."
-                                    },
-                                    "link": {
-                                      "type": "string",
-                                      "format": "uri",
-                                      "description": "The link of the social."
-                                    }
-                                  },
-                                  "required": [
-                                    "site",
-                                    "link"
-                                  ]
-                                },
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "socials",
-                                  "json": "socials"
-                                }
-                              },
-                              "deletedAt": {
-                                "type": "string",
-                                "format": "date-time",
-                                "nullable": true,
-                                "description": "Timestamp when the user record was soft-deleted (null if not deleted)",
-                                "x-go-type": "core.NullTime",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "deleted_at",
-                                  "json": "deletedAt"
-                                }
-                              },
-                              "roleNames": {
-                                "type": "array",
-                                "x-go-type": "pq.StringArray",
-                                "x-go-type-import": {
-                                  "path": "github.com/lib/pq"
-                                },
-                                "x-go-type-skip-optional-pointer": true,
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
-                                "example": [
-                                  "organization admin",
-                                  "user"
-                                ],
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "role_names",
-                                  "json": "roleNames"
-                                }
-                              },
-                              "teams": {
-                                "type": "object",
-                                "description": "Teams the user belongs to with role information",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "teams",
-                                  "json": "teams"
-                                },
-                                "properties": {
-                                  "teamsWithRoles": {
-                                    "type": "array",
-                                    "description": "Team memberships for the user with their assigned roles.",
-                                    "items": {
-                                      "type": "object",
-                                      "additionalProperties": false,
-                                      "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                                      "required": [
-                                        "id",
-                                        "name",
-                                        "roleNames"
-                                      ],
-                                      "properties": {
-                                        "id": {
-                                          "description": "Unique identifier of the team.",
-                                          "x-go-name": "ID",
-                                          "x-order": 1,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "id",
-                                            "json": "id,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "uuid",
-                                          "x-go-type": "uuid.UUID",
-                                          "x-go-type-import": {
-                                            "path": "github.com/gofrs/uuid"
-                                          }
-                                        },
-                                        "name": {
-                                          "type": "string",
-                                          "description": "Name of the team.",
-                                          "x-order": 2,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "name",
-                                            "json": "name,omitempty"
-                                          }
-                                        },
-                                        "description": {
-                                          "type": "string",
-                                          "description": "Human readable description of the team.",
-                                          "x-order": 3,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "description",
-                                            "json": "description,omitempty"
-                                          }
-                                        },
-                                        "owner": {
-                                          "description": "Identifier of the team owner.",
-                                          "x-order": 4,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "owner",
-                                            "json": "owner,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "uuid",
-                                          "x-go-type": "uuid.UUID",
-                                          "x-go-type-import": {
-                                            "path": "github.com/gofrs/uuid"
-                                          }
-                                        },
-                                        "metadata": {
-                                          "type": "object",
-                                          "additionalProperties": true,
-                                          "description": "Free-form metadata associated with the team.",
-                                          "x-go-type": "core.Map",
-                                          "x-go-type-skip-optional-pointer": true,
-                                          "x-order": 5,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "metadata",
-                                            "json": "metadata,omitempty"
-                                          }
-                                        },
-                                        "createdAt": {
-                                          "description": "Timestamp when the team was created.",
-                                          "x-order": 6,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "created_at",
-                                            "json": "createdAt,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "date-time",
-                                          "x-go-type-skip-optional-pointer": true
-                                        },
-                                        "updatedAt": {
-                                          "description": "Timestamp when the team was last updated.",
-                                          "x-order": 7,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "updated_at",
-                                            "json": "updatedAt,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "date-time",
-                                          "x-go-type-skip-optional-pointer": true
-                                        },
-                                        "deletedAt": {
-                                          "type": "string",
-                                          "format": "date-time",
-                                          "nullable": true,
-                                          "description": "Timestamp when the team was soft-deleted (null if not deleted).",
-                                          "x-go-type": "core.NullTime",
-                                          "x-order": 8,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "deleted_at",
-                                            "json": "deletedAt,omitempty"
-                                          }
-                                        },
-                                        "roleNames": {
-                                          "type": "array",
-                                          "x-go-type": "pq.StringArray",
-                                          "x-go-type-import": {
-                                            "path": "github.com/lib/pq"
-                                          },
-                                          "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
-                                          "items": {
-                                            "type": "string"
-                                          },
-                                          "x-order": 9,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "role_names",
-                                            "json": "roleNames"
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "teams_with_roles",
-                                      "json": "teamsWithRoles"
-                                    }
-                                  },
-                                  "totalCount": {
-                                    "type": "integer",
-                                    "description": "Total number of team memberships returned for the user.",
-                                    "minimum": 0,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "total_count",
-                                      "json": "totalCount"
-                                    }
-                                  }
-                                }
-                              },
-                              "organizations": {
-                                "type": "object",
-                                "description": "Organizations the user belongs to with role information",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "organizations",
-                                  "json": "organizations"
-                                },
-                                "properties": {
-                                  "organizationsWithRoles": {
-                                    "type": "array",
-                                    "description": "Organization memberships for the user with their assigned roles.",
-                                    "items": {
-                                      "type": "object",
-                                      "additionalProperties": false,
-                                      "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                                      "required": [
-                                        "id",
-                                        "name",
-                                        "roleNames"
-                                      ],
-                                      "properties": {
-                                        "id": {
-                                          "description": "Unique identifier of the organization.",
-                                          "x-go-name": "ID",
-                                          "x-order": 1,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "id",
-                                            "json": "id,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "uuid",
-                                          "x-go-type": "uuid.UUID",
-                                          "x-go-type-import": {
-                                            "path": "github.com/gofrs/uuid"
-                                          }
-                                        },
-                                        "name": {
-                                          "type": "string",
-                                          "description": "Name of the organization.",
-                                          "x-order": 2,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "name",
-                                            "json": "name,omitempty"
-                                          }
-                                        },
-                                        "description": {
-                                          "type": "string",
-                                          "description": "Human readable description of the organization.",
-                                          "x-order": 3,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "description",
-                                            "json": "description,omitempty"
-                                          }
-                                        },
-                                        "country": {
-                                          "type": "string",
-                                          "description": "Country associated with the organization.",
-                                          "x-order": 4,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "country",
-                                            "json": "country,omitempty"
-                                          }
-                                        },
-                                        "region": {
-                                          "type": "string",
-                                          "description": "Region associated with the organization.",
-                                          "x-order": 5,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "region",
-                                            "json": "region,omitempty"
-                                          }
-                                        },
-                                        "owner": {
-                                          "description": "Identifier of the organization owner.",
-                                          "x-order": 6,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "owner",
-                                            "json": "owner,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "uuid",
-                                          "x-go-type": "uuid.UUID",
-                                          "x-go-type-import": {
-                                            "path": "github.com/gofrs/uuid"
-                                          }
-                                        },
-                                        "createdAt": {
-                                          "description": "Timestamp when the organization was created.",
-                                          "x-order": 7,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "created_at",
-                                            "json": "createdAt,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "date-time",
-                                          "x-go-type-skip-optional-pointer": true
-                                        },
-                                        "updatedAt": {
-                                          "description": "Timestamp when the organization was last updated.",
-                                          "x-order": 8,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "updated_at",
-                                            "json": "updatedAt,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "date-time",
-                                          "x-go-type-skip-optional-pointer": true
-                                        },
-                                        "deletedAt": {
-                                          "type": "string",
-                                          "format": "date-time",
-                                          "nullable": true,
-                                          "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
-                                          "x-go-type": "core.NullTime",
-                                          "x-order": 9,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "deleted_at",
-                                            "json": "deletedAt,omitempty"
-                                          }
-                                        },
-                                        "roleNames": {
-                                          "type": "array",
-                                          "x-go-type": "pq.StringArray",
-                                          "x-go-type-import": {
-                                            "path": "github.com/lib/pq"
-                                          },
-                                          "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
-                                          "items": {
-                                            "type": "string"
-                                          },
-                                          "x-order": 10,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "role_names",
-                                            "json": "roleNames"
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "organizations_with_roles",
-                                      "json": "organizationsWithRoles"
-                                    }
-                                  },
-                                  "totalCount": {
-                                    "type": "integer",
-                                    "description": "Total number of organization memberships returned for the user.",
-                                    "minimum": 0,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "total_count",
-                                      "json": "totalCount"
-                                    }
-                                  }
+                                  "json": "avatarUrl,omitempty"
                                 }
                               }
-                            },
-                            "additionalProperties": false
+                            }
                           },
                           "location": {
                             "description": "Optional structured location metadata (branch, host, path, ...).",
@@ -1547,33 +874,20 @@ const DesignSchema: Record<string, unknown> = {
                       "x-go-type-skip-optional-pointer": true
                     },
                     "user": {
-                      "description": "Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
+                      "description": "Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
                       "nullable": true,
-                      "x-go-type": "*userV1beta.User",
-                      "x-go-type-import": {
-                        "path": "github.com/meshery/schemas/models/v1beta2/user",
-                        "name": "userV1beta"
-                      },
+                      "x-go-type": "*CatalogAuthor",
                       "x-oapi-codegen-extra-tags": {
                         "db": "-"
                       },
                       "type": "object",
+                      "additionalProperties": false,
                       "required": [
-                        "id",
-                        "userId",
-                        "provider",
-                        "email",
-                        "firstName",
-                        "lastName",
-                        "status",
-                        "createdAt",
-                        "updatedAt",
-                        "lastLoginTime",
-                        "deletedAt"
+                        "id"
                       ],
                       "properties": {
                         "id": {
-                          "description": "Unique identifier for the user",
+                          "description": "Unique identifier for the user.",
                           "x-go-name": "ID",
                           "x-oapi-codegen-extra-tags": {
                             "db": "id",
@@ -1587,712 +901,52 @@ const DesignSchema: Record<string, unknown> = {
                           }
                         },
                         "userId": {
-                          "type": "string",
-                          "maxLength": 200,
                           "deprecated": true,
-                          "description": "Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.",
+                          "description": "Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.",
+                          "x-go-name": "UserID",
                           "x-oapi-codegen-extra-tags": {
                             "db": "user_id",
-                            "json": "userId"
+                            "json": "userId,omitempty"
                           },
-                          "x-id-format": "external"
-                        },
-                        "provider": {
                           "type": "string",
-                          "maxLength": 100,
-                          "description": "Authentication provider (e.g., Google, Github)",
-                          "example": [
-                            "local",
-                            "github",
-                            "google",
-                            "twitter"
-                          ],
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "provider",
-                            "json": "provider"
-                          }
-                        },
-                        "email": {
-                          "type": "string",
-                          "format": "email",
-                          "maxLength": 300,
-                          "description": "User's email address",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "email",
-                            "json": "email"
+                          "format": "uuid",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
                           }
                         },
                         "firstName": {
                           "type": "string",
                           "maxLength": 200,
-                          "description": "User's first name",
+                          "description": "User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                          "x-go-type-skip-optional-pointer": true,
                           "x-oapi-codegen-extra-tags": {
                             "db": "first_name",
-                            "json": "firstName"
+                            "json": "firstName,omitempty"
                           }
                         },
                         "lastName": {
                           "type": "string",
                           "maxLength": 300,
-                          "description": "User's last name",
+                          "description": "User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                          "x-go-type-skip-optional-pointer": true,
                           "x-oapi-codegen-extra-tags": {
                             "db": "last_name",
-                            "json": "lastName"
+                            "json": "lastName,omitempty"
                           }
                         },
                         "avatarUrl": {
                           "type": "string",
                           "format": "uri",
                           "maxLength": 500,
-                          "description": "URL to user's avatar image",
+                          "description": "URL to the user's avatar image.",
+                          "x-go-type-skip-optional-pointer": true,
                           "x-oapi-codegen-extra-tags": {
                             "db": "avatar_url",
-                            "json": "avatarUrl"
-                          }
-                        },
-                        "status": {
-                          "type": "string",
-                          "maxLength": 100,
-                          "enum": [
-                            "active",
-                            "inactive",
-                            "pending",
-                            "anonymous"
-                          ],
-                          "description": "User account status",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "status",
-                            "json": "status"
-                          }
-                        },
-                        "bio": {
-                          "type": "string",
-                          "maxLength": 1000,
-                          "default": "",
-                          "description": "User's biography or description",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "bio",
-                            "json": "bio"
-                          }
-                        },
-                        "country": {
-                          "type": "object",
-                          "description": "User's country information stored as JSONB",
-                          "additionalProperties": true,
-                          "x-go-type": "core.Map",
-                          "x-go-type-skip-optional-pointer": true,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "country",
-                            "json": "country"
-                          }
-                        },
-                        "region": {
-                          "type": "object",
-                          "description": "User's region information stored as JSONB",
-                          "additionalProperties": true,
-                          "x-go-type": "core.Map",
-                          "x-go-type-skip-optional-pointer": true,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "region",
-                            "json": "region"
-                          }
-                        },
-                        "preferences": {
-                          "x-go-type": "Preference",
-                          "description": "User preferences stored as JSONB",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "preferences",
-                            "json": "preferences"
-                          },
-                          "x-generate-db-helpers": true,
-                          "type": "object",
-                          "required": [
-                            "anonymousUsageStats",
-                            "anonymousPerfResults",
-                            "updatedAt",
-                            "dashboardPreferences",
-                            "selectedOrganizationId",
-                            "selectedWorkspaceForOrganizations",
-                            "usersExtensionPreferences",
-                            "remoteProviderPreferences"
-                          ],
-                          "properties": {
-                            "meshAdapters": {
-                              "type": "array",
-                              "items": {
-                                "x-go-type": "Adapter",
-                                "type": "object",
-                                "description": "Placeholder for Adapter struct definition."
-                              },
-                              "description": "The mesh adapters of the preference."
-                            },
-                            "grafana": {
-                              "x-go-type": "Grafana",
-                              "type": "object",
-                              "properties": {
-                                "grafanaUrl": {
-                                  "type": "string",
-                                  "description": "Grafana URL for the user configuration.",
-                                  "maxLength": 500
-                                },
-                                "grafanaApiKey": {
-                                  "type": "string",
-                                  "description": "Grafana API key for the user configuration.",
-                                  "maxLength": 500
-                                },
-                                "selectedBoardsConfigs": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "board": {
-                                        "type": "object",
-                                        "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                      },
-                                      "panels": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                        },
-                                        "description": "Panels selected for the Grafana board configuration."
-                                      },
-                                      "templateVars": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "description": "Template variables applied to the selected Grafana board configuration."
-                                      }
-                                    }
-                                  },
-                                  "description": "Selected Grafana board configurations for the user."
-                                }
-                              }
-                            },
-                            "prometheus": {
-                              "x-go-type": "Prometheus",
-                              "type": "object",
-                              "properties": {
-                                "prometheusUrl": {
-                                  "type": "string",
-                                  "description": "The prometheus URL of the prometheus.",
-                                  "maxLength": 500
-                                },
-                                "selectedPrometheusBoardsConfigs": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "board": {
-                                        "type": "object",
-                                        "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                      },
-                                      "panels": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                        },
-                                        "description": "Panels selected for the Grafana board configuration."
-                                      },
-                                      "templateVars": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "description": "Template variables applied to the selected Grafana board configuration."
-                                      }
-                                    }
-                                  },
-                                  "description": "The selected prometheus boards configs of the prometheus."
-                                }
-                              }
-                            },
-                            "loadTestPrefs": {
-                              "x-go-type": "LoadTestPreferences",
-                              "type": "object",
-                              "properties": {
-                                "c": {
-                                  "type": "integer",
-                                  "description": "Concurrent requests",
-                                  "minimum": 0
-                                },
-                                "qps": {
-                                  "type": "integer",
-                                  "description": "Queries per second",
-                                  "minimum": 0
-                                },
-                                "t": {
-                                  "type": "string",
-                                  "description": "Duration",
-                                  "maxLength": 500
-                                },
-                                "gen": {
-                                  "type": "string",
-                                  "description": "Load generator",
-                                  "maxLength": 500
-                                }
-                              }
-                            },
-                            "anonymousUsageStats": {
-                              "type": "boolean",
-                              "description": "The anonymous usage stats of the preference."
-                            },
-                            "anonymousPerfResults": {
-                              "type": "boolean",
-                              "description": "The anonymous perf results of the preference."
-                            },
-                            "updatedAt": {
-                              "type": "string",
-                              "format": "date-time",
-                              "description": "Timestamp of when the resource was last updated."
-                            },
-                            "dashboardPreferences": {
-                              "type": "object",
-                              "additionalProperties": true,
-                              "description": "The dashboard preferences of the preference."
-                            },
-                            "selectedOrganizationId": {
-                              "type": "string",
-                              "description": "ID of the associated selectedOrganization.",
-                              "maxLength": 500,
-                              "format": "uuid"
-                            },
-                            "selectedWorkspaceForOrganizations": {
-                              "type": "object",
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "The selected workspace for organizations of the preference."
-                            },
-                            "usersExtensionPreferences": {
-                              "type": "object",
-                              "additionalProperties": true,
-                              "description": "The users extension preferences of the preference."
-                            },
-                            "remoteProviderPreferences": {
-                              "type": "object",
-                              "additionalProperties": true,
-                              "description": "The remote provider preferences of the preference."
-                            }
-                          }
-                        },
-                        "acceptedTermsAt": {
-                          "description": "Timestamp when user accepted terms and conditions",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "accepted_terms_at",
-                            "json": "acceptedTermsAt"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "firstLoginTime": {
-                          "description": "Timestamp of user's first login",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "first_login_time",
-                            "json": "firstLoginTime"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "lastLoginTime": {
-                          "description": "Timestamp of user's most recent login",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "last_login_time",
-                            "json": "lastLoginTime"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "createdAt": {
-                          "description": "Timestamp when the user record was created",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "created_at",
-                            "json": "createdAt"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "updatedAt": {
-                          "description": "Timestamp when the user record was last updated",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "updated_at",
-                            "json": "updatedAt"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "socials": {
-                          "type": "array",
-                          "description": "Various online profiles associated with the user account",
-                          "x-go-type": "UserSocials",
-                          "items": {
-                            "x-go-type": "Social",
-                            "description": "Various online profiles associated with the user account, like GitHub, LinkedIn, X, and so on.",
-                            "type": "object",
-                            "properties": {
-                              "site": {
-                                "type": "string",
-                                "maxLength": 50,
-                                "description": "The site of the social."
-                              },
-                              "link": {
-                                "type": "string",
-                                "format": "uri",
-                                "description": "The link of the social."
-                              }
-                            },
-                            "required": [
-                              "site",
-                              "link"
-                            ]
-                          },
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "socials",
-                            "json": "socials"
-                          }
-                        },
-                        "deletedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "nullable": true,
-                          "description": "Timestamp when the user record was soft-deleted (null if not deleted)",
-                          "x-go-type": "core.NullTime",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "deleted_at",
-                            "json": "deletedAt"
-                          }
-                        },
-                        "roleNames": {
-                          "type": "array",
-                          "x-go-type": "pq.StringArray",
-                          "x-go-type-import": {
-                            "path": "github.com/lib/pq"
-                          },
-                          "x-go-type-skip-optional-pointer": true,
-                          "items": {
-                            "type": "string"
-                          },
-                          "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
-                          "example": [
-                            "organization admin",
-                            "user"
-                          ],
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "role_names",
-                            "json": "roleNames"
-                          }
-                        },
-                        "teams": {
-                          "type": "object",
-                          "description": "Teams the user belongs to with role information",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "teams",
-                            "json": "teams"
-                          },
-                          "properties": {
-                            "teamsWithRoles": {
-                              "type": "array",
-                              "description": "Team memberships for the user with their assigned roles.",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                                "required": [
-                                  "id",
-                                  "name",
-                                  "roleNames"
-                                ],
-                                "properties": {
-                                  "id": {
-                                    "description": "Unique identifier of the team.",
-                                    "x-go-name": "ID",
-                                    "x-order": 1,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "id",
-                                      "json": "id,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
-                                    }
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "Name of the team.",
-                                    "x-order": 2,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "name",
-                                      "json": "name,omitempty"
-                                    }
-                                  },
-                                  "description": {
-                                    "type": "string",
-                                    "description": "Human readable description of the team.",
-                                    "x-order": 3,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "description",
-                                      "json": "description,omitempty"
-                                    }
-                                  },
-                                  "owner": {
-                                    "description": "Identifier of the team owner.",
-                                    "x-order": 4,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "owner",
-                                      "json": "owner,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
-                                    }
-                                  },
-                                  "metadata": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "description": "Free-form metadata associated with the team.",
-                                    "x-go-type": "core.Map",
-                                    "x-go-type-skip-optional-pointer": true,
-                                    "x-order": 5,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "metadata",
-                                      "json": "metadata,omitempty"
-                                    }
-                                  },
-                                  "createdAt": {
-                                    "description": "Timestamp when the team was created.",
-                                    "x-order": 6,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "created_at",
-                                      "json": "createdAt,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "x-go-type-skip-optional-pointer": true
-                                  },
-                                  "updatedAt": {
-                                    "description": "Timestamp when the team was last updated.",
-                                    "x-order": 7,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "updated_at",
-                                      "json": "updatedAt,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "x-go-type-skip-optional-pointer": true
-                                  },
-                                  "deletedAt": {
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "nullable": true,
-                                    "description": "Timestamp when the team was soft-deleted (null if not deleted).",
-                                    "x-go-type": "core.NullTime",
-                                    "x-order": 8,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "deleted_at",
-                                      "json": "deletedAt,omitempty"
-                                    }
-                                  },
-                                  "roleNames": {
-                                    "type": "array",
-                                    "x-go-type": "pq.StringArray",
-                                    "x-go-type-import": {
-                                      "path": "github.com/lib/pq"
-                                    },
-                                    "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "x-order": 9,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "role_names",
-                                      "json": "roleNames"
-                                    }
-                                  }
-                                }
-                              },
-                              "x-oapi-codegen-extra-tags": {
-                                "db": "teams_with_roles",
-                                "json": "teamsWithRoles"
-                              }
-                            },
-                            "totalCount": {
-                              "type": "integer",
-                              "description": "Total number of team memberships returned for the user.",
-                              "minimum": 0,
-                              "x-oapi-codegen-extra-tags": {
-                                "db": "total_count",
-                                "json": "totalCount"
-                              }
-                            }
-                          }
-                        },
-                        "organizations": {
-                          "type": "object",
-                          "description": "Organizations the user belongs to with role information",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "organizations",
-                            "json": "organizations"
-                          },
-                          "properties": {
-                            "organizationsWithRoles": {
-                              "type": "array",
-                              "description": "Organization memberships for the user with their assigned roles.",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                                "required": [
-                                  "id",
-                                  "name",
-                                  "roleNames"
-                                ],
-                                "properties": {
-                                  "id": {
-                                    "description": "Unique identifier of the organization.",
-                                    "x-go-name": "ID",
-                                    "x-order": 1,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "id",
-                                      "json": "id,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
-                                    }
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "Name of the organization.",
-                                    "x-order": 2,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "name",
-                                      "json": "name,omitempty"
-                                    }
-                                  },
-                                  "description": {
-                                    "type": "string",
-                                    "description": "Human readable description of the organization.",
-                                    "x-order": 3,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "description",
-                                      "json": "description,omitempty"
-                                    }
-                                  },
-                                  "country": {
-                                    "type": "string",
-                                    "description": "Country associated with the organization.",
-                                    "x-order": 4,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "country",
-                                      "json": "country,omitempty"
-                                    }
-                                  },
-                                  "region": {
-                                    "type": "string",
-                                    "description": "Region associated with the organization.",
-                                    "x-order": 5,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "region",
-                                      "json": "region,omitempty"
-                                    }
-                                  },
-                                  "owner": {
-                                    "description": "Identifier of the organization owner.",
-                                    "x-order": 6,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "owner",
-                                      "json": "owner,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
-                                    }
-                                  },
-                                  "createdAt": {
-                                    "description": "Timestamp when the organization was created.",
-                                    "x-order": 7,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "created_at",
-                                      "json": "createdAt,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "x-go-type-skip-optional-pointer": true
-                                  },
-                                  "updatedAt": {
-                                    "description": "Timestamp when the organization was last updated.",
-                                    "x-order": 8,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "updated_at",
-                                      "json": "updatedAt,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "x-go-type-skip-optional-pointer": true
-                                  },
-                                  "deletedAt": {
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "nullable": true,
-                                    "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
-                                    "x-go-type": "core.NullTime",
-                                    "x-order": 9,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "deleted_at",
-                                      "json": "deletedAt,omitempty"
-                                    }
-                                  },
-                                  "roleNames": {
-                                    "type": "array",
-                                    "x-go-type": "pq.StringArray",
-                                    "x-go-type-import": {
-                                      "path": "github.com/lib/pq"
-                                    },
-                                    "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "x-order": 10,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "role_names",
-                                      "json": "roleNames"
-                                    }
-                                  }
-                                }
-                              },
-                              "x-oapi-codegen-extra-tags": {
-                                "db": "organizations_with_roles",
-                                "json": "organizationsWithRoles"
-                              }
-                            },
-                            "totalCount": {
-                              "type": "integer",
-                              "description": "Total number of organization memberships returned for the user.",
-                              "minimum": 0,
-                              "x-oapi-codegen-extra-tags": {
-                                "db": "total_count",
-                                "json": "totalCount"
-                              }
-                            }
+                            "json": "avatarUrl,omitempty"
                           }
                         }
-                      },
-                      "additionalProperties": false
+                      }
                     },
                     "location": {
                       "description": "Optional structured location metadata (branch, host, path, ...).",
@@ -2710,33 +1364,20 @@ const DesignSchema: Record<string, unknown> = {
                       "x-go-type-skip-optional-pointer": true
                     },
                     "user": {
-                      "description": "Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
+                      "description": "Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
                       "nullable": true,
-                      "x-go-type": "*userV1beta.User",
-                      "x-go-type-import": {
-                        "path": "github.com/meshery/schemas/models/v1beta2/user",
-                        "name": "userV1beta"
-                      },
+                      "x-go-type": "*CatalogAuthor",
                       "x-oapi-codegen-extra-tags": {
                         "db": "-"
                       },
                       "type": "object",
+                      "additionalProperties": false,
                       "required": [
-                        "id",
-                        "userId",
-                        "provider",
-                        "email",
-                        "firstName",
-                        "lastName",
-                        "status",
-                        "createdAt",
-                        "updatedAt",
-                        "lastLoginTime",
-                        "deletedAt"
+                        "id"
                       ],
                       "properties": {
                         "id": {
-                          "description": "Unique identifier for the user",
+                          "description": "Unique identifier for the user.",
                           "x-go-name": "ID",
                           "x-oapi-codegen-extra-tags": {
                             "db": "id",
@@ -2750,712 +1391,52 @@ const DesignSchema: Record<string, unknown> = {
                           }
                         },
                         "userId": {
-                          "type": "string",
-                          "maxLength": 200,
                           "deprecated": true,
-                          "description": "Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.",
+                          "description": "Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.",
+                          "x-go-name": "UserID",
                           "x-oapi-codegen-extra-tags": {
                             "db": "user_id",
-                            "json": "userId"
+                            "json": "userId,omitempty"
                           },
-                          "x-id-format": "external"
-                        },
-                        "provider": {
                           "type": "string",
-                          "maxLength": 100,
-                          "description": "Authentication provider (e.g., Google, Github)",
-                          "example": [
-                            "local",
-                            "github",
-                            "google",
-                            "twitter"
-                          ],
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "provider",
-                            "json": "provider"
-                          }
-                        },
-                        "email": {
-                          "type": "string",
-                          "format": "email",
-                          "maxLength": 300,
-                          "description": "User's email address",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "email",
-                            "json": "email"
+                          "format": "uuid",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
                           }
                         },
                         "firstName": {
                           "type": "string",
                           "maxLength": 200,
-                          "description": "User's first name",
+                          "description": "User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                          "x-go-type-skip-optional-pointer": true,
                           "x-oapi-codegen-extra-tags": {
                             "db": "first_name",
-                            "json": "firstName"
+                            "json": "firstName,omitempty"
                           }
                         },
                         "lastName": {
                           "type": "string",
                           "maxLength": 300,
-                          "description": "User's last name",
+                          "description": "User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                          "x-go-type-skip-optional-pointer": true,
                           "x-oapi-codegen-extra-tags": {
                             "db": "last_name",
-                            "json": "lastName"
+                            "json": "lastName,omitempty"
                           }
                         },
                         "avatarUrl": {
                           "type": "string",
                           "format": "uri",
                           "maxLength": 500,
-                          "description": "URL to user's avatar image",
+                          "description": "URL to the user's avatar image.",
+                          "x-go-type-skip-optional-pointer": true,
                           "x-oapi-codegen-extra-tags": {
                             "db": "avatar_url",
-                            "json": "avatarUrl"
-                          }
-                        },
-                        "status": {
-                          "type": "string",
-                          "maxLength": 100,
-                          "enum": [
-                            "active",
-                            "inactive",
-                            "pending",
-                            "anonymous"
-                          ],
-                          "description": "User account status",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "status",
-                            "json": "status"
-                          }
-                        },
-                        "bio": {
-                          "type": "string",
-                          "maxLength": 1000,
-                          "default": "",
-                          "description": "User's biography or description",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "bio",
-                            "json": "bio"
-                          }
-                        },
-                        "country": {
-                          "type": "object",
-                          "description": "User's country information stored as JSONB",
-                          "additionalProperties": true,
-                          "x-go-type": "core.Map",
-                          "x-go-type-skip-optional-pointer": true,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "country",
-                            "json": "country"
-                          }
-                        },
-                        "region": {
-                          "type": "object",
-                          "description": "User's region information stored as JSONB",
-                          "additionalProperties": true,
-                          "x-go-type": "core.Map",
-                          "x-go-type-skip-optional-pointer": true,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "region",
-                            "json": "region"
-                          }
-                        },
-                        "preferences": {
-                          "x-go-type": "Preference",
-                          "description": "User preferences stored as JSONB",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "preferences",
-                            "json": "preferences"
-                          },
-                          "x-generate-db-helpers": true,
-                          "type": "object",
-                          "required": [
-                            "anonymousUsageStats",
-                            "anonymousPerfResults",
-                            "updatedAt",
-                            "dashboardPreferences",
-                            "selectedOrganizationId",
-                            "selectedWorkspaceForOrganizations",
-                            "usersExtensionPreferences",
-                            "remoteProviderPreferences"
-                          ],
-                          "properties": {
-                            "meshAdapters": {
-                              "type": "array",
-                              "items": {
-                                "x-go-type": "Adapter",
-                                "type": "object",
-                                "description": "Placeholder for Adapter struct definition."
-                              },
-                              "description": "The mesh adapters of the preference."
-                            },
-                            "grafana": {
-                              "x-go-type": "Grafana",
-                              "type": "object",
-                              "properties": {
-                                "grafanaUrl": {
-                                  "type": "string",
-                                  "description": "Grafana URL for the user configuration.",
-                                  "maxLength": 500
-                                },
-                                "grafanaApiKey": {
-                                  "type": "string",
-                                  "description": "Grafana API key for the user configuration.",
-                                  "maxLength": 500
-                                },
-                                "selectedBoardsConfigs": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "board": {
-                                        "type": "object",
-                                        "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                      },
-                                      "panels": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                        },
-                                        "description": "Panels selected for the Grafana board configuration."
-                                      },
-                                      "templateVars": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "description": "Template variables applied to the selected Grafana board configuration."
-                                      }
-                                    }
-                                  },
-                                  "description": "Selected Grafana board configurations for the user."
-                                }
-                              }
-                            },
-                            "prometheus": {
-                              "x-go-type": "Prometheus",
-                              "type": "object",
-                              "properties": {
-                                "prometheusUrl": {
-                                  "type": "string",
-                                  "description": "The prometheus URL of the prometheus.",
-                                  "maxLength": 500
-                                },
-                                "selectedPrometheusBoardsConfigs": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "board": {
-                                        "type": "object",
-                                        "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                      },
-                                      "panels": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                        },
-                                        "description": "Panels selected for the Grafana board configuration."
-                                      },
-                                      "templateVars": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "description": "Template variables applied to the selected Grafana board configuration."
-                                      }
-                                    }
-                                  },
-                                  "description": "The selected prometheus boards configs of the prometheus."
-                                }
-                              }
-                            },
-                            "loadTestPrefs": {
-                              "x-go-type": "LoadTestPreferences",
-                              "type": "object",
-                              "properties": {
-                                "c": {
-                                  "type": "integer",
-                                  "description": "Concurrent requests",
-                                  "minimum": 0
-                                },
-                                "qps": {
-                                  "type": "integer",
-                                  "description": "Queries per second",
-                                  "minimum": 0
-                                },
-                                "t": {
-                                  "type": "string",
-                                  "description": "Duration",
-                                  "maxLength": 500
-                                },
-                                "gen": {
-                                  "type": "string",
-                                  "description": "Load generator",
-                                  "maxLength": 500
-                                }
-                              }
-                            },
-                            "anonymousUsageStats": {
-                              "type": "boolean",
-                              "description": "The anonymous usage stats of the preference."
-                            },
-                            "anonymousPerfResults": {
-                              "type": "boolean",
-                              "description": "The anonymous perf results of the preference."
-                            },
-                            "updatedAt": {
-                              "type": "string",
-                              "format": "date-time",
-                              "description": "Timestamp of when the resource was last updated."
-                            },
-                            "dashboardPreferences": {
-                              "type": "object",
-                              "additionalProperties": true,
-                              "description": "The dashboard preferences of the preference."
-                            },
-                            "selectedOrganizationId": {
-                              "type": "string",
-                              "description": "ID of the associated selectedOrganization.",
-                              "maxLength": 500,
-                              "format": "uuid"
-                            },
-                            "selectedWorkspaceForOrganizations": {
-                              "type": "object",
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "The selected workspace for organizations of the preference."
-                            },
-                            "usersExtensionPreferences": {
-                              "type": "object",
-                              "additionalProperties": true,
-                              "description": "The users extension preferences of the preference."
-                            },
-                            "remoteProviderPreferences": {
-                              "type": "object",
-                              "additionalProperties": true,
-                              "description": "The remote provider preferences of the preference."
-                            }
-                          }
-                        },
-                        "acceptedTermsAt": {
-                          "description": "Timestamp when user accepted terms and conditions",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "accepted_terms_at",
-                            "json": "acceptedTermsAt"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "firstLoginTime": {
-                          "description": "Timestamp of user's first login",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "first_login_time",
-                            "json": "firstLoginTime"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "lastLoginTime": {
-                          "description": "Timestamp of user's most recent login",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "last_login_time",
-                            "json": "lastLoginTime"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "createdAt": {
-                          "description": "Timestamp when the user record was created",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "created_at",
-                            "json": "createdAt"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "updatedAt": {
-                          "description": "Timestamp when the user record was last updated",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "updated_at",
-                            "json": "updatedAt"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "socials": {
-                          "type": "array",
-                          "description": "Various online profiles associated with the user account",
-                          "x-go-type": "UserSocials",
-                          "items": {
-                            "x-go-type": "Social",
-                            "description": "Various online profiles associated with the user account, like GitHub, LinkedIn, X, and so on.",
-                            "type": "object",
-                            "properties": {
-                              "site": {
-                                "type": "string",
-                                "maxLength": 50,
-                                "description": "The site of the social."
-                              },
-                              "link": {
-                                "type": "string",
-                                "format": "uri",
-                                "description": "The link of the social."
-                              }
-                            },
-                            "required": [
-                              "site",
-                              "link"
-                            ]
-                          },
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "socials",
-                            "json": "socials"
-                          }
-                        },
-                        "deletedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "nullable": true,
-                          "description": "Timestamp when the user record was soft-deleted (null if not deleted)",
-                          "x-go-type": "core.NullTime",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "deleted_at",
-                            "json": "deletedAt"
-                          }
-                        },
-                        "roleNames": {
-                          "type": "array",
-                          "x-go-type": "pq.StringArray",
-                          "x-go-type-import": {
-                            "path": "github.com/lib/pq"
-                          },
-                          "x-go-type-skip-optional-pointer": true,
-                          "items": {
-                            "type": "string"
-                          },
-                          "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
-                          "example": [
-                            "organization admin",
-                            "user"
-                          ],
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "role_names",
-                            "json": "roleNames"
-                          }
-                        },
-                        "teams": {
-                          "type": "object",
-                          "description": "Teams the user belongs to with role information",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "teams",
-                            "json": "teams"
-                          },
-                          "properties": {
-                            "teamsWithRoles": {
-                              "type": "array",
-                              "description": "Team memberships for the user with their assigned roles.",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                                "required": [
-                                  "id",
-                                  "name",
-                                  "roleNames"
-                                ],
-                                "properties": {
-                                  "id": {
-                                    "description": "Unique identifier of the team.",
-                                    "x-go-name": "ID",
-                                    "x-order": 1,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "id",
-                                      "json": "id,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
-                                    }
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "Name of the team.",
-                                    "x-order": 2,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "name",
-                                      "json": "name,omitempty"
-                                    }
-                                  },
-                                  "description": {
-                                    "type": "string",
-                                    "description": "Human readable description of the team.",
-                                    "x-order": 3,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "description",
-                                      "json": "description,omitempty"
-                                    }
-                                  },
-                                  "owner": {
-                                    "description": "Identifier of the team owner.",
-                                    "x-order": 4,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "owner",
-                                      "json": "owner,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
-                                    }
-                                  },
-                                  "metadata": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "description": "Free-form metadata associated with the team.",
-                                    "x-go-type": "core.Map",
-                                    "x-go-type-skip-optional-pointer": true,
-                                    "x-order": 5,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "metadata",
-                                      "json": "metadata,omitempty"
-                                    }
-                                  },
-                                  "createdAt": {
-                                    "description": "Timestamp when the team was created.",
-                                    "x-order": 6,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "created_at",
-                                      "json": "createdAt,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "x-go-type-skip-optional-pointer": true
-                                  },
-                                  "updatedAt": {
-                                    "description": "Timestamp when the team was last updated.",
-                                    "x-order": 7,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "updated_at",
-                                      "json": "updatedAt,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "x-go-type-skip-optional-pointer": true
-                                  },
-                                  "deletedAt": {
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "nullable": true,
-                                    "description": "Timestamp when the team was soft-deleted (null if not deleted).",
-                                    "x-go-type": "core.NullTime",
-                                    "x-order": 8,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "deleted_at",
-                                      "json": "deletedAt,omitempty"
-                                    }
-                                  },
-                                  "roleNames": {
-                                    "type": "array",
-                                    "x-go-type": "pq.StringArray",
-                                    "x-go-type-import": {
-                                      "path": "github.com/lib/pq"
-                                    },
-                                    "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "x-order": 9,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "role_names",
-                                      "json": "roleNames"
-                                    }
-                                  }
-                                }
-                              },
-                              "x-oapi-codegen-extra-tags": {
-                                "db": "teams_with_roles",
-                                "json": "teamsWithRoles"
-                              }
-                            },
-                            "totalCount": {
-                              "type": "integer",
-                              "description": "Total number of team memberships returned for the user.",
-                              "minimum": 0,
-                              "x-oapi-codegen-extra-tags": {
-                                "db": "total_count",
-                                "json": "totalCount"
-                              }
-                            }
-                          }
-                        },
-                        "organizations": {
-                          "type": "object",
-                          "description": "Organizations the user belongs to with role information",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "organizations",
-                            "json": "organizations"
-                          },
-                          "properties": {
-                            "organizationsWithRoles": {
-                              "type": "array",
-                              "description": "Organization memberships for the user with their assigned roles.",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                                "required": [
-                                  "id",
-                                  "name",
-                                  "roleNames"
-                                ],
-                                "properties": {
-                                  "id": {
-                                    "description": "Unique identifier of the organization.",
-                                    "x-go-name": "ID",
-                                    "x-order": 1,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "id",
-                                      "json": "id,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
-                                    }
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "Name of the organization.",
-                                    "x-order": 2,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "name",
-                                      "json": "name,omitempty"
-                                    }
-                                  },
-                                  "description": {
-                                    "type": "string",
-                                    "description": "Human readable description of the organization.",
-                                    "x-order": 3,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "description",
-                                      "json": "description,omitempty"
-                                    }
-                                  },
-                                  "country": {
-                                    "type": "string",
-                                    "description": "Country associated with the organization.",
-                                    "x-order": 4,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "country",
-                                      "json": "country,omitempty"
-                                    }
-                                  },
-                                  "region": {
-                                    "type": "string",
-                                    "description": "Region associated with the organization.",
-                                    "x-order": 5,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "region",
-                                      "json": "region,omitempty"
-                                    }
-                                  },
-                                  "owner": {
-                                    "description": "Identifier of the organization owner.",
-                                    "x-order": 6,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "owner",
-                                      "json": "owner,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
-                                    }
-                                  },
-                                  "createdAt": {
-                                    "description": "Timestamp when the organization was created.",
-                                    "x-order": 7,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "created_at",
-                                      "json": "createdAt,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "x-go-type-skip-optional-pointer": true
-                                  },
-                                  "updatedAt": {
-                                    "description": "Timestamp when the organization was last updated.",
-                                    "x-order": 8,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "updated_at",
-                                      "json": "updatedAt,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "x-go-type-skip-optional-pointer": true
-                                  },
-                                  "deletedAt": {
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "nullable": true,
-                                    "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
-                                    "x-go-type": "core.NullTime",
-                                    "x-order": 9,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "deleted_at",
-                                      "json": "deletedAt,omitempty"
-                                    }
-                                  },
-                                  "roleNames": {
-                                    "type": "array",
-                                    "x-go-type": "pq.StringArray",
-                                    "x-go-type-import": {
-                                      "path": "github.com/lib/pq"
-                                    },
-                                    "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "x-order": 10,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "role_names",
-                                      "json": "roleNames"
-                                    }
-                                  }
-                                }
-                              },
-                              "x-oapi-codegen-extra-tags": {
-                                "db": "organizations_with_roles",
-                                "json": "organizationsWithRoles"
-                              }
-                            },
-                            "totalCount": {
-                              "type": "integer",
-                              "description": "Total number of organization memberships returned for the user.",
-                              "minimum": 0,
-                              "x-oapi-codegen-extra-tags": {
-                                "db": "total_count",
-                                "json": "totalCount"
-                              }
-                            }
+                            "json": "avatarUrl,omitempty"
                           }
                         }
-                      },
-                      "additionalProperties": false
+                      }
                     },
                     "location": {
                       "description": "Optional structured location metadata (branch, host, path, ...).",
@@ -3840,33 +1821,20 @@ const DesignSchema: Record<string, unknown> = {
                       "x-go-type-skip-optional-pointer": true
                     },
                     "user": {
-                      "description": "Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
+                      "description": "Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
                       "nullable": true,
-                      "x-go-type": "*userV1beta.User",
-                      "x-go-type-import": {
-                        "path": "github.com/meshery/schemas/models/v1beta2/user",
-                        "name": "userV1beta"
-                      },
+                      "x-go-type": "*CatalogAuthor",
                       "x-oapi-codegen-extra-tags": {
                         "db": "-"
                       },
                       "type": "object",
+                      "additionalProperties": false,
                       "required": [
-                        "id",
-                        "userId",
-                        "provider",
-                        "email",
-                        "firstName",
-                        "lastName",
-                        "status",
-                        "createdAt",
-                        "updatedAt",
-                        "lastLoginTime",
-                        "deletedAt"
+                        "id"
                       ],
                       "properties": {
                         "id": {
-                          "description": "Unique identifier for the user",
+                          "description": "Unique identifier for the user.",
                           "x-go-name": "ID",
                           "x-oapi-codegen-extra-tags": {
                             "db": "id",
@@ -3880,712 +1848,52 @@ const DesignSchema: Record<string, unknown> = {
                           }
                         },
                         "userId": {
-                          "type": "string",
-                          "maxLength": 200,
                           "deprecated": true,
-                          "description": "Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.",
+                          "description": "Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.",
+                          "x-go-name": "UserID",
                           "x-oapi-codegen-extra-tags": {
                             "db": "user_id",
-                            "json": "userId"
+                            "json": "userId,omitempty"
                           },
-                          "x-id-format": "external"
-                        },
-                        "provider": {
                           "type": "string",
-                          "maxLength": 100,
-                          "description": "Authentication provider (e.g., Google, Github)",
-                          "example": [
-                            "local",
-                            "github",
-                            "google",
-                            "twitter"
-                          ],
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "provider",
-                            "json": "provider"
-                          }
-                        },
-                        "email": {
-                          "type": "string",
-                          "format": "email",
-                          "maxLength": 300,
-                          "description": "User's email address",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "email",
-                            "json": "email"
+                          "format": "uuid",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
                           }
                         },
                         "firstName": {
                           "type": "string",
                           "maxLength": 200,
-                          "description": "User's first name",
+                          "description": "User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                          "x-go-type-skip-optional-pointer": true,
                           "x-oapi-codegen-extra-tags": {
                             "db": "first_name",
-                            "json": "firstName"
+                            "json": "firstName,omitempty"
                           }
                         },
                         "lastName": {
                           "type": "string",
                           "maxLength": 300,
-                          "description": "User's last name",
+                          "description": "User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                          "x-go-type-skip-optional-pointer": true,
                           "x-oapi-codegen-extra-tags": {
                             "db": "last_name",
-                            "json": "lastName"
+                            "json": "lastName,omitempty"
                           }
                         },
                         "avatarUrl": {
                           "type": "string",
                           "format": "uri",
                           "maxLength": 500,
-                          "description": "URL to user's avatar image",
+                          "description": "URL to the user's avatar image.",
+                          "x-go-type-skip-optional-pointer": true,
                           "x-oapi-codegen-extra-tags": {
                             "db": "avatar_url",
-                            "json": "avatarUrl"
-                          }
-                        },
-                        "status": {
-                          "type": "string",
-                          "maxLength": 100,
-                          "enum": [
-                            "active",
-                            "inactive",
-                            "pending",
-                            "anonymous"
-                          ],
-                          "description": "User account status",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "status",
-                            "json": "status"
-                          }
-                        },
-                        "bio": {
-                          "type": "string",
-                          "maxLength": 1000,
-                          "default": "",
-                          "description": "User's biography or description",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "bio",
-                            "json": "bio"
-                          }
-                        },
-                        "country": {
-                          "type": "object",
-                          "description": "User's country information stored as JSONB",
-                          "additionalProperties": true,
-                          "x-go-type": "core.Map",
-                          "x-go-type-skip-optional-pointer": true,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "country",
-                            "json": "country"
-                          }
-                        },
-                        "region": {
-                          "type": "object",
-                          "description": "User's region information stored as JSONB",
-                          "additionalProperties": true,
-                          "x-go-type": "core.Map",
-                          "x-go-type-skip-optional-pointer": true,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "region",
-                            "json": "region"
-                          }
-                        },
-                        "preferences": {
-                          "x-go-type": "Preference",
-                          "description": "User preferences stored as JSONB",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "preferences",
-                            "json": "preferences"
-                          },
-                          "x-generate-db-helpers": true,
-                          "type": "object",
-                          "required": [
-                            "anonymousUsageStats",
-                            "anonymousPerfResults",
-                            "updatedAt",
-                            "dashboardPreferences",
-                            "selectedOrganizationId",
-                            "selectedWorkspaceForOrganizations",
-                            "usersExtensionPreferences",
-                            "remoteProviderPreferences"
-                          ],
-                          "properties": {
-                            "meshAdapters": {
-                              "type": "array",
-                              "items": {
-                                "x-go-type": "Adapter",
-                                "type": "object",
-                                "description": "Placeholder for Adapter struct definition."
-                              },
-                              "description": "The mesh adapters of the preference."
-                            },
-                            "grafana": {
-                              "x-go-type": "Grafana",
-                              "type": "object",
-                              "properties": {
-                                "grafanaUrl": {
-                                  "type": "string",
-                                  "description": "Grafana URL for the user configuration.",
-                                  "maxLength": 500
-                                },
-                                "grafanaApiKey": {
-                                  "type": "string",
-                                  "description": "Grafana API key for the user configuration.",
-                                  "maxLength": 500
-                                },
-                                "selectedBoardsConfigs": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "board": {
-                                        "type": "object",
-                                        "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                      },
-                                      "panels": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                        },
-                                        "description": "Panels selected for the Grafana board configuration."
-                                      },
-                                      "templateVars": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "description": "Template variables applied to the selected Grafana board configuration."
-                                      }
-                                    }
-                                  },
-                                  "description": "Selected Grafana board configurations for the user."
-                                }
-                              }
-                            },
-                            "prometheus": {
-                              "x-go-type": "Prometheus",
-                              "type": "object",
-                              "properties": {
-                                "prometheusUrl": {
-                                  "type": "string",
-                                  "description": "The prometheus URL of the prometheus.",
-                                  "maxLength": 500
-                                },
-                                "selectedPrometheusBoardsConfigs": {
-                                  "type": "array",
-                                  "items": {
-                                    "type": "object",
-                                    "properties": {
-                                      "board": {
-                                        "type": "object",
-                                        "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                      },
-                                      "panels": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                        },
-                                        "description": "Panels selected for the Grafana board configuration."
-                                      },
-                                      "templateVars": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "string"
-                                        },
-                                        "description": "Template variables applied to the selected Grafana board configuration."
-                                      }
-                                    }
-                                  },
-                                  "description": "The selected prometheus boards configs of the prometheus."
-                                }
-                              }
-                            },
-                            "loadTestPrefs": {
-                              "x-go-type": "LoadTestPreferences",
-                              "type": "object",
-                              "properties": {
-                                "c": {
-                                  "type": "integer",
-                                  "description": "Concurrent requests",
-                                  "minimum": 0
-                                },
-                                "qps": {
-                                  "type": "integer",
-                                  "description": "Queries per second",
-                                  "minimum": 0
-                                },
-                                "t": {
-                                  "type": "string",
-                                  "description": "Duration",
-                                  "maxLength": 500
-                                },
-                                "gen": {
-                                  "type": "string",
-                                  "description": "Load generator",
-                                  "maxLength": 500
-                                }
-                              }
-                            },
-                            "anonymousUsageStats": {
-                              "type": "boolean",
-                              "description": "The anonymous usage stats of the preference."
-                            },
-                            "anonymousPerfResults": {
-                              "type": "boolean",
-                              "description": "The anonymous perf results of the preference."
-                            },
-                            "updatedAt": {
-                              "type": "string",
-                              "format": "date-time",
-                              "description": "Timestamp of when the resource was last updated."
-                            },
-                            "dashboardPreferences": {
-                              "type": "object",
-                              "additionalProperties": true,
-                              "description": "The dashboard preferences of the preference."
-                            },
-                            "selectedOrganizationId": {
-                              "type": "string",
-                              "description": "ID of the associated selectedOrganization.",
-                              "maxLength": 500,
-                              "format": "uuid"
-                            },
-                            "selectedWorkspaceForOrganizations": {
-                              "type": "object",
-                              "additionalProperties": {
-                                "type": "string"
-                              },
-                              "description": "The selected workspace for organizations of the preference."
-                            },
-                            "usersExtensionPreferences": {
-                              "type": "object",
-                              "additionalProperties": true,
-                              "description": "The users extension preferences of the preference."
-                            },
-                            "remoteProviderPreferences": {
-                              "type": "object",
-                              "additionalProperties": true,
-                              "description": "The remote provider preferences of the preference."
-                            }
-                          }
-                        },
-                        "acceptedTermsAt": {
-                          "description": "Timestamp when user accepted terms and conditions",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "accepted_terms_at",
-                            "json": "acceptedTermsAt"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "firstLoginTime": {
-                          "description": "Timestamp of user's first login",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "first_login_time",
-                            "json": "firstLoginTime"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "lastLoginTime": {
-                          "description": "Timestamp of user's most recent login",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "last_login_time",
-                            "json": "lastLoginTime"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "createdAt": {
-                          "description": "Timestamp when the user record was created",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "created_at",
-                            "json": "createdAt"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "updatedAt": {
-                          "description": "Timestamp when the user record was last updated",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "updated_at",
-                            "json": "updatedAt"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "socials": {
-                          "type": "array",
-                          "description": "Various online profiles associated with the user account",
-                          "x-go-type": "UserSocials",
-                          "items": {
-                            "x-go-type": "Social",
-                            "description": "Various online profiles associated with the user account, like GitHub, LinkedIn, X, and so on.",
-                            "type": "object",
-                            "properties": {
-                              "site": {
-                                "type": "string",
-                                "maxLength": 50,
-                                "description": "The site of the social."
-                              },
-                              "link": {
-                                "type": "string",
-                                "format": "uri",
-                                "description": "The link of the social."
-                              }
-                            },
-                            "required": [
-                              "site",
-                              "link"
-                            ]
-                          },
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "socials",
-                            "json": "socials"
-                          }
-                        },
-                        "deletedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "nullable": true,
-                          "description": "Timestamp when the user record was soft-deleted (null if not deleted)",
-                          "x-go-type": "core.NullTime",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "deleted_at",
-                            "json": "deletedAt"
-                          }
-                        },
-                        "roleNames": {
-                          "type": "array",
-                          "x-go-type": "pq.StringArray",
-                          "x-go-type-import": {
-                            "path": "github.com/lib/pq"
-                          },
-                          "x-go-type-skip-optional-pointer": true,
-                          "items": {
-                            "type": "string"
-                          },
-                          "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
-                          "example": [
-                            "organization admin",
-                            "user"
-                          ],
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "role_names",
-                            "json": "roleNames"
-                          }
-                        },
-                        "teams": {
-                          "type": "object",
-                          "description": "Teams the user belongs to with role information",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "teams",
-                            "json": "teams"
-                          },
-                          "properties": {
-                            "teamsWithRoles": {
-                              "type": "array",
-                              "description": "Team memberships for the user with their assigned roles.",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                                "required": [
-                                  "id",
-                                  "name",
-                                  "roleNames"
-                                ],
-                                "properties": {
-                                  "id": {
-                                    "description": "Unique identifier of the team.",
-                                    "x-go-name": "ID",
-                                    "x-order": 1,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "id",
-                                      "json": "id,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
-                                    }
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "Name of the team.",
-                                    "x-order": 2,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "name",
-                                      "json": "name,omitempty"
-                                    }
-                                  },
-                                  "description": {
-                                    "type": "string",
-                                    "description": "Human readable description of the team.",
-                                    "x-order": 3,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "description",
-                                      "json": "description,omitempty"
-                                    }
-                                  },
-                                  "owner": {
-                                    "description": "Identifier of the team owner.",
-                                    "x-order": 4,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "owner",
-                                      "json": "owner,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
-                                    }
-                                  },
-                                  "metadata": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "description": "Free-form metadata associated with the team.",
-                                    "x-go-type": "core.Map",
-                                    "x-go-type-skip-optional-pointer": true,
-                                    "x-order": 5,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "metadata",
-                                      "json": "metadata,omitempty"
-                                    }
-                                  },
-                                  "createdAt": {
-                                    "description": "Timestamp when the team was created.",
-                                    "x-order": 6,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "created_at",
-                                      "json": "createdAt,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "x-go-type-skip-optional-pointer": true
-                                  },
-                                  "updatedAt": {
-                                    "description": "Timestamp when the team was last updated.",
-                                    "x-order": 7,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "updated_at",
-                                      "json": "updatedAt,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "x-go-type-skip-optional-pointer": true
-                                  },
-                                  "deletedAt": {
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "nullable": true,
-                                    "description": "Timestamp when the team was soft-deleted (null if not deleted).",
-                                    "x-go-type": "core.NullTime",
-                                    "x-order": 8,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "deleted_at",
-                                      "json": "deletedAt,omitempty"
-                                    }
-                                  },
-                                  "roleNames": {
-                                    "type": "array",
-                                    "x-go-type": "pq.StringArray",
-                                    "x-go-type-import": {
-                                      "path": "github.com/lib/pq"
-                                    },
-                                    "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "x-order": 9,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "role_names",
-                                      "json": "roleNames"
-                                    }
-                                  }
-                                }
-                              },
-                              "x-oapi-codegen-extra-tags": {
-                                "db": "teams_with_roles",
-                                "json": "teamsWithRoles"
-                              }
-                            },
-                            "totalCount": {
-                              "type": "integer",
-                              "description": "Total number of team memberships returned for the user.",
-                              "minimum": 0,
-                              "x-oapi-codegen-extra-tags": {
-                                "db": "total_count",
-                                "json": "totalCount"
-                              }
-                            }
-                          }
-                        },
-                        "organizations": {
-                          "type": "object",
-                          "description": "Organizations the user belongs to with role information",
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "organizations",
-                            "json": "organizations"
-                          },
-                          "properties": {
-                            "organizationsWithRoles": {
-                              "type": "array",
-                              "description": "Organization memberships for the user with their assigned roles.",
-                              "items": {
-                                "type": "object",
-                                "additionalProperties": false,
-                                "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                                "required": [
-                                  "id",
-                                  "name",
-                                  "roleNames"
-                                ],
-                                "properties": {
-                                  "id": {
-                                    "description": "Unique identifier of the organization.",
-                                    "x-go-name": "ID",
-                                    "x-order": 1,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "id",
-                                      "json": "id,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
-                                    }
-                                  },
-                                  "name": {
-                                    "type": "string",
-                                    "description": "Name of the organization.",
-                                    "x-order": 2,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "name",
-                                      "json": "name,omitempty"
-                                    }
-                                  },
-                                  "description": {
-                                    "type": "string",
-                                    "description": "Human readable description of the organization.",
-                                    "x-order": 3,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "description",
-                                      "json": "description,omitempty"
-                                    }
-                                  },
-                                  "country": {
-                                    "type": "string",
-                                    "description": "Country associated with the organization.",
-                                    "x-order": 4,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "country",
-                                      "json": "country,omitempty"
-                                    }
-                                  },
-                                  "region": {
-                                    "type": "string",
-                                    "description": "Region associated with the organization.",
-                                    "x-order": 5,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "region",
-                                      "json": "region,omitempty"
-                                    }
-                                  },
-                                  "owner": {
-                                    "description": "Identifier of the organization owner.",
-                                    "x-order": 6,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "owner",
-                                      "json": "owner,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
-                                    }
-                                  },
-                                  "createdAt": {
-                                    "description": "Timestamp when the organization was created.",
-                                    "x-order": 7,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "created_at",
-                                      "json": "createdAt,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "x-go-type-skip-optional-pointer": true
-                                  },
-                                  "updatedAt": {
-                                    "description": "Timestamp when the organization was last updated.",
-                                    "x-order": 8,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "updated_at",
-                                      "json": "updatedAt,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "x-go-type-skip-optional-pointer": true
-                                  },
-                                  "deletedAt": {
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "nullable": true,
-                                    "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
-                                    "x-go-type": "core.NullTime",
-                                    "x-order": 9,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "deleted_at",
-                                      "json": "deletedAt,omitempty"
-                                    }
-                                  },
-                                  "roleNames": {
-                                    "type": "array",
-                                    "x-go-type": "pq.StringArray",
-                                    "x-go-type-import": {
-                                      "path": "github.com/lib/pq"
-                                    },
-                                    "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "x-order": 10,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "role_names",
-                                      "json": "roleNames"
-                                    }
-                                  }
-                                }
-                              },
-                              "x-oapi-codegen-extra-tags": {
-                                "db": "organizations_with_roles",
-                                "json": "organizationsWithRoles"
-                              }
-                            },
-                            "totalCount": {
-                              "type": "integer",
-                              "description": "Total number of organization memberships returned for the user.",
-                              "minimum": 0,
-                              "x-oapi-codegen-extra-tags": {
-                                "db": "total_count",
-                                "json": "totalCount"
-                              }
-                            }
+                            "json": "avatarUrl,omitempty"
                           }
                         }
-                      },
-                      "additionalProperties": false
+                      }
                     },
                     "location": {
                       "description": "Optional structured location metadata (branch, host, path, ...).",
@@ -5126,33 +2434,20 @@ const DesignSchema: Record<string, unknown> = {
                         "x-go-type-skip-optional-pointer": true
                       },
                       "user": {
-                        "description": "Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
+                        "description": "Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
                         "nullable": true,
-                        "x-go-type": "*userV1beta.User",
-                        "x-go-type-import": {
-                          "path": "github.com/meshery/schemas/models/v1beta2/user",
-                          "name": "userV1beta"
-                        },
+                        "x-go-type": "*CatalogAuthor",
                         "x-oapi-codegen-extra-tags": {
                           "db": "-"
                         },
                         "type": "object",
+                        "additionalProperties": false,
                         "required": [
-                          "id",
-                          "userId",
-                          "provider",
-                          "email",
-                          "firstName",
-                          "lastName",
-                          "status",
-                          "createdAt",
-                          "updatedAt",
-                          "lastLoginTime",
-                          "deletedAt"
+                          "id"
                         ],
                         "properties": {
                           "id": {
-                            "description": "Unique identifier for the user",
+                            "description": "Unique identifier for the user.",
                             "x-go-name": "ID",
                             "x-oapi-codegen-extra-tags": {
                               "db": "id",
@@ -5166,712 +2461,52 @@ const DesignSchema: Record<string, unknown> = {
                             }
                           },
                           "userId": {
-                            "type": "string",
-                            "maxLength": 200,
                             "deprecated": true,
-                            "description": "Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.",
+                            "description": "Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.",
+                            "x-go-name": "UserID",
                             "x-oapi-codegen-extra-tags": {
                               "db": "user_id",
-                              "json": "userId"
+                              "json": "userId,omitempty"
                             },
-                            "x-id-format": "external"
-                          },
-                          "provider": {
                             "type": "string",
-                            "maxLength": 100,
-                            "description": "Authentication provider (e.g., Google, Github)",
-                            "example": [
-                              "local",
-                              "github",
-                              "google",
-                              "twitter"
-                            ],
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "provider",
-                              "json": "provider"
-                            }
-                          },
-                          "email": {
-                            "type": "string",
-                            "format": "email",
-                            "maxLength": 300,
-                            "description": "User's email address",
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "email",
-                              "json": "email"
+                            "format": "uuid",
+                            "x-go-type": "uuid.UUID",
+                            "x-go-type-import": {
+                              "path": "github.com/gofrs/uuid"
                             }
                           },
                           "firstName": {
                             "type": "string",
                             "maxLength": 200,
-                            "description": "User's first name",
+                            "description": "User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                            "x-go-type-skip-optional-pointer": true,
                             "x-oapi-codegen-extra-tags": {
                               "db": "first_name",
-                              "json": "firstName"
+                              "json": "firstName,omitempty"
                             }
                           },
                           "lastName": {
                             "type": "string",
                             "maxLength": 300,
-                            "description": "User's last name",
+                            "description": "User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                            "x-go-type-skip-optional-pointer": true,
                             "x-oapi-codegen-extra-tags": {
                               "db": "last_name",
-                              "json": "lastName"
+                              "json": "lastName,omitempty"
                             }
                           },
                           "avatarUrl": {
                             "type": "string",
                             "format": "uri",
                             "maxLength": 500,
-                            "description": "URL to user's avatar image",
+                            "description": "URL to the user's avatar image.",
+                            "x-go-type-skip-optional-pointer": true,
                             "x-oapi-codegen-extra-tags": {
                               "db": "avatar_url",
-                              "json": "avatarUrl"
-                            }
-                          },
-                          "status": {
-                            "type": "string",
-                            "maxLength": 100,
-                            "enum": [
-                              "active",
-                              "inactive",
-                              "pending",
-                              "anonymous"
-                            ],
-                            "description": "User account status",
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "status",
-                              "json": "status"
-                            }
-                          },
-                          "bio": {
-                            "type": "string",
-                            "maxLength": 1000,
-                            "default": "",
-                            "description": "User's biography or description",
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "bio",
-                              "json": "bio"
-                            }
-                          },
-                          "country": {
-                            "type": "object",
-                            "description": "User's country information stored as JSONB",
-                            "additionalProperties": true,
-                            "x-go-type": "core.Map",
-                            "x-go-type-skip-optional-pointer": true,
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "country",
-                              "json": "country"
-                            }
-                          },
-                          "region": {
-                            "type": "object",
-                            "description": "User's region information stored as JSONB",
-                            "additionalProperties": true,
-                            "x-go-type": "core.Map",
-                            "x-go-type-skip-optional-pointer": true,
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "region",
-                              "json": "region"
-                            }
-                          },
-                          "preferences": {
-                            "x-go-type": "Preference",
-                            "description": "User preferences stored as JSONB",
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "preferences",
-                              "json": "preferences"
-                            },
-                            "x-generate-db-helpers": true,
-                            "type": "object",
-                            "required": [
-                              "anonymousUsageStats",
-                              "anonymousPerfResults",
-                              "updatedAt",
-                              "dashboardPreferences",
-                              "selectedOrganizationId",
-                              "selectedWorkspaceForOrganizations",
-                              "usersExtensionPreferences",
-                              "remoteProviderPreferences"
-                            ],
-                            "properties": {
-                              "meshAdapters": {
-                                "type": "array",
-                                "items": {
-                                  "x-go-type": "Adapter",
-                                  "type": "object",
-                                  "description": "Placeholder for Adapter struct definition."
-                                },
-                                "description": "The mesh adapters of the preference."
-                              },
-                              "grafana": {
-                                "x-go-type": "Grafana",
-                                "type": "object",
-                                "properties": {
-                                  "grafanaUrl": {
-                                    "type": "string",
-                                    "description": "Grafana URL for the user configuration.",
-                                    "maxLength": 500
-                                  },
-                                  "grafanaApiKey": {
-                                    "type": "string",
-                                    "description": "Grafana API key for the user configuration.",
-                                    "maxLength": 500
-                                  },
-                                  "selectedBoardsConfigs": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "board": {
-                                          "type": "object",
-                                          "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                        },
-                                        "panels": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "object",
-                                            "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                          },
-                                          "description": "Panels selected for the Grafana board configuration."
-                                        },
-                                        "templateVars": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          },
-                                          "description": "Template variables applied to the selected Grafana board configuration."
-                                        }
-                                      }
-                                    },
-                                    "description": "Selected Grafana board configurations for the user."
-                                  }
-                                }
-                              },
-                              "prometheus": {
-                                "x-go-type": "Prometheus",
-                                "type": "object",
-                                "properties": {
-                                  "prometheusUrl": {
-                                    "type": "string",
-                                    "description": "The prometheus URL of the prometheus.",
-                                    "maxLength": 500
-                                  },
-                                  "selectedPrometheusBoardsConfigs": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "properties": {
-                                        "board": {
-                                          "type": "object",
-                                          "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                        },
-                                        "panels": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "object",
-                                            "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                          },
-                                          "description": "Panels selected for the Grafana board configuration."
-                                        },
-                                        "templateVars": {
-                                          "type": "array",
-                                          "items": {
-                                            "type": "string"
-                                          },
-                                          "description": "Template variables applied to the selected Grafana board configuration."
-                                        }
-                                      }
-                                    },
-                                    "description": "The selected prometheus boards configs of the prometheus."
-                                  }
-                                }
-                              },
-                              "loadTestPrefs": {
-                                "x-go-type": "LoadTestPreferences",
-                                "type": "object",
-                                "properties": {
-                                  "c": {
-                                    "type": "integer",
-                                    "description": "Concurrent requests",
-                                    "minimum": 0
-                                  },
-                                  "qps": {
-                                    "type": "integer",
-                                    "description": "Queries per second",
-                                    "minimum": 0
-                                  },
-                                  "t": {
-                                    "type": "string",
-                                    "description": "Duration",
-                                    "maxLength": 500
-                                  },
-                                  "gen": {
-                                    "type": "string",
-                                    "description": "Load generator",
-                                    "maxLength": 500
-                                  }
-                                }
-                              },
-                              "anonymousUsageStats": {
-                                "type": "boolean",
-                                "description": "The anonymous usage stats of the preference."
-                              },
-                              "anonymousPerfResults": {
-                                "type": "boolean",
-                                "description": "The anonymous perf results of the preference."
-                              },
-                              "updatedAt": {
-                                "type": "string",
-                                "format": "date-time",
-                                "description": "Timestamp of when the resource was last updated."
-                              },
-                              "dashboardPreferences": {
-                                "type": "object",
-                                "additionalProperties": true,
-                                "description": "The dashboard preferences of the preference."
-                              },
-                              "selectedOrganizationId": {
-                                "type": "string",
-                                "description": "ID of the associated selectedOrganization.",
-                                "maxLength": 500,
-                                "format": "uuid"
-                              },
-                              "selectedWorkspaceForOrganizations": {
-                                "type": "object",
-                                "additionalProperties": {
-                                  "type": "string"
-                                },
-                                "description": "The selected workspace for organizations of the preference."
-                              },
-                              "usersExtensionPreferences": {
-                                "type": "object",
-                                "additionalProperties": true,
-                                "description": "The users extension preferences of the preference."
-                              },
-                              "remoteProviderPreferences": {
-                                "type": "object",
-                                "additionalProperties": true,
-                                "description": "The remote provider preferences of the preference."
-                              }
-                            }
-                          },
-                          "acceptedTermsAt": {
-                            "description": "Timestamp when user accepted terms and conditions",
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "accepted_terms_at",
-                              "json": "acceptedTermsAt"
-                            },
-                            "type": "string",
-                            "format": "date-time",
-                            "x-go-type-skip-optional-pointer": true
-                          },
-                          "firstLoginTime": {
-                            "description": "Timestamp of user's first login",
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "first_login_time",
-                              "json": "firstLoginTime"
-                            },
-                            "type": "string",
-                            "format": "date-time",
-                            "x-go-type-skip-optional-pointer": true
-                          },
-                          "lastLoginTime": {
-                            "description": "Timestamp of user's most recent login",
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "last_login_time",
-                              "json": "lastLoginTime"
-                            },
-                            "type": "string",
-                            "format": "date-time",
-                            "x-go-type-skip-optional-pointer": true
-                          },
-                          "createdAt": {
-                            "description": "Timestamp when the user record was created",
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "created_at",
-                              "json": "createdAt"
-                            },
-                            "type": "string",
-                            "format": "date-time",
-                            "x-go-type-skip-optional-pointer": true
-                          },
-                          "updatedAt": {
-                            "description": "Timestamp when the user record was last updated",
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "updated_at",
-                              "json": "updatedAt"
-                            },
-                            "type": "string",
-                            "format": "date-time",
-                            "x-go-type-skip-optional-pointer": true
-                          },
-                          "socials": {
-                            "type": "array",
-                            "description": "Various online profiles associated with the user account",
-                            "x-go-type": "UserSocials",
-                            "items": {
-                              "x-go-type": "Social",
-                              "description": "Various online profiles associated with the user account, like GitHub, LinkedIn, X, and so on.",
-                              "type": "object",
-                              "properties": {
-                                "site": {
-                                  "type": "string",
-                                  "maxLength": 50,
-                                  "description": "The site of the social."
-                                },
-                                "link": {
-                                  "type": "string",
-                                  "format": "uri",
-                                  "description": "The link of the social."
-                                }
-                              },
-                              "required": [
-                                "site",
-                                "link"
-                              ]
-                            },
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "socials",
-                              "json": "socials"
-                            }
-                          },
-                          "deletedAt": {
-                            "type": "string",
-                            "format": "date-time",
-                            "nullable": true,
-                            "description": "Timestamp when the user record was soft-deleted (null if not deleted)",
-                            "x-go-type": "core.NullTime",
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "deleted_at",
-                              "json": "deletedAt"
-                            }
-                          },
-                          "roleNames": {
-                            "type": "array",
-                            "x-go-type": "pq.StringArray",
-                            "x-go-type-import": {
-                              "path": "github.com/lib/pq"
-                            },
-                            "x-go-type-skip-optional-pointer": true,
-                            "items": {
-                              "type": "string"
-                            },
-                            "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
-                            "example": [
-                              "organization admin",
-                              "user"
-                            ],
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "role_names",
-                              "json": "roleNames"
-                            }
-                          },
-                          "teams": {
-                            "type": "object",
-                            "description": "Teams the user belongs to with role information",
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "teams",
-                              "json": "teams"
-                            },
-                            "properties": {
-                              "teamsWithRoles": {
-                                "type": "array",
-                                "description": "Team memberships for the user with their assigned roles.",
-                                "items": {
-                                  "type": "object",
-                                  "additionalProperties": false,
-                                  "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                                  "required": [
-                                    "id",
-                                    "name",
-                                    "roleNames"
-                                  ],
-                                  "properties": {
-                                    "id": {
-                                      "description": "Unique identifier of the team.",
-                                      "x-go-name": "ID",
-                                      "x-order": 1,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "id",
-                                        "json": "id,omitempty"
-                                      },
-                                      "type": "string",
-                                      "format": "uuid",
-                                      "x-go-type": "uuid.UUID",
-                                      "x-go-type-import": {
-                                        "path": "github.com/gofrs/uuid"
-                                      }
-                                    },
-                                    "name": {
-                                      "type": "string",
-                                      "description": "Name of the team.",
-                                      "x-order": 2,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "name",
-                                        "json": "name,omitempty"
-                                      }
-                                    },
-                                    "description": {
-                                      "type": "string",
-                                      "description": "Human readable description of the team.",
-                                      "x-order": 3,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "description",
-                                        "json": "description,omitempty"
-                                      }
-                                    },
-                                    "owner": {
-                                      "description": "Identifier of the team owner.",
-                                      "x-order": 4,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "owner",
-                                        "json": "owner,omitempty"
-                                      },
-                                      "type": "string",
-                                      "format": "uuid",
-                                      "x-go-type": "uuid.UUID",
-                                      "x-go-type-import": {
-                                        "path": "github.com/gofrs/uuid"
-                                      }
-                                    },
-                                    "metadata": {
-                                      "type": "object",
-                                      "additionalProperties": true,
-                                      "description": "Free-form metadata associated with the team.",
-                                      "x-go-type": "core.Map",
-                                      "x-go-type-skip-optional-pointer": true,
-                                      "x-order": 5,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "metadata",
-                                        "json": "metadata,omitempty"
-                                      }
-                                    },
-                                    "createdAt": {
-                                      "description": "Timestamp when the team was created.",
-                                      "x-order": 6,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "created_at",
-                                        "json": "createdAt,omitempty"
-                                      },
-                                      "type": "string",
-                                      "format": "date-time",
-                                      "x-go-type-skip-optional-pointer": true
-                                    },
-                                    "updatedAt": {
-                                      "description": "Timestamp when the team was last updated.",
-                                      "x-order": 7,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "updated_at",
-                                        "json": "updatedAt,omitempty"
-                                      },
-                                      "type": "string",
-                                      "format": "date-time",
-                                      "x-go-type-skip-optional-pointer": true
-                                    },
-                                    "deletedAt": {
-                                      "type": "string",
-                                      "format": "date-time",
-                                      "nullable": true,
-                                      "description": "Timestamp when the team was soft-deleted (null if not deleted).",
-                                      "x-go-type": "core.NullTime",
-                                      "x-order": 8,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "deleted_at",
-                                        "json": "deletedAt,omitempty"
-                                      }
-                                    },
-                                    "roleNames": {
-                                      "type": "array",
-                                      "x-go-type": "pq.StringArray",
-                                      "x-go-type-import": {
-                                        "path": "github.com/lib/pq"
-                                      },
-                                      "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "x-order": 9,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "role_names",
-                                        "json": "roleNames"
-                                      }
-                                    }
-                                  }
-                                },
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "teams_with_roles",
-                                  "json": "teamsWithRoles"
-                                }
-                              },
-                              "totalCount": {
-                                "type": "integer",
-                                "description": "Total number of team memberships returned for the user.",
-                                "minimum": 0,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "total_count",
-                                  "json": "totalCount"
-                                }
-                              }
-                            }
-                          },
-                          "organizations": {
-                            "type": "object",
-                            "description": "Organizations the user belongs to with role information",
-                            "x-oapi-codegen-extra-tags": {
-                              "db": "organizations",
-                              "json": "organizations"
-                            },
-                            "properties": {
-                              "organizationsWithRoles": {
-                                "type": "array",
-                                "description": "Organization memberships for the user with their assigned roles.",
-                                "items": {
-                                  "type": "object",
-                                  "additionalProperties": false,
-                                  "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                                  "required": [
-                                    "id",
-                                    "name",
-                                    "roleNames"
-                                  ],
-                                  "properties": {
-                                    "id": {
-                                      "description": "Unique identifier of the organization.",
-                                      "x-go-name": "ID",
-                                      "x-order": 1,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "id",
-                                        "json": "id,omitempty"
-                                      },
-                                      "type": "string",
-                                      "format": "uuid",
-                                      "x-go-type": "uuid.UUID",
-                                      "x-go-type-import": {
-                                        "path": "github.com/gofrs/uuid"
-                                      }
-                                    },
-                                    "name": {
-                                      "type": "string",
-                                      "description": "Name of the organization.",
-                                      "x-order": 2,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "name",
-                                        "json": "name,omitempty"
-                                      }
-                                    },
-                                    "description": {
-                                      "type": "string",
-                                      "description": "Human readable description of the organization.",
-                                      "x-order": 3,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "description",
-                                        "json": "description,omitempty"
-                                      }
-                                    },
-                                    "country": {
-                                      "type": "string",
-                                      "description": "Country associated with the organization.",
-                                      "x-order": 4,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "country",
-                                        "json": "country,omitempty"
-                                      }
-                                    },
-                                    "region": {
-                                      "type": "string",
-                                      "description": "Region associated with the organization.",
-                                      "x-order": 5,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "region",
-                                        "json": "region,omitempty"
-                                      }
-                                    },
-                                    "owner": {
-                                      "description": "Identifier of the organization owner.",
-                                      "x-order": 6,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "owner",
-                                        "json": "owner,omitempty"
-                                      },
-                                      "type": "string",
-                                      "format": "uuid",
-                                      "x-go-type": "uuid.UUID",
-                                      "x-go-type-import": {
-                                        "path": "github.com/gofrs/uuid"
-                                      }
-                                    },
-                                    "createdAt": {
-                                      "description": "Timestamp when the organization was created.",
-                                      "x-order": 7,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "created_at",
-                                        "json": "createdAt,omitempty"
-                                      },
-                                      "type": "string",
-                                      "format": "date-time",
-                                      "x-go-type-skip-optional-pointer": true
-                                    },
-                                    "updatedAt": {
-                                      "description": "Timestamp when the organization was last updated.",
-                                      "x-order": 8,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "updated_at",
-                                        "json": "updatedAt,omitempty"
-                                      },
-                                      "type": "string",
-                                      "format": "date-time",
-                                      "x-go-type-skip-optional-pointer": true
-                                    },
-                                    "deletedAt": {
-                                      "type": "string",
-                                      "format": "date-time",
-                                      "nullable": true,
-                                      "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
-                                      "x-go-type": "core.NullTime",
-                                      "x-order": 9,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "deleted_at",
-                                        "json": "deletedAt,omitempty"
-                                      }
-                                    },
-                                    "roleNames": {
-                                      "type": "array",
-                                      "x-go-type": "pq.StringArray",
-                                      "x-go-type-import": {
-                                        "path": "github.com/lib/pq"
-                                      },
-                                      "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
-                                      "items": {
-                                        "type": "string"
-                                      },
-                                      "x-order": 10,
-                                      "x-oapi-codegen-extra-tags": {
-                                        "db": "role_names",
-                                        "json": "roleNames"
-                                      }
-                                    }
-                                  }
-                                },
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "organizations_with_roles",
-                                  "json": "organizationsWithRoles"
-                                }
-                              },
-                              "totalCount": {
-                                "type": "integer",
-                                "description": "Total number of organization memberships returned for the user.",
-                                "minimum": 0,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "total_count",
-                                  "json": "totalCount"
-                                }
-                              }
+                              "json": "avatarUrl,omitempty"
                             }
                           }
-                        },
-                        "additionalProperties": false
+                        }
                       },
                       "location": {
                         "description": "Optional structured location metadata (branch, host, path, ...).",
@@ -6301,33 +2936,20 @@ const DesignSchema: Record<string, unknown> = {
                             "x-go-type-skip-optional-pointer": true
                           },
                           "user": {
-                            "description": "Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
+                            "description": "Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
                             "nullable": true,
-                            "x-go-type": "*userV1beta.User",
-                            "x-go-type-import": {
-                              "path": "github.com/meshery/schemas/models/v1beta2/user",
-                              "name": "userV1beta"
-                            },
+                            "x-go-type": "*CatalogAuthor",
                             "x-oapi-codegen-extra-tags": {
                               "db": "-"
                             },
                             "type": "object",
+                            "additionalProperties": false,
                             "required": [
-                              "id",
-                              "userId",
-                              "provider",
-                              "email",
-                              "firstName",
-                              "lastName",
-                              "status",
-                              "createdAt",
-                              "updatedAt",
-                              "lastLoginTime",
-                              "deletedAt"
+                              "id"
                             ],
                             "properties": {
                               "id": {
-                                "description": "Unique identifier for the user",
+                                "description": "Unique identifier for the user.",
                                 "x-go-name": "ID",
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "id",
@@ -6341,712 +2963,52 @@ const DesignSchema: Record<string, unknown> = {
                                 }
                               },
                               "userId": {
-                                "type": "string",
-                                "maxLength": 200,
                                 "deprecated": true,
-                                "description": "Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.",
+                                "description": "Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.",
+                                "x-go-name": "UserID",
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "user_id",
-                                  "json": "userId"
+                                  "json": "userId,omitempty"
                                 },
-                                "x-id-format": "external"
-                              },
-                              "provider": {
                                 "type": "string",
-                                "maxLength": 100,
-                                "description": "Authentication provider (e.g., Google, Github)",
-                                "example": [
-                                  "local",
-                                  "github",
-                                  "google",
-                                  "twitter"
-                                ],
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "provider",
-                                  "json": "provider"
-                                }
-                              },
-                              "email": {
-                                "type": "string",
-                                "format": "email",
-                                "maxLength": 300,
-                                "description": "User's email address",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "email",
-                                  "json": "email"
+                                "format": "uuid",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
                                 }
                               },
                               "firstName": {
                                 "type": "string",
                                 "maxLength": 200,
-                                "description": "User's first name",
+                                "description": "User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                                "x-go-type-skip-optional-pointer": true,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "first_name",
-                                  "json": "firstName"
+                                  "json": "firstName,omitempty"
                                 }
                               },
                               "lastName": {
                                 "type": "string",
                                 "maxLength": 300,
-                                "description": "User's last name",
+                                "description": "User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                                "x-go-type-skip-optional-pointer": true,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "last_name",
-                                  "json": "lastName"
+                                  "json": "lastName,omitempty"
                                 }
                               },
                               "avatarUrl": {
                                 "type": "string",
                                 "format": "uri",
                                 "maxLength": 500,
-                                "description": "URL to user's avatar image",
+                                "description": "URL to the user's avatar image.",
+                                "x-go-type-skip-optional-pointer": true,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "avatar_url",
-                                  "json": "avatarUrl"
-                                }
-                              },
-                              "status": {
-                                "type": "string",
-                                "maxLength": 100,
-                                "enum": [
-                                  "active",
-                                  "inactive",
-                                  "pending",
-                                  "anonymous"
-                                ],
-                                "description": "User account status",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "status",
-                                  "json": "status"
-                                }
-                              },
-                              "bio": {
-                                "type": "string",
-                                "maxLength": 1000,
-                                "default": "",
-                                "description": "User's biography or description",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "bio",
-                                  "json": "bio"
-                                }
-                              },
-                              "country": {
-                                "type": "object",
-                                "description": "User's country information stored as JSONB",
-                                "additionalProperties": true,
-                                "x-go-type": "core.Map",
-                                "x-go-type-skip-optional-pointer": true,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "country",
-                                  "json": "country"
-                                }
-                              },
-                              "region": {
-                                "type": "object",
-                                "description": "User's region information stored as JSONB",
-                                "additionalProperties": true,
-                                "x-go-type": "core.Map",
-                                "x-go-type-skip-optional-pointer": true,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "region",
-                                  "json": "region"
-                                }
-                              },
-                              "preferences": {
-                                "x-go-type": "Preference",
-                                "description": "User preferences stored as JSONB",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "preferences",
-                                  "json": "preferences"
-                                },
-                                "x-generate-db-helpers": true,
-                                "type": "object",
-                                "required": [
-                                  "anonymousUsageStats",
-                                  "anonymousPerfResults",
-                                  "updatedAt",
-                                  "dashboardPreferences",
-                                  "selectedOrganizationId",
-                                  "selectedWorkspaceForOrganizations",
-                                  "usersExtensionPreferences",
-                                  "remoteProviderPreferences"
-                                ],
-                                "properties": {
-                                  "meshAdapters": {
-                                    "type": "array",
-                                    "items": {
-                                      "x-go-type": "Adapter",
-                                      "type": "object",
-                                      "description": "Placeholder for Adapter struct definition."
-                                    },
-                                    "description": "The mesh adapters of the preference."
-                                  },
-                                  "grafana": {
-                                    "x-go-type": "Grafana",
-                                    "type": "object",
-                                    "properties": {
-                                      "grafanaUrl": {
-                                        "type": "string",
-                                        "description": "Grafana URL for the user configuration.",
-                                        "maxLength": 500
-                                      },
-                                      "grafanaApiKey": {
-                                        "type": "string",
-                                        "description": "Grafana API key for the user configuration.",
-                                        "maxLength": 500
-                                      },
-                                      "selectedBoardsConfigs": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "properties": {
-                                            "board": {
-                                              "type": "object",
-                                              "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                            },
-                                            "panels": {
-                                              "type": "array",
-                                              "items": {
-                                                "type": "object",
-                                                "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                              },
-                                              "description": "Panels selected for the Grafana board configuration."
-                                            },
-                                            "templateVars": {
-                                              "type": "array",
-                                              "items": {
-                                                "type": "string"
-                                              },
-                                              "description": "Template variables applied to the selected Grafana board configuration."
-                                            }
-                                          }
-                                        },
-                                        "description": "Selected Grafana board configurations for the user."
-                                      }
-                                    }
-                                  },
-                                  "prometheus": {
-                                    "x-go-type": "Prometheus",
-                                    "type": "object",
-                                    "properties": {
-                                      "prometheusUrl": {
-                                        "type": "string",
-                                        "description": "The prometheus URL of the prometheus.",
-                                        "maxLength": 500
-                                      },
-                                      "selectedPrometheusBoardsConfigs": {
-                                        "type": "array",
-                                        "items": {
-                                          "type": "object",
-                                          "properties": {
-                                            "board": {
-                                              "type": "object",
-                                              "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                            },
-                                            "panels": {
-                                              "type": "array",
-                                              "items": {
-                                                "type": "object",
-                                                "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                              },
-                                              "description": "Panels selected for the Grafana board configuration."
-                                            },
-                                            "templateVars": {
-                                              "type": "array",
-                                              "items": {
-                                                "type": "string"
-                                              },
-                                              "description": "Template variables applied to the selected Grafana board configuration."
-                                            }
-                                          }
-                                        },
-                                        "description": "The selected prometheus boards configs of the prometheus."
-                                      }
-                                    }
-                                  },
-                                  "loadTestPrefs": {
-                                    "x-go-type": "LoadTestPreferences",
-                                    "type": "object",
-                                    "properties": {
-                                      "c": {
-                                        "type": "integer",
-                                        "description": "Concurrent requests",
-                                        "minimum": 0
-                                      },
-                                      "qps": {
-                                        "type": "integer",
-                                        "description": "Queries per second",
-                                        "minimum": 0
-                                      },
-                                      "t": {
-                                        "type": "string",
-                                        "description": "Duration",
-                                        "maxLength": 500
-                                      },
-                                      "gen": {
-                                        "type": "string",
-                                        "description": "Load generator",
-                                        "maxLength": 500
-                                      }
-                                    }
-                                  },
-                                  "anonymousUsageStats": {
-                                    "type": "boolean",
-                                    "description": "The anonymous usage stats of the preference."
-                                  },
-                                  "anonymousPerfResults": {
-                                    "type": "boolean",
-                                    "description": "The anonymous perf results of the preference."
-                                  },
-                                  "updatedAt": {
-                                    "type": "string",
-                                    "format": "date-time",
-                                    "description": "Timestamp of when the resource was last updated."
-                                  },
-                                  "dashboardPreferences": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "description": "The dashboard preferences of the preference."
-                                  },
-                                  "selectedOrganizationId": {
-                                    "type": "string",
-                                    "description": "ID of the associated selectedOrganization.",
-                                    "maxLength": 500,
-                                    "format": "uuid"
-                                  },
-                                  "selectedWorkspaceForOrganizations": {
-                                    "type": "object",
-                                    "additionalProperties": {
-                                      "type": "string"
-                                    },
-                                    "description": "The selected workspace for organizations of the preference."
-                                  },
-                                  "usersExtensionPreferences": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "description": "The users extension preferences of the preference."
-                                  },
-                                  "remoteProviderPreferences": {
-                                    "type": "object",
-                                    "additionalProperties": true,
-                                    "description": "The remote provider preferences of the preference."
-                                  }
-                                }
-                              },
-                              "acceptedTermsAt": {
-                                "description": "Timestamp when user accepted terms and conditions",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "accepted_terms_at",
-                                  "json": "acceptedTermsAt"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "firstLoginTime": {
-                                "description": "Timestamp of user's first login",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "first_login_time",
-                                  "json": "firstLoginTime"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "lastLoginTime": {
-                                "description": "Timestamp of user's most recent login",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "last_login_time",
-                                  "json": "lastLoginTime"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "createdAt": {
-                                "description": "Timestamp when the user record was created",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "created_at",
-                                  "json": "createdAt"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "updatedAt": {
-                                "description": "Timestamp when the user record was last updated",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "updated_at",
-                                  "json": "updatedAt"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "socials": {
-                                "type": "array",
-                                "description": "Various online profiles associated with the user account",
-                                "x-go-type": "UserSocials",
-                                "items": {
-                                  "x-go-type": "Social",
-                                  "description": "Various online profiles associated with the user account, like GitHub, LinkedIn, X, and so on.",
-                                  "type": "object",
-                                  "properties": {
-                                    "site": {
-                                      "type": "string",
-                                      "maxLength": 50,
-                                      "description": "The site of the social."
-                                    },
-                                    "link": {
-                                      "type": "string",
-                                      "format": "uri",
-                                      "description": "The link of the social."
-                                    }
-                                  },
-                                  "required": [
-                                    "site",
-                                    "link"
-                                  ]
-                                },
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "socials",
-                                  "json": "socials"
-                                }
-                              },
-                              "deletedAt": {
-                                "type": "string",
-                                "format": "date-time",
-                                "nullable": true,
-                                "description": "Timestamp when the user record was soft-deleted (null if not deleted)",
-                                "x-go-type": "core.NullTime",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "deleted_at",
-                                  "json": "deletedAt"
-                                }
-                              },
-                              "roleNames": {
-                                "type": "array",
-                                "x-go-type": "pq.StringArray",
-                                "x-go-type-import": {
-                                  "path": "github.com/lib/pq"
-                                },
-                                "x-go-type-skip-optional-pointer": true,
-                                "items": {
-                                  "type": "string"
-                                },
-                                "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
-                                "example": [
-                                  "organization admin",
-                                  "user"
-                                ],
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "role_names",
-                                  "json": "roleNames"
-                                }
-                              },
-                              "teams": {
-                                "type": "object",
-                                "description": "Teams the user belongs to with role information",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "teams",
-                                  "json": "teams"
-                                },
-                                "properties": {
-                                  "teamsWithRoles": {
-                                    "type": "array",
-                                    "description": "Team memberships for the user with their assigned roles.",
-                                    "items": {
-                                      "type": "object",
-                                      "additionalProperties": false,
-                                      "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                                      "required": [
-                                        "id",
-                                        "name",
-                                        "roleNames"
-                                      ],
-                                      "properties": {
-                                        "id": {
-                                          "description": "Unique identifier of the team.",
-                                          "x-go-name": "ID",
-                                          "x-order": 1,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "id",
-                                            "json": "id,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "uuid",
-                                          "x-go-type": "uuid.UUID",
-                                          "x-go-type-import": {
-                                            "path": "github.com/gofrs/uuid"
-                                          }
-                                        },
-                                        "name": {
-                                          "type": "string",
-                                          "description": "Name of the team.",
-                                          "x-order": 2,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "name",
-                                            "json": "name,omitempty"
-                                          }
-                                        },
-                                        "description": {
-                                          "type": "string",
-                                          "description": "Human readable description of the team.",
-                                          "x-order": 3,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "description",
-                                            "json": "description,omitempty"
-                                          }
-                                        },
-                                        "owner": {
-                                          "description": "Identifier of the team owner.",
-                                          "x-order": 4,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "owner",
-                                            "json": "owner,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "uuid",
-                                          "x-go-type": "uuid.UUID",
-                                          "x-go-type-import": {
-                                            "path": "github.com/gofrs/uuid"
-                                          }
-                                        },
-                                        "metadata": {
-                                          "type": "object",
-                                          "additionalProperties": true,
-                                          "description": "Free-form metadata associated with the team.",
-                                          "x-go-type": "core.Map",
-                                          "x-go-type-skip-optional-pointer": true,
-                                          "x-order": 5,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "metadata",
-                                            "json": "metadata,omitempty"
-                                          }
-                                        },
-                                        "createdAt": {
-                                          "description": "Timestamp when the team was created.",
-                                          "x-order": 6,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "created_at",
-                                            "json": "createdAt,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "date-time",
-                                          "x-go-type-skip-optional-pointer": true
-                                        },
-                                        "updatedAt": {
-                                          "description": "Timestamp when the team was last updated.",
-                                          "x-order": 7,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "updated_at",
-                                            "json": "updatedAt,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "date-time",
-                                          "x-go-type-skip-optional-pointer": true
-                                        },
-                                        "deletedAt": {
-                                          "type": "string",
-                                          "format": "date-time",
-                                          "nullable": true,
-                                          "description": "Timestamp when the team was soft-deleted (null if not deleted).",
-                                          "x-go-type": "core.NullTime",
-                                          "x-order": 8,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "deleted_at",
-                                            "json": "deletedAt,omitempty"
-                                          }
-                                        },
-                                        "roleNames": {
-                                          "type": "array",
-                                          "x-go-type": "pq.StringArray",
-                                          "x-go-type-import": {
-                                            "path": "github.com/lib/pq"
-                                          },
-                                          "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
-                                          "items": {
-                                            "type": "string"
-                                          },
-                                          "x-order": 9,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "role_names",
-                                            "json": "roleNames"
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "teams_with_roles",
-                                      "json": "teamsWithRoles"
-                                    }
-                                  },
-                                  "totalCount": {
-                                    "type": "integer",
-                                    "description": "Total number of team memberships returned for the user.",
-                                    "minimum": 0,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "total_count",
-                                      "json": "totalCount"
-                                    }
-                                  }
-                                }
-                              },
-                              "organizations": {
-                                "type": "object",
-                                "description": "Organizations the user belongs to with role information",
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "organizations",
-                                  "json": "organizations"
-                                },
-                                "properties": {
-                                  "organizationsWithRoles": {
-                                    "type": "array",
-                                    "description": "Organization memberships for the user with their assigned roles.",
-                                    "items": {
-                                      "type": "object",
-                                      "additionalProperties": false,
-                                      "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                                      "required": [
-                                        "id",
-                                        "name",
-                                        "roleNames"
-                                      ],
-                                      "properties": {
-                                        "id": {
-                                          "description": "Unique identifier of the organization.",
-                                          "x-go-name": "ID",
-                                          "x-order": 1,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "id",
-                                            "json": "id,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "uuid",
-                                          "x-go-type": "uuid.UUID",
-                                          "x-go-type-import": {
-                                            "path": "github.com/gofrs/uuid"
-                                          }
-                                        },
-                                        "name": {
-                                          "type": "string",
-                                          "description": "Name of the organization.",
-                                          "x-order": 2,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "name",
-                                            "json": "name,omitempty"
-                                          }
-                                        },
-                                        "description": {
-                                          "type": "string",
-                                          "description": "Human readable description of the organization.",
-                                          "x-order": 3,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "description",
-                                            "json": "description,omitempty"
-                                          }
-                                        },
-                                        "country": {
-                                          "type": "string",
-                                          "description": "Country associated with the organization.",
-                                          "x-order": 4,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "country",
-                                            "json": "country,omitempty"
-                                          }
-                                        },
-                                        "region": {
-                                          "type": "string",
-                                          "description": "Region associated with the organization.",
-                                          "x-order": 5,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "region",
-                                            "json": "region,omitempty"
-                                          }
-                                        },
-                                        "owner": {
-                                          "description": "Identifier of the organization owner.",
-                                          "x-order": 6,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "owner",
-                                            "json": "owner,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "uuid",
-                                          "x-go-type": "uuid.UUID",
-                                          "x-go-type-import": {
-                                            "path": "github.com/gofrs/uuid"
-                                          }
-                                        },
-                                        "createdAt": {
-                                          "description": "Timestamp when the organization was created.",
-                                          "x-order": 7,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "created_at",
-                                            "json": "createdAt,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "date-time",
-                                          "x-go-type-skip-optional-pointer": true
-                                        },
-                                        "updatedAt": {
-                                          "description": "Timestamp when the organization was last updated.",
-                                          "x-order": 8,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "updated_at",
-                                            "json": "updatedAt,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "date-time",
-                                          "x-go-type-skip-optional-pointer": true
-                                        },
-                                        "deletedAt": {
-                                          "type": "string",
-                                          "format": "date-time",
-                                          "nullable": true,
-                                          "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
-                                          "x-go-type": "core.NullTime",
-                                          "x-order": 9,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "deleted_at",
-                                            "json": "deletedAt,omitempty"
-                                          }
-                                        },
-                                        "roleNames": {
-                                          "type": "array",
-                                          "x-go-type": "pq.StringArray",
-                                          "x-go-type-import": {
-                                            "path": "github.com/lib/pq"
-                                          },
-                                          "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
-                                          "items": {
-                                            "type": "string"
-                                          },
-                                          "x-order": 10,
-                                          "x-oapi-codegen-extra-tags": {
-                                            "db": "role_names",
-                                            "json": "roleNames"
-                                          }
-                                        }
-                                      }
-                                    },
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "organizations_with_roles",
-                                      "json": "organizationsWithRoles"
-                                    }
-                                  },
-                                  "totalCount": {
-                                    "type": "integer",
-                                    "description": "Total number of organization memberships returned for the user.",
-                                    "minimum": 0,
-                                    "x-oapi-codegen-extra-tags": {
-                                      "db": "total_count",
-                                      "json": "totalCount"
-                                    }
-                                  }
+                                  "json": "avatarUrl,omitempty"
                                 }
                               }
-                            },
-                            "additionalProperties": false
+                            }
                           },
                           "location": {
                             "description": "Optional structured location metadata (branch, host, path, ...).",
@@ -7599,17 +3561,17 @@ const DesignSchema: Record<string, unknown> = {
                       ],
                       "properties": {
                         "id": {
-                          "description": "Unique identifier for the user",
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
+                          },
                           "x-go-name": "ID",
                           "x-oapi-codegen-extra-tags": {
                             "db": "id",
                             "json": "id"
-                          },
-                          "type": "string",
-                          "format": "uuid",
-                          "x-go-type": "uuid.UUID",
-                          "x-go-type-import": {
-                            "path": "github.com/gofrs/uuid"
                           }
                         },
                         "userId": {
@@ -8037,18 +3999,18 @@ const DesignSchema: Record<string, unknown> = {
                                 ],
                                 "properties": {
                                   "id": {
-                                    "description": "Unique identifier of the team.",
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    },
                                     "x-go-name": "ID",
                                     "x-order": 1,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "id",
                                       "json": "id,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
                                     }
                                   },
                                   "name": {
@@ -8070,17 +4032,17 @@ const DesignSchema: Record<string, unknown> = {
                                     }
                                   },
                                   "owner": {
-                                    "description": "Identifier of the team owner.",
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    },
                                     "x-order": 4,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "owner",
                                       "json": "owner,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
                                     }
                                   },
                                   "metadata": {
@@ -8185,18 +4147,18 @@ const DesignSchema: Record<string, unknown> = {
                                 ],
                                 "properties": {
                                   "id": {
-                                    "description": "Unique identifier of the organization.",
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    },
                                     "x-go-name": "ID",
                                     "x-order": 1,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "id",
                                       "json": "id,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
                                     }
                                   },
                                   "name": {
@@ -8236,17 +4198,17 @@ const DesignSchema: Record<string, unknown> = {
                                     }
                                   },
                                   "owner": {
-                                    "description": "Identifier of the organization owner.",
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    },
                                     "x-order": 6,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "owner",
                                       "json": "owner,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
                                     }
                                   },
                                   "createdAt": {
@@ -8573,17 +4535,17 @@ const DesignSchema: Record<string, unknown> = {
                       ],
                       "properties": {
                         "id": {
-                          "description": "Unique identifier for the user",
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
+                          },
                           "x-go-name": "ID",
                           "x-oapi-codegen-extra-tags": {
                             "db": "id",
                             "json": "id"
-                          },
-                          "type": "string",
-                          "format": "uuid",
-                          "x-go-type": "uuid.UUID",
-                          "x-go-type-import": {
-                            "path": "github.com/gofrs/uuid"
                           }
                         },
                         "userId": {
@@ -9011,18 +4973,18 @@ const DesignSchema: Record<string, unknown> = {
                                 ],
                                 "properties": {
                                   "id": {
-                                    "description": "Unique identifier of the team.",
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    },
                                     "x-go-name": "ID",
                                     "x-order": 1,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "id",
                                       "json": "id,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
                                     }
                                   },
                                   "name": {
@@ -9044,17 +5006,17 @@ const DesignSchema: Record<string, unknown> = {
                                     }
                                   },
                                   "owner": {
-                                    "description": "Identifier of the team owner.",
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    },
                                     "x-order": 4,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "owner",
                                       "json": "owner,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
                                     }
                                   },
                                   "metadata": {
@@ -9159,18 +5121,18 @@ const DesignSchema: Record<string, unknown> = {
                                 ],
                                 "properties": {
                                   "id": {
-                                    "description": "Unique identifier of the organization.",
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    },
                                     "x-go-name": "ID",
                                     "x-order": 1,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "id",
                                       "json": "id,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
                                     }
                                   },
                                   "name": {
@@ -9210,17 +5172,17 @@ const DesignSchema: Record<string, unknown> = {
                                     }
                                   },
                                   "owner": {
-                                    "description": "Identifier of the organization owner.",
+                                    "type": "string",
+                                    "format": "uuid",
+                                    "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                    "x-go-type": "uuid.UUID",
+                                    "x-go-type-import": {
+                                      "path": "github.com/gofrs/uuid"
+                                    },
                                     "x-order": 6,
                                     "x-oapi-codegen-extra-tags": {
                                       "db": "owner",
                                       "json": "owner,omitempty"
-                                    },
-                                    "type": "string",
-                                    "format": "uuid",
-                                    "x-go-type": "uuid.UUID",
-                                    "x-go-type-import": {
-                                      "path": "github.com/gofrs/uuid"
                                     }
                                   },
                                   "createdAt": {
@@ -10104,17 +6066,17 @@ const DesignSchema: Record<string, unknown> = {
                             ],
                             "properties": {
                               "id": {
-                                "description": "Unique identifier for the user",
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                },
                                 "x-go-name": "ID",
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "id",
                                   "json": "id"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
                                 }
                               },
                               "userId": {
@@ -10542,18 +6504,18 @@ const DesignSchema: Record<string, unknown> = {
                                       ],
                                       "properties": {
                                         "id": {
-                                          "description": "Unique identifier of the team.",
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          },
                                           "x-go-name": "ID",
                                           "x-order": 1,
                                           "x-oapi-codegen-extra-tags": {
                                             "db": "id",
                                             "json": "id,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "uuid",
-                                          "x-go-type": "uuid.UUID",
-                                          "x-go-type-import": {
-                                            "path": "github.com/gofrs/uuid"
                                           }
                                         },
                                         "name": {
@@ -10575,17 +6537,17 @@ const DesignSchema: Record<string, unknown> = {
                                           }
                                         },
                                         "owner": {
-                                          "description": "Identifier of the team owner.",
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          },
                                           "x-order": 4,
                                           "x-oapi-codegen-extra-tags": {
                                             "db": "owner",
                                             "json": "owner,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "uuid",
-                                          "x-go-type": "uuid.UUID",
-                                          "x-go-type-import": {
-                                            "path": "github.com/gofrs/uuid"
                                           }
                                         },
                                         "metadata": {
@@ -10690,18 +6652,18 @@ const DesignSchema: Record<string, unknown> = {
                                       ],
                                       "properties": {
                                         "id": {
-                                          "description": "Unique identifier of the organization.",
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          },
                                           "x-go-name": "ID",
                                           "x-order": 1,
                                           "x-oapi-codegen-extra-tags": {
                                             "db": "id",
                                             "json": "id,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "uuid",
-                                          "x-go-type": "uuid.UUID",
-                                          "x-go-type-import": {
-                                            "path": "github.com/gofrs/uuid"
                                           }
                                         },
                                         "name": {
@@ -10741,17 +6703,17 @@ const DesignSchema: Record<string, unknown> = {
                                           }
                                         },
                                         "owner": {
-                                          "description": "Identifier of the organization owner.",
+                                          "type": "string",
+                                          "format": "uuid",
+                                          "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                          "x-go-type": "uuid.UUID",
+                                          "x-go-type-import": {
+                                            "path": "github.com/gofrs/uuid"
+                                          },
                                           "x-order": 6,
                                           "x-oapi-codegen-extra-tags": {
                                             "db": "owner",
                                             "json": "owner,omitempty"
-                                          },
-                                          "type": "string",
-                                          "format": "uuid",
-                                          "x-go-type": "uuid.UUID",
-                                          "x-go-type-import": {
-                                            "path": "github.com/gofrs/uuid"
                                           }
                                         },
                                         "createdAt": {
@@ -11003,6 +6965,76 @@ const DesignSchema: Record<string, unknown> = {
       }
     },
     "schemas": {
+      "CatalogAuthor": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "Public projection of a user as served on unauthenticated catalog endpoints (e.g. GET /api/catalog/content/{type}). Carries only the fields the Cloud privacy ruling permits an anonymous caller to see: identity, display names, and avatar URL. Email and every other personally-identifying or account-internal field are deliberately absent (meshery/schemas#1106). For the full authenticated user record see User in v1beta2/user/api.yml.",
+        "required": [
+          "id"
+        ],
+        "properties": {
+          "id": {
+            "description": "Unique identifier for the user.",
+            "x-go-name": "ID",
+            "x-oapi-codegen-extra-tags": {
+              "db": "id",
+              "json": "id"
+            },
+            "type": "string",
+            "format": "uuid",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/gofrs/uuid"
+            }
+          },
+          "userId": {
+            "deprecated": true,
+            "description": "Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.",
+            "x-go-name": "UserID",
+            "x-oapi-codegen-extra-tags": {
+              "db": "user_id",
+              "json": "userId,omitempty"
+            },
+            "type": "string",
+            "format": "uuid",
+            "x-go-type": "uuid.UUID",
+            "x-go-type-import": {
+              "path": "github.com/gofrs/uuid"
+            }
+          },
+          "firstName": {
+            "type": "string",
+            "maxLength": 200,
+            "description": "User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+            "x-go-type-skip-optional-pointer": true,
+            "x-oapi-codegen-extra-tags": {
+              "db": "first_name",
+              "json": "firstName,omitempty"
+            }
+          },
+          "lastName": {
+            "type": "string",
+            "maxLength": 300,
+            "description": "User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+            "x-go-type-skip-optional-pointer": true,
+            "x-oapi-codegen-extra-tags": {
+              "db": "last_name",
+              "json": "lastName,omitempty"
+            }
+          },
+          "avatarUrl": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 500,
+            "description": "URL to the user's avatar image.",
+            "x-go-type-skip-optional-pointer": true,
+            "x-oapi-codegen-extra-tags": {
+              "db": "avatar_url",
+              "json": "avatarUrl,omitempty"
+            }
+          }
+        }
+      },
       "DeletePatternModel": {
         "type": "object",
         "description": "Reference to a design for bulk deletion by ID.",
@@ -15814,33 +11846,20 @@ const DesignSchema: Record<string, unknown> = {
             "x-go-type-skip-optional-pointer": true
           },
           "user": {
-            "description": "Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
+            "description": "Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
             "nullable": true,
-            "x-go-type": "*userV1beta.User",
-            "x-go-type-import": {
-              "path": "github.com/meshery/schemas/models/v1beta2/user",
-              "name": "userV1beta"
-            },
+            "x-go-type": "*CatalogAuthor",
             "x-oapi-codegen-extra-tags": {
               "db": "-"
             },
             "type": "object",
+            "additionalProperties": false,
             "required": [
-              "id",
-              "userId",
-              "provider",
-              "email",
-              "firstName",
-              "lastName",
-              "status",
-              "createdAt",
-              "updatedAt",
-              "lastLoginTime",
-              "deletedAt"
+              "id"
             ],
             "properties": {
               "id": {
-                "description": "Unique identifier for the user",
+                "description": "Unique identifier for the user.",
                 "x-go-name": "ID",
                 "x-oapi-codegen-extra-tags": {
                   "db": "id",
@@ -15854,712 +11873,52 @@ const DesignSchema: Record<string, unknown> = {
                 }
               },
               "userId": {
-                "type": "string",
-                "maxLength": 200,
                 "deprecated": true,
-                "description": "Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.",
+                "description": "Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.",
+                "x-go-name": "UserID",
                 "x-oapi-codegen-extra-tags": {
                   "db": "user_id",
-                  "json": "userId"
+                  "json": "userId,omitempty"
                 },
-                "x-id-format": "external"
-              },
-              "provider": {
                 "type": "string",
-                "maxLength": 100,
-                "description": "Authentication provider (e.g., Google, Github)",
-                "example": [
-                  "local",
-                  "github",
-                  "google",
-                  "twitter"
-                ],
-                "x-oapi-codegen-extra-tags": {
-                  "db": "provider",
-                  "json": "provider"
-                }
-              },
-              "email": {
-                "type": "string",
-                "format": "email",
-                "maxLength": 300,
-                "description": "User's email address",
-                "x-oapi-codegen-extra-tags": {
-                  "db": "email",
-                  "json": "email"
+                "format": "uuid",
+                "x-go-type": "uuid.UUID",
+                "x-go-type-import": {
+                  "path": "github.com/gofrs/uuid"
                 }
               },
               "firstName": {
                 "type": "string",
                 "maxLength": 200,
-                "description": "User's first name",
+                "description": "User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                "x-go-type-skip-optional-pointer": true,
                 "x-oapi-codegen-extra-tags": {
                   "db": "first_name",
-                  "json": "firstName"
+                  "json": "firstName,omitempty"
                 }
               },
               "lastName": {
                 "type": "string",
                 "maxLength": 300,
-                "description": "User's last name",
+                "description": "User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                "x-go-type-skip-optional-pointer": true,
                 "x-oapi-codegen-extra-tags": {
                   "db": "last_name",
-                  "json": "lastName"
+                  "json": "lastName,omitempty"
                 }
               },
               "avatarUrl": {
                 "type": "string",
                 "format": "uri",
                 "maxLength": 500,
-                "description": "URL to user's avatar image",
+                "description": "URL to the user's avatar image.",
+                "x-go-type-skip-optional-pointer": true,
                 "x-oapi-codegen-extra-tags": {
                   "db": "avatar_url",
-                  "json": "avatarUrl"
-                }
-              },
-              "status": {
-                "type": "string",
-                "maxLength": 100,
-                "enum": [
-                  "active",
-                  "inactive",
-                  "pending",
-                  "anonymous"
-                ],
-                "description": "User account status",
-                "x-oapi-codegen-extra-tags": {
-                  "db": "status",
-                  "json": "status"
-                }
-              },
-              "bio": {
-                "type": "string",
-                "maxLength": 1000,
-                "default": "",
-                "description": "User's biography or description",
-                "x-oapi-codegen-extra-tags": {
-                  "db": "bio",
-                  "json": "bio"
-                }
-              },
-              "country": {
-                "type": "object",
-                "description": "User's country information stored as JSONB",
-                "additionalProperties": true,
-                "x-go-type": "core.Map",
-                "x-go-type-skip-optional-pointer": true,
-                "x-oapi-codegen-extra-tags": {
-                  "db": "country",
-                  "json": "country"
-                }
-              },
-              "region": {
-                "type": "object",
-                "description": "User's region information stored as JSONB",
-                "additionalProperties": true,
-                "x-go-type": "core.Map",
-                "x-go-type-skip-optional-pointer": true,
-                "x-oapi-codegen-extra-tags": {
-                  "db": "region",
-                  "json": "region"
-                }
-              },
-              "preferences": {
-                "x-go-type": "Preference",
-                "description": "User preferences stored as JSONB",
-                "x-oapi-codegen-extra-tags": {
-                  "db": "preferences",
-                  "json": "preferences"
-                },
-                "x-generate-db-helpers": true,
-                "type": "object",
-                "required": [
-                  "anonymousUsageStats",
-                  "anonymousPerfResults",
-                  "updatedAt",
-                  "dashboardPreferences",
-                  "selectedOrganizationId",
-                  "selectedWorkspaceForOrganizations",
-                  "usersExtensionPreferences",
-                  "remoteProviderPreferences"
-                ],
-                "properties": {
-                  "meshAdapters": {
-                    "type": "array",
-                    "items": {
-                      "x-go-type": "Adapter",
-                      "type": "object",
-                      "description": "Placeholder for Adapter struct definition."
-                    },
-                    "description": "The mesh adapters of the preference."
-                  },
-                  "grafana": {
-                    "x-go-type": "Grafana",
-                    "type": "object",
-                    "properties": {
-                      "grafanaUrl": {
-                        "type": "string",
-                        "description": "Grafana URL for the user configuration.",
-                        "maxLength": 500
-                      },
-                      "grafanaApiKey": {
-                        "type": "string",
-                        "description": "Grafana API key for the user configuration.",
-                        "maxLength": 500
-                      },
-                      "selectedBoardsConfigs": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "board": {
-                              "type": "object",
-                              "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                            },
-                            "panels": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                              },
-                              "description": "Panels selected for the Grafana board configuration."
-                            },
-                            "templateVars": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              },
-                              "description": "Template variables applied to the selected Grafana board configuration."
-                            }
-                          }
-                        },
-                        "description": "Selected Grafana board configurations for the user."
-                      }
-                    }
-                  },
-                  "prometheus": {
-                    "x-go-type": "Prometheus",
-                    "type": "object",
-                    "properties": {
-                      "prometheusUrl": {
-                        "type": "string",
-                        "description": "The prometheus URL of the prometheus.",
-                        "maxLength": 500
-                      },
-                      "selectedPrometheusBoardsConfigs": {
-                        "type": "array",
-                        "items": {
-                          "type": "object",
-                          "properties": {
-                            "board": {
-                              "type": "object",
-                              "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                            },
-                            "panels": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                              },
-                              "description": "Panels selected for the Grafana board configuration."
-                            },
-                            "templateVars": {
-                              "type": "array",
-                              "items": {
-                                "type": "string"
-                              },
-                              "description": "Template variables applied to the selected Grafana board configuration."
-                            }
-                          }
-                        },
-                        "description": "The selected prometheus boards configs of the prometheus."
-                      }
-                    }
-                  },
-                  "loadTestPrefs": {
-                    "x-go-type": "LoadTestPreferences",
-                    "type": "object",
-                    "properties": {
-                      "c": {
-                        "type": "integer",
-                        "description": "Concurrent requests",
-                        "minimum": 0
-                      },
-                      "qps": {
-                        "type": "integer",
-                        "description": "Queries per second",
-                        "minimum": 0
-                      },
-                      "t": {
-                        "type": "string",
-                        "description": "Duration",
-                        "maxLength": 500
-                      },
-                      "gen": {
-                        "type": "string",
-                        "description": "Load generator",
-                        "maxLength": 500
-                      }
-                    }
-                  },
-                  "anonymousUsageStats": {
-                    "type": "boolean",
-                    "description": "The anonymous usage stats of the preference."
-                  },
-                  "anonymousPerfResults": {
-                    "type": "boolean",
-                    "description": "The anonymous perf results of the preference."
-                  },
-                  "updatedAt": {
-                    "type": "string",
-                    "format": "date-time",
-                    "description": "Timestamp of when the resource was last updated."
-                  },
-                  "dashboardPreferences": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "description": "The dashboard preferences of the preference."
-                  },
-                  "selectedOrganizationId": {
-                    "type": "string",
-                    "description": "ID of the associated selectedOrganization.",
-                    "maxLength": 500,
-                    "format": "uuid"
-                  },
-                  "selectedWorkspaceForOrganizations": {
-                    "type": "object",
-                    "additionalProperties": {
-                      "type": "string"
-                    },
-                    "description": "The selected workspace for organizations of the preference."
-                  },
-                  "usersExtensionPreferences": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "description": "The users extension preferences of the preference."
-                  },
-                  "remoteProviderPreferences": {
-                    "type": "object",
-                    "additionalProperties": true,
-                    "description": "The remote provider preferences of the preference."
-                  }
-                }
-              },
-              "acceptedTermsAt": {
-                "description": "Timestamp when user accepted terms and conditions",
-                "x-oapi-codegen-extra-tags": {
-                  "db": "accepted_terms_at",
-                  "json": "acceptedTermsAt"
-                },
-                "type": "string",
-                "format": "date-time",
-                "x-go-type-skip-optional-pointer": true
-              },
-              "firstLoginTime": {
-                "description": "Timestamp of user's first login",
-                "x-oapi-codegen-extra-tags": {
-                  "db": "first_login_time",
-                  "json": "firstLoginTime"
-                },
-                "type": "string",
-                "format": "date-time",
-                "x-go-type-skip-optional-pointer": true
-              },
-              "lastLoginTime": {
-                "description": "Timestamp of user's most recent login",
-                "x-oapi-codegen-extra-tags": {
-                  "db": "last_login_time",
-                  "json": "lastLoginTime"
-                },
-                "type": "string",
-                "format": "date-time",
-                "x-go-type-skip-optional-pointer": true
-              },
-              "createdAt": {
-                "description": "Timestamp when the user record was created",
-                "x-oapi-codegen-extra-tags": {
-                  "db": "created_at",
-                  "json": "createdAt"
-                },
-                "type": "string",
-                "format": "date-time",
-                "x-go-type-skip-optional-pointer": true
-              },
-              "updatedAt": {
-                "description": "Timestamp when the user record was last updated",
-                "x-oapi-codegen-extra-tags": {
-                  "db": "updated_at",
-                  "json": "updatedAt"
-                },
-                "type": "string",
-                "format": "date-time",
-                "x-go-type-skip-optional-pointer": true
-              },
-              "socials": {
-                "type": "array",
-                "description": "Various online profiles associated with the user account",
-                "x-go-type": "UserSocials",
-                "items": {
-                  "x-go-type": "Social",
-                  "description": "Various online profiles associated with the user account, like GitHub, LinkedIn, X, and so on.",
-                  "type": "object",
-                  "properties": {
-                    "site": {
-                      "type": "string",
-                      "maxLength": 50,
-                      "description": "The site of the social."
-                    },
-                    "link": {
-                      "type": "string",
-                      "format": "uri",
-                      "description": "The link of the social."
-                    }
-                  },
-                  "required": [
-                    "site",
-                    "link"
-                  ]
-                },
-                "x-oapi-codegen-extra-tags": {
-                  "db": "socials",
-                  "json": "socials"
-                }
-              },
-              "deletedAt": {
-                "type": "string",
-                "format": "date-time",
-                "nullable": true,
-                "description": "Timestamp when the user record was soft-deleted (null if not deleted)",
-                "x-go-type": "core.NullTime",
-                "x-oapi-codegen-extra-tags": {
-                  "db": "deleted_at",
-                  "json": "deletedAt"
-                }
-              },
-              "roleNames": {
-                "type": "array",
-                "x-go-type": "pq.StringArray",
-                "x-go-type-import": {
-                  "path": "github.com/lib/pq"
-                },
-                "x-go-type-skip-optional-pointer": true,
-                "items": {
-                  "type": "string"
-                },
-                "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
-                "example": [
-                  "organization admin",
-                  "user"
-                ],
-                "x-oapi-codegen-extra-tags": {
-                  "db": "role_names",
-                  "json": "roleNames"
-                }
-              },
-              "teams": {
-                "type": "object",
-                "description": "Teams the user belongs to with role information",
-                "x-oapi-codegen-extra-tags": {
-                  "db": "teams",
-                  "json": "teams"
-                },
-                "properties": {
-                  "teamsWithRoles": {
-                    "type": "array",
-                    "description": "Team memberships for the user with their assigned roles.",
-                    "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                      "required": [
-                        "id",
-                        "name",
-                        "roleNames"
-                      ],
-                      "properties": {
-                        "id": {
-                          "description": "Unique identifier of the team.",
-                          "x-go-name": "ID",
-                          "x-order": 1,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "id",
-                            "json": "id,omitempty"
-                          },
-                          "type": "string",
-                          "format": "uuid",
-                          "x-go-type": "uuid.UUID",
-                          "x-go-type-import": {
-                            "path": "github.com/gofrs/uuid"
-                          }
-                        },
-                        "name": {
-                          "type": "string",
-                          "description": "Name of the team.",
-                          "x-order": 2,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "name",
-                            "json": "name,omitempty"
-                          }
-                        },
-                        "description": {
-                          "type": "string",
-                          "description": "Human readable description of the team.",
-                          "x-order": 3,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "description",
-                            "json": "description,omitempty"
-                          }
-                        },
-                        "owner": {
-                          "description": "Identifier of the team owner.",
-                          "x-order": 4,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "owner",
-                            "json": "owner,omitempty"
-                          },
-                          "type": "string",
-                          "format": "uuid",
-                          "x-go-type": "uuid.UUID",
-                          "x-go-type-import": {
-                            "path": "github.com/gofrs/uuid"
-                          }
-                        },
-                        "metadata": {
-                          "type": "object",
-                          "additionalProperties": true,
-                          "description": "Free-form metadata associated with the team.",
-                          "x-go-type": "core.Map",
-                          "x-go-type-skip-optional-pointer": true,
-                          "x-order": 5,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "metadata",
-                            "json": "metadata,omitempty"
-                          }
-                        },
-                        "createdAt": {
-                          "description": "Timestamp when the team was created.",
-                          "x-order": 6,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "created_at",
-                            "json": "createdAt,omitempty"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "updatedAt": {
-                          "description": "Timestamp when the team was last updated.",
-                          "x-order": 7,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "updated_at",
-                            "json": "updatedAt,omitempty"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "deletedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "nullable": true,
-                          "description": "Timestamp when the team was soft-deleted (null if not deleted).",
-                          "x-go-type": "core.NullTime",
-                          "x-order": 8,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "deleted_at",
-                            "json": "deletedAt,omitempty"
-                          }
-                        },
-                        "roleNames": {
-                          "type": "array",
-                          "x-go-type": "pq.StringArray",
-                          "x-go-type-import": {
-                            "path": "github.com/lib/pq"
-                          },
-                          "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "x-order": 9,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "role_names",
-                            "json": "roleNames"
-                          }
-                        }
-                      }
-                    },
-                    "x-oapi-codegen-extra-tags": {
-                      "db": "teams_with_roles",
-                      "json": "teamsWithRoles"
-                    }
-                  },
-                  "totalCount": {
-                    "type": "integer",
-                    "description": "Total number of team memberships returned for the user.",
-                    "minimum": 0,
-                    "x-oapi-codegen-extra-tags": {
-                      "db": "total_count",
-                      "json": "totalCount"
-                    }
-                  }
-                }
-              },
-              "organizations": {
-                "type": "object",
-                "description": "Organizations the user belongs to with role information",
-                "x-oapi-codegen-extra-tags": {
-                  "db": "organizations",
-                  "json": "organizations"
-                },
-                "properties": {
-                  "organizationsWithRoles": {
-                    "type": "array",
-                    "description": "Organization memberships for the user with their assigned roles.",
-                    "items": {
-                      "type": "object",
-                      "additionalProperties": false,
-                      "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                      "required": [
-                        "id",
-                        "name",
-                        "roleNames"
-                      ],
-                      "properties": {
-                        "id": {
-                          "description": "Unique identifier of the organization.",
-                          "x-go-name": "ID",
-                          "x-order": 1,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "id",
-                            "json": "id,omitempty"
-                          },
-                          "type": "string",
-                          "format": "uuid",
-                          "x-go-type": "uuid.UUID",
-                          "x-go-type-import": {
-                            "path": "github.com/gofrs/uuid"
-                          }
-                        },
-                        "name": {
-                          "type": "string",
-                          "description": "Name of the organization.",
-                          "x-order": 2,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "name",
-                            "json": "name,omitempty"
-                          }
-                        },
-                        "description": {
-                          "type": "string",
-                          "description": "Human readable description of the organization.",
-                          "x-order": 3,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "description",
-                            "json": "description,omitempty"
-                          }
-                        },
-                        "country": {
-                          "type": "string",
-                          "description": "Country associated with the organization.",
-                          "x-order": 4,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "country",
-                            "json": "country,omitempty"
-                          }
-                        },
-                        "region": {
-                          "type": "string",
-                          "description": "Region associated with the organization.",
-                          "x-order": 5,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "region",
-                            "json": "region,omitempty"
-                          }
-                        },
-                        "owner": {
-                          "description": "Identifier of the organization owner.",
-                          "x-order": 6,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "owner",
-                            "json": "owner,omitempty"
-                          },
-                          "type": "string",
-                          "format": "uuid",
-                          "x-go-type": "uuid.UUID",
-                          "x-go-type-import": {
-                            "path": "github.com/gofrs/uuid"
-                          }
-                        },
-                        "createdAt": {
-                          "description": "Timestamp when the organization was created.",
-                          "x-order": 7,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "created_at",
-                            "json": "createdAt,omitempty"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "updatedAt": {
-                          "description": "Timestamp when the organization was last updated.",
-                          "x-order": 8,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "updated_at",
-                            "json": "updatedAt,omitempty"
-                          },
-                          "type": "string",
-                          "format": "date-time",
-                          "x-go-type-skip-optional-pointer": true
-                        },
-                        "deletedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "nullable": true,
-                          "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
-                          "x-go-type": "core.NullTime",
-                          "x-order": 9,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "deleted_at",
-                            "json": "deletedAt,omitempty"
-                          }
-                        },
-                        "roleNames": {
-                          "type": "array",
-                          "x-go-type": "pq.StringArray",
-                          "x-go-type-import": {
-                            "path": "github.com/lib/pq"
-                          },
-                          "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
-                          "items": {
-                            "type": "string"
-                          },
-                          "x-order": 10,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "role_names",
-                            "json": "roleNames"
-                          }
-                        }
-                      }
-                    },
-                    "x-oapi-codegen-extra-tags": {
-                      "db": "organizations_with_roles",
-                      "json": "organizationsWithRoles"
-                    }
-                  },
-                  "totalCount": {
-                    "type": "integer",
-                    "description": "Total number of organization memberships returned for the user.",
-                    "minimum": 0,
-                    "x-oapi-codegen-extra-tags": {
-                      "db": "total_count",
-                      "json": "totalCount"
-                    }
-                  }
+                  "json": "avatarUrl,omitempty"
                 }
               }
-            },
-            "additionalProperties": false
+            }
           },
           "location": {
             "description": "Optional structured location metadata (branch, host, path, ...).",
@@ -16835,33 +12194,20 @@ const DesignSchema: Record<string, unknown> = {
                   "x-go-type-skip-optional-pointer": true
                 },
                 "user": {
-                  "description": "Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
+                  "description": "Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
                   "nullable": true,
-                  "x-go-type": "*userV1beta.User",
-                  "x-go-type-import": {
-                    "path": "github.com/meshery/schemas/models/v1beta2/user",
-                    "name": "userV1beta"
-                  },
+                  "x-go-type": "*CatalogAuthor",
                   "x-oapi-codegen-extra-tags": {
                     "db": "-"
                   },
                   "type": "object",
+                  "additionalProperties": false,
                   "required": [
-                    "id",
-                    "userId",
-                    "provider",
-                    "email",
-                    "firstName",
-                    "lastName",
-                    "status",
-                    "createdAt",
-                    "updatedAt",
-                    "lastLoginTime",
-                    "deletedAt"
+                    "id"
                   ],
                   "properties": {
                     "id": {
-                      "description": "Unique identifier for the user",
+                      "description": "Unique identifier for the user.",
                       "x-go-name": "ID",
                       "x-oapi-codegen-extra-tags": {
                         "db": "id",
@@ -16875,712 +12221,52 @@ const DesignSchema: Record<string, unknown> = {
                       }
                     },
                     "userId": {
-                      "type": "string",
-                      "maxLength": 200,
                       "deprecated": true,
-                      "description": "Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.",
+                      "description": "Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.",
+                      "x-go-name": "UserID",
                       "x-oapi-codegen-extra-tags": {
                         "db": "user_id",
-                        "json": "userId"
+                        "json": "userId,omitempty"
                       },
-                      "x-id-format": "external"
-                    },
-                    "provider": {
                       "type": "string",
-                      "maxLength": 100,
-                      "description": "Authentication provider (e.g., Google, Github)",
-                      "example": [
-                        "local",
-                        "github",
-                        "google",
-                        "twitter"
-                      ],
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "provider",
-                        "json": "provider"
-                      }
-                    },
-                    "email": {
-                      "type": "string",
-                      "format": "email",
-                      "maxLength": 300,
-                      "description": "User's email address",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "email",
-                        "json": "email"
+                      "format": "uuid",
+                      "x-go-type": "uuid.UUID",
+                      "x-go-type-import": {
+                        "path": "github.com/gofrs/uuid"
                       }
                     },
                     "firstName": {
                       "type": "string",
                       "maxLength": 200,
-                      "description": "User's first name",
+                      "description": "User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                      "x-go-type-skip-optional-pointer": true,
                       "x-oapi-codegen-extra-tags": {
                         "db": "first_name",
-                        "json": "firstName"
+                        "json": "firstName,omitempty"
                       }
                     },
                     "lastName": {
                       "type": "string",
                       "maxLength": 300,
-                      "description": "User's last name",
+                      "description": "User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                      "x-go-type-skip-optional-pointer": true,
                       "x-oapi-codegen-extra-tags": {
                         "db": "last_name",
-                        "json": "lastName"
+                        "json": "lastName,omitempty"
                       }
                     },
                     "avatarUrl": {
                       "type": "string",
                       "format": "uri",
                       "maxLength": 500,
-                      "description": "URL to user's avatar image",
+                      "description": "URL to the user's avatar image.",
+                      "x-go-type-skip-optional-pointer": true,
                       "x-oapi-codegen-extra-tags": {
                         "db": "avatar_url",
-                        "json": "avatarUrl"
-                      }
-                    },
-                    "status": {
-                      "type": "string",
-                      "maxLength": 100,
-                      "enum": [
-                        "active",
-                        "inactive",
-                        "pending",
-                        "anonymous"
-                      ],
-                      "description": "User account status",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "status",
-                        "json": "status"
-                      }
-                    },
-                    "bio": {
-                      "type": "string",
-                      "maxLength": 1000,
-                      "default": "",
-                      "description": "User's biography or description",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "bio",
-                        "json": "bio"
-                      }
-                    },
-                    "country": {
-                      "type": "object",
-                      "description": "User's country information stored as JSONB",
-                      "additionalProperties": true,
-                      "x-go-type": "core.Map",
-                      "x-go-type-skip-optional-pointer": true,
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "country",
-                        "json": "country"
-                      }
-                    },
-                    "region": {
-                      "type": "object",
-                      "description": "User's region information stored as JSONB",
-                      "additionalProperties": true,
-                      "x-go-type": "core.Map",
-                      "x-go-type-skip-optional-pointer": true,
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "region",
-                        "json": "region"
-                      }
-                    },
-                    "preferences": {
-                      "x-go-type": "Preference",
-                      "description": "User preferences stored as JSONB",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "preferences",
-                        "json": "preferences"
-                      },
-                      "x-generate-db-helpers": true,
-                      "type": "object",
-                      "required": [
-                        "anonymousUsageStats",
-                        "anonymousPerfResults",
-                        "updatedAt",
-                        "dashboardPreferences",
-                        "selectedOrganizationId",
-                        "selectedWorkspaceForOrganizations",
-                        "usersExtensionPreferences",
-                        "remoteProviderPreferences"
-                      ],
-                      "properties": {
-                        "meshAdapters": {
-                          "type": "array",
-                          "items": {
-                            "x-go-type": "Adapter",
-                            "type": "object",
-                            "description": "Placeholder for Adapter struct definition."
-                          },
-                          "description": "The mesh adapters of the preference."
-                        },
-                        "grafana": {
-                          "x-go-type": "Grafana",
-                          "type": "object",
-                          "properties": {
-                            "grafanaUrl": {
-                              "type": "string",
-                              "description": "Grafana URL for the user configuration.",
-                              "maxLength": 500
-                            },
-                            "grafanaApiKey": {
-                              "type": "string",
-                              "description": "Grafana API key for the user configuration.",
-                              "maxLength": 500
-                            },
-                            "selectedBoardsConfigs": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "board": {
-                                    "type": "object",
-                                    "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                  },
-                                  "panels": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                    },
-                                    "description": "Panels selected for the Grafana board configuration."
-                                  },
-                                  "templateVars": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "description": "Template variables applied to the selected Grafana board configuration."
-                                  }
-                                }
-                              },
-                              "description": "Selected Grafana board configurations for the user."
-                            }
-                          }
-                        },
-                        "prometheus": {
-                          "x-go-type": "Prometheus",
-                          "type": "object",
-                          "properties": {
-                            "prometheusUrl": {
-                              "type": "string",
-                              "description": "The prometheus URL of the prometheus.",
-                              "maxLength": 500
-                            },
-                            "selectedPrometheusBoardsConfigs": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "board": {
-                                    "type": "object",
-                                    "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                  },
-                                  "panels": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                    },
-                                    "description": "Panels selected for the Grafana board configuration."
-                                  },
-                                  "templateVars": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "description": "Template variables applied to the selected Grafana board configuration."
-                                  }
-                                }
-                              },
-                              "description": "The selected prometheus boards configs of the prometheus."
-                            }
-                          }
-                        },
-                        "loadTestPrefs": {
-                          "x-go-type": "LoadTestPreferences",
-                          "type": "object",
-                          "properties": {
-                            "c": {
-                              "type": "integer",
-                              "description": "Concurrent requests",
-                              "minimum": 0
-                            },
-                            "qps": {
-                              "type": "integer",
-                              "description": "Queries per second",
-                              "minimum": 0
-                            },
-                            "t": {
-                              "type": "string",
-                              "description": "Duration",
-                              "maxLength": 500
-                            },
-                            "gen": {
-                              "type": "string",
-                              "description": "Load generator",
-                              "maxLength": 500
-                            }
-                          }
-                        },
-                        "anonymousUsageStats": {
-                          "type": "boolean",
-                          "description": "The anonymous usage stats of the preference."
-                        },
-                        "anonymousPerfResults": {
-                          "type": "boolean",
-                          "description": "The anonymous perf results of the preference."
-                        },
-                        "updatedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "Timestamp of when the resource was last updated."
-                        },
-                        "dashboardPreferences": {
-                          "type": "object",
-                          "additionalProperties": true,
-                          "description": "The dashboard preferences of the preference."
-                        },
-                        "selectedOrganizationId": {
-                          "type": "string",
-                          "description": "ID of the associated selectedOrganization.",
-                          "maxLength": 500,
-                          "format": "uuid"
-                        },
-                        "selectedWorkspaceForOrganizations": {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "The selected workspace for organizations of the preference."
-                        },
-                        "usersExtensionPreferences": {
-                          "type": "object",
-                          "additionalProperties": true,
-                          "description": "The users extension preferences of the preference."
-                        },
-                        "remoteProviderPreferences": {
-                          "type": "object",
-                          "additionalProperties": true,
-                          "description": "The remote provider preferences of the preference."
-                        }
-                      }
-                    },
-                    "acceptedTermsAt": {
-                      "description": "Timestamp when user accepted terms and conditions",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "accepted_terms_at",
-                        "json": "acceptedTermsAt"
-                      },
-                      "type": "string",
-                      "format": "date-time",
-                      "x-go-type-skip-optional-pointer": true
-                    },
-                    "firstLoginTime": {
-                      "description": "Timestamp of user's first login",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "first_login_time",
-                        "json": "firstLoginTime"
-                      },
-                      "type": "string",
-                      "format": "date-time",
-                      "x-go-type-skip-optional-pointer": true
-                    },
-                    "lastLoginTime": {
-                      "description": "Timestamp of user's most recent login",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "last_login_time",
-                        "json": "lastLoginTime"
-                      },
-                      "type": "string",
-                      "format": "date-time",
-                      "x-go-type-skip-optional-pointer": true
-                    },
-                    "createdAt": {
-                      "description": "Timestamp when the user record was created",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "created_at",
-                        "json": "createdAt"
-                      },
-                      "type": "string",
-                      "format": "date-time",
-                      "x-go-type-skip-optional-pointer": true
-                    },
-                    "updatedAt": {
-                      "description": "Timestamp when the user record was last updated",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "updated_at",
-                        "json": "updatedAt"
-                      },
-                      "type": "string",
-                      "format": "date-time",
-                      "x-go-type-skip-optional-pointer": true
-                    },
-                    "socials": {
-                      "type": "array",
-                      "description": "Various online profiles associated with the user account",
-                      "x-go-type": "UserSocials",
-                      "items": {
-                        "x-go-type": "Social",
-                        "description": "Various online profiles associated with the user account, like GitHub, LinkedIn, X, and so on.",
-                        "type": "object",
-                        "properties": {
-                          "site": {
-                            "type": "string",
-                            "maxLength": 50,
-                            "description": "The site of the social."
-                          },
-                          "link": {
-                            "type": "string",
-                            "format": "uri",
-                            "description": "The link of the social."
-                          }
-                        },
-                        "required": [
-                          "site",
-                          "link"
-                        ]
-                      },
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "socials",
-                        "json": "socials"
-                      }
-                    },
-                    "deletedAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "nullable": true,
-                      "description": "Timestamp when the user record was soft-deleted (null if not deleted)",
-                      "x-go-type": "core.NullTime",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "deleted_at",
-                        "json": "deletedAt"
-                      }
-                    },
-                    "roleNames": {
-                      "type": "array",
-                      "x-go-type": "pq.StringArray",
-                      "x-go-type-import": {
-                        "path": "github.com/lib/pq"
-                      },
-                      "x-go-type-skip-optional-pointer": true,
-                      "items": {
-                        "type": "string"
-                      },
-                      "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
-                      "example": [
-                        "organization admin",
-                        "user"
-                      ],
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "role_names",
-                        "json": "roleNames"
-                      }
-                    },
-                    "teams": {
-                      "type": "object",
-                      "description": "Teams the user belongs to with role information",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "teams",
-                        "json": "teams"
-                      },
-                      "properties": {
-                        "teamsWithRoles": {
-                          "type": "array",
-                          "description": "Team memberships for the user with their assigned roles.",
-                          "items": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                            "required": [
-                              "id",
-                              "name",
-                              "roleNames"
-                            ],
-                            "properties": {
-                              "id": {
-                                "description": "Unique identifier of the team.",
-                                "x-go-name": "ID",
-                                "x-order": 1,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "id",
-                                  "json": "id,omitempty"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
-                                }
-                              },
-                              "name": {
-                                "type": "string",
-                                "description": "Name of the team.",
-                                "x-order": 2,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "name",
-                                  "json": "name,omitempty"
-                                }
-                              },
-                              "description": {
-                                "type": "string",
-                                "description": "Human readable description of the team.",
-                                "x-order": 3,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "description",
-                                  "json": "description,omitempty"
-                                }
-                              },
-                              "owner": {
-                                "description": "Identifier of the team owner.",
-                                "x-order": 4,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "owner",
-                                  "json": "owner,omitempty"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
-                                }
-                              },
-                              "metadata": {
-                                "type": "object",
-                                "additionalProperties": true,
-                                "description": "Free-form metadata associated with the team.",
-                                "x-go-type": "core.Map",
-                                "x-go-type-skip-optional-pointer": true,
-                                "x-order": 5,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "metadata",
-                                  "json": "metadata,omitempty"
-                                }
-                              },
-                              "createdAt": {
-                                "description": "Timestamp when the team was created.",
-                                "x-order": 6,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "created_at",
-                                  "json": "createdAt,omitempty"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "updatedAt": {
-                                "description": "Timestamp when the team was last updated.",
-                                "x-order": 7,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "updated_at",
-                                  "json": "updatedAt,omitempty"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "deletedAt": {
-                                "type": "string",
-                                "format": "date-time",
-                                "nullable": true,
-                                "description": "Timestamp when the team was soft-deleted (null if not deleted).",
-                                "x-go-type": "core.NullTime",
-                                "x-order": 8,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "deleted_at",
-                                  "json": "deletedAt,omitempty"
-                                }
-                              },
-                              "roleNames": {
-                                "type": "array",
-                                "x-go-type": "pq.StringArray",
-                                "x-go-type-import": {
-                                  "path": "github.com/lib/pq"
-                                },
-                                "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "x-order": 9,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "role_names",
-                                  "json": "roleNames"
-                                }
-                              }
-                            }
-                          },
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "teams_with_roles",
-                            "json": "teamsWithRoles"
-                          }
-                        },
-                        "totalCount": {
-                          "type": "integer",
-                          "description": "Total number of team memberships returned for the user.",
-                          "minimum": 0,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "total_count",
-                            "json": "totalCount"
-                          }
-                        }
-                      }
-                    },
-                    "organizations": {
-                      "type": "object",
-                      "description": "Organizations the user belongs to with role information",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "organizations",
-                        "json": "organizations"
-                      },
-                      "properties": {
-                        "organizationsWithRoles": {
-                          "type": "array",
-                          "description": "Organization memberships for the user with their assigned roles.",
-                          "items": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                            "required": [
-                              "id",
-                              "name",
-                              "roleNames"
-                            ],
-                            "properties": {
-                              "id": {
-                                "description": "Unique identifier of the organization.",
-                                "x-go-name": "ID",
-                                "x-order": 1,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "id",
-                                  "json": "id,omitempty"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
-                                }
-                              },
-                              "name": {
-                                "type": "string",
-                                "description": "Name of the organization.",
-                                "x-order": 2,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "name",
-                                  "json": "name,omitempty"
-                                }
-                              },
-                              "description": {
-                                "type": "string",
-                                "description": "Human readable description of the organization.",
-                                "x-order": 3,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "description",
-                                  "json": "description,omitempty"
-                                }
-                              },
-                              "country": {
-                                "type": "string",
-                                "description": "Country associated with the organization.",
-                                "x-order": 4,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "country",
-                                  "json": "country,omitempty"
-                                }
-                              },
-                              "region": {
-                                "type": "string",
-                                "description": "Region associated with the organization.",
-                                "x-order": 5,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "region",
-                                  "json": "region,omitempty"
-                                }
-                              },
-                              "owner": {
-                                "description": "Identifier of the organization owner.",
-                                "x-order": 6,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "owner",
-                                  "json": "owner,omitempty"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
-                                }
-                              },
-                              "createdAt": {
-                                "description": "Timestamp when the organization was created.",
-                                "x-order": 7,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "created_at",
-                                  "json": "createdAt,omitempty"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "updatedAt": {
-                                "description": "Timestamp when the organization was last updated.",
-                                "x-order": 8,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "updated_at",
-                                  "json": "updatedAt,omitempty"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "deletedAt": {
-                                "type": "string",
-                                "format": "date-time",
-                                "nullable": true,
-                                "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
-                                "x-go-type": "core.NullTime",
-                                "x-order": 9,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "deleted_at",
-                                  "json": "deletedAt,omitempty"
-                                }
-                              },
-                              "roleNames": {
-                                "type": "array",
-                                "x-go-type": "pq.StringArray",
-                                "x-go-type-import": {
-                                  "path": "github.com/lib/pq"
-                                },
-                                "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "x-order": 10,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "role_names",
-                                  "json": "roleNames"
-                                }
-                              }
-                            }
-                          },
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "organizations_with_roles",
-                            "json": "organizationsWithRoles"
-                          }
-                        },
-                        "totalCount": {
-                          "type": "integer",
-                          "description": "Total number of organization memberships returned for the user.",
-                          "minimum": 0,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "total_count",
-                            "json": "totalCount"
-                          }
-                        }
+                        "json": "avatarUrl,omitempty"
                       }
                     }
-                  },
-                  "additionalProperties": false
+                  }
                 },
                 "location": {
                   "description": "Optional structured location metadata (branch, host, path, ...).",
@@ -18417,33 +13103,20 @@ const DesignSchema: Record<string, unknown> = {
                   "x-go-type-skip-optional-pointer": true
                 },
                 "user": {
-                  "description": "Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
+                  "description": "Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:\"-\"` to keep it out of ORM column scans.\n",
                   "nullable": true,
-                  "x-go-type": "*userV1beta.User",
-                  "x-go-type-import": {
-                    "path": "github.com/meshery/schemas/models/v1beta2/user",
-                    "name": "userV1beta"
-                  },
+                  "x-go-type": "*CatalogAuthor",
                   "x-oapi-codegen-extra-tags": {
                     "db": "-"
                   },
                   "type": "object",
+                  "additionalProperties": false,
                   "required": [
-                    "id",
-                    "userId",
-                    "provider",
-                    "email",
-                    "firstName",
-                    "lastName",
-                    "status",
-                    "createdAt",
-                    "updatedAt",
-                    "lastLoginTime",
-                    "deletedAt"
+                    "id"
                   ],
                   "properties": {
                     "id": {
-                      "description": "Unique identifier for the user",
+                      "description": "Unique identifier for the user.",
                       "x-go-name": "ID",
                       "x-oapi-codegen-extra-tags": {
                         "db": "id",
@@ -18457,712 +13130,52 @@ const DesignSchema: Record<string, unknown> = {
                       }
                     },
                     "userId": {
-                      "type": "string",
-                      "maxLength": 200,
                       "deprecated": true,
-                      "description": "Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email.",
+                      "description": "Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id.",
+                      "x-go-name": "UserID",
                       "x-oapi-codegen-extra-tags": {
                         "db": "user_id",
-                        "json": "userId"
+                        "json": "userId,omitempty"
                       },
-                      "x-id-format": "external"
-                    },
-                    "provider": {
                       "type": "string",
-                      "maxLength": 100,
-                      "description": "Authentication provider (e.g., Google, Github)",
-                      "example": [
-                        "local",
-                        "github",
-                        "google",
-                        "twitter"
-                      ],
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "provider",
-                        "json": "provider"
-                      }
-                    },
-                    "email": {
-                      "type": "string",
-                      "format": "email",
-                      "maxLength": 300,
-                      "description": "User's email address",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "email",
-                        "json": "email"
+                      "format": "uuid",
+                      "x-go-type": "uuid.UUID",
+                      "x-go-type-import": {
+                        "path": "github.com/gofrs/uuid"
                       }
                     },
                     "firstName": {
                       "type": "string",
                       "maxLength": 200,
-                      "description": "User's first name",
+                      "description": "User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                      "x-go-type-skip-optional-pointer": true,
                       "x-oapi-codegen-extra-tags": {
                         "db": "first_name",
-                        "json": "firstName"
+                        "json": "firstName,omitempty"
                       }
                     },
                     "lastName": {
                       "type": "string",
                       "maxLength": 300,
-                      "description": "User's last name",
+                      "description": "User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling.",
+                      "x-go-type-skip-optional-pointer": true,
                       "x-oapi-codegen-extra-tags": {
                         "db": "last_name",
-                        "json": "lastName"
+                        "json": "lastName,omitempty"
                       }
                     },
                     "avatarUrl": {
                       "type": "string",
                       "format": "uri",
                       "maxLength": 500,
-                      "description": "URL to user's avatar image",
+                      "description": "URL to the user's avatar image.",
+                      "x-go-type-skip-optional-pointer": true,
                       "x-oapi-codegen-extra-tags": {
                         "db": "avatar_url",
-                        "json": "avatarUrl"
-                      }
-                    },
-                    "status": {
-                      "type": "string",
-                      "maxLength": 100,
-                      "enum": [
-                        "active",
-                        "inactive",
-                        "pending",
-                        "anonymous"
-                      ],
-                      "description": "User account status",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "status",
-                        "json": "status"
-                      }
-                    },
-                    "bio": {
-                      "type": "string",
-                      "maxLength": 1000,
-                      "default": "",
-                      "description": "User's biography or description",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "bio",
-                        "json": "bio"
-                      }
-                    },
-                    "country": {
-                      "type": "object",
-                      "description": "User's country information stored as JSONB",
-                      "additionalProperties": true,
-                      "x-go-type": "core.Map",
-                      "x-go-type-skip-optional-pointer": true,
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "country",
-                        "json": "country"
-                      }
-                    },
-                    "region": {
-                      "type": "object",
-                      "description": "User's region information stored as JSONB",
-                      "additionalProperties": true,
-                      "x-go-type": "core.Map",
-                      "x-go-type-skip-optional-pointer": true,
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "region",
-                        "json": "region"
-                      }
-                    },
-                    "preferences": {
-                      "x-go-type": "Preference",
-                      "description": "User preferences stored as JSONB",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "preferences",
-                        "json": "preferences"
-                      },
-                      "x-generate-db-helpers": true,
-                      "type": "object",
-                      "required": [
-                        "anonymousUsageStats",
-                        "anonymousPerfResults",
-                        "updatedAt",
-                        "dashboardPreferences",
-                        "selectedOrganizationId",
-                        "selectedWorkspaceForOrganizations",
-                        "usersExtensionPreferences",
-                        "remoteProviderPreferences"
-                      ],
-                      "properties": {
-                        "meshAdapters": {
-                          "type": "array",
-                          "items": {
-                            "x-go-type": "Adapter",
-                            "type": "object",
-                            "description": "Placeholder for Adapter struct definition."
-                          },
-                          "description": "The mesh adapters of the preference."
-                        },
-                        "grafana": {
-                          "x-go-type": "Grafana",
-                          "type": "object",
-                          "properties": {
-                            "grafanaUrl": {
-                              "type": "string",
-                              "description": "Grafana URL for the user configuration.",
-                              "maxLength": 500
-                            },
-                            "grafanaApiKey": {
-                              "type": "string",
-                              "description": "Grafana API key for the user configuration.",
-                              "maxLength": 500
-                            },
-                            "selectedBoardsConfigs": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "board": {
-                                    "type": "object",
-                                    "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                  },
-                                  "panels": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                    },
-                                    "description": "Panels selected for the Grafana board configuration."
-                                  },
-                                  "templateVars": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "description": "Template variables applied to the selected Grafana board configuration."
-                                  }
-                                }
-                              },
-                              "description": "Selected Grafana board configurations for the user."
-                            }
-                          }
-                        },
-                        "prometheus": {
-                          "x-go-type": "Prometheus",
-                          "type": "object",
-                          "properties": {
-                            "prometheusUrl": {
-                              "type": "string",
-                              "description": "The prometheus URL of the prometheus.",
-                              "maxLength": 500
-                            },
-                            "selectedPrometheusBoardsConfigs": {
-                              "type": "array",
-                              "items": {
-                                "type": "object",
-                                "properties": {
-                                  "board": {
-                                    "type": "object",
-                                    "description": "Placeholder for GrafanaBoard definition (define fields as needed)"
-                                  },
-                                  "panels": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "object",
-                                      "description": "Grafana panel structure imported from github.com/grafana-tools/sdk"
-                                    },
-                                    "description": "Panels selected for the Grafana board configuration."
-                                  },
-                                  "templateVars": {
-                                    "type": "array",
-                                    "items": {
-                                      "type": "string"
-                                    },
-                                    "description": "Template variables applied to the selected Grafana board configuration."
-                                  }
-                                }
-                              },
-                              "description": "The selected prometheus boards configs of the prometheus."
-                            }
-                          }
-                        },
-                        "loadTestPrefs": {
-                          "x-go-type": "LoadTestPreferences",
-                          "type": "object",
-                          "properties": {
-                            "c": {
-                              "type": "integer",
-                              "description": "Concurrent requests",
-                              "minimum": 0
-                            },
-                            "qps": {
-                              "type": "integer",
-                              "description": "Queries per second",
-                              "minimum": 0
-                            },
-                            "t": {
-                              "type": "string",
-                              "description": "Duration",
-                              "maxLength": 500
-                            },
-                            "gen": {
-                              "type": "string",
-                              "description": "Load generator",
-                              "maxLength": 500
-                            }
-                          }
-                        },
-                        "anonymousUsageStats": {
-                          "type": "boolean",
-                          "description": "The anonymous usage stats of the preference."
-                        },
-                        "anonymousPerfResults": {
-                          "type": "boolean",
-                          "description": "The anonymous perf results of the preference."
-                        },
-                        "updatedAt": {
-                          "type": "string",
-                          "format": "date-time",
-                          "description": "Timestamp of when the resource was last updated."
-                        },
-                        "dashboardPreferences": {
-                          "type": "object",
-                          "additionalProperties": true,
-                          "description": "The dashboard preferences of the preference."
-                        },
-                        "selectedOrganizationId": {
-                          "type": "string",
-                          "description": "ID of the associated selectedOrganization.",
-                          "maxLength": 500,
-                          "format": "uuid"
-                        },
-                        "selectedWorkspaceForOrganizations": {
-                          "type": "object",
-                          "additionalProperties": {
-                            "type": "string"
-                          },
-                          "description": "The selected workspace for organizations of the preference."
-                        },
-                        "usersExtensionPreferences": {
-                          "type": "object",
-                          "additionalProperties": true,
-                          "description": "The users extension preferences of the preference."
-                        },
-                        "remoteProviderPreferences": {
-                          "type": "object",
-                          "additionalProperties": true,
-                          "description": "The remote provider preferences of the preference."
-                        }
-                      }
-                    },
-                    "acceptedTermsAt": {
-                      "description": "Timestamp when user accepted terms and conditions",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "accepted_terms_at",
-                        "json": "acceptedTermsAt"
-                      },
-                      "type": "string",
-                      "format": "date-time",
-                      "x-go-type-skip-optional-pointer": true
-                    },
-                    "firstLoginTime": {
-                      "description": "Timestamp of user's first login",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "first_login_time",
-                        "json": "firstLoginTime"
-                      },
-                      "type": "string",
-                      "format": "date-time",
-                      "x-go-type-skip-optional-pointer": true
-                    },
-                    "lastLoginTime": {
-                      "description": "Timestamp of user's most recent login",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "last_login_time",
-                        "json": "lastLoginTime"
-                      },
-                      "type": "string",
-                      "format": "date-time",
-                      "x-go-type-skip-optional-pointer": true
-                    },
-                    "createdAt": {
-                      "description": "Timestamp when the user record was created",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "created_at",
-                        "json": "createdAt"
-                      },
-                      "type": "string",
-                      "format": "date-time",
-                      "x-go-type-skip-optional-pointer": true
-                    },
-                    "updatedAt": {
-                      "description": "Timestamp when the user record was last updated",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "updated_at",
-                        "json": "updatedAt"
-                      },
-                      "type": "string",
-                      "format": "date-time",
-                      "x-go-type-skip-optional-pointer": true
-                    },
-                    "socials": {
-                      "type": "array",
-                      "description": "Various online profiles associated with the user account",
-                      "x-go-type": "UserSocials",
-                      "items": {
-                        "x-go-type": "Social",
-                        "description": "Various online profiles associated with the user account, like GitHub, LinkedIn, X, and so on.",
-                        "type": "object",
-                        "properties": {
-                          "site": {
-                            "type": "string",
-                            "maxLength": 50,
-                            "description": "The site of the social."
-                          },
-                          "link": {
-                            "type": "string",
-                            "format": "uri",
-                            "description": "The link of the social."
-                          }
-                        },
-                        "required": [
-                          "site",
-                          "link"
-                        ]
-                      },
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "socials",
-                        "json": "socials"
-                      }
-                    },
-                    "deletedAt": {
-                      "type": "string",
-                      "format": "date-time",
-                      "nullable": true,
-                      "description": "Timestamp when the user record was soft-deleted (null if not deleted)",
-                      "x-go-type": "core.NullTime",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "deleted_at",
-                        "json": "deletedAt"
-                      }
-                    },
-                    "roleNames": {
-                      "type": "array",
-                      "x-go-type": "pq.StringArray",
-                      "x-go-type-import": {
-                        "path": "github.com/lib/pq"
-                      },
-                      "x-go-type-skip-optional-pointer": true,
-                      "items": {
-                        "type": "string"
-                      },
-                      "description": "Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as \"admin\", \"organization admin\" and \"user\" are a subset, not the whole set.",
-                      "example": [
-                        "organization admin",
-                        "user"
-                      ],
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "role_names",
-                        "json": "roleNames"
-                      }
-                    },
-                    "teams": {
-                      "type": "object",
-                      "description": "Teams the user belongs to with role information",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "teams",
-                        "json": "teams"
-                      },
-                      "properties": {
-                        "teamsWithRoles": {
-                          "type": "array",
-                          "description": "Team memberships for the user with their assigned roles.",
-                          "items": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "description": "A team the user is a member of, together with the names of the roles assigned to that user within the team. Returned as an item of User.teams.teamsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                            "required": [
-                              "id",
-                              "name",
-                              "roleNames"
-                            ],
-                            "properties": {
-                              "id": {
-                                "description": "Unique identifier of the team.",
-                                "x-go-name": "ID",
-                                "x-order": 1,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "id",
-                                  "json": "id,omitempty"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
-                                }
-                              },
-                              "name": {
-                                "type": "string",
-                                "description": "Name of the team.",
-                                "x-order": 2,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "name",
-                                  "json": "name,omitempty"
-                                }
-                              },
-                              "description": {
-                                "type": "string",
-                                "description": "Human readable description of the team.",
-                                "x-order": 3,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "description",
-                                  "json": "description,omitempty"
-                                }
-                              },
-                              "owner": {
-                                "description": "Identifier of the team owner.",
-                                "x-order": 4,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "owner",
-                                  "json": "owner,omitempty"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
-                                }
-                              },
-                              "metadata": {
-                                "type": "object",
-                                "additionalProperties": true,
-                                "description": "Free-form metadata associated with the team.",
-                                "x-go-type": "core.Map",
-                                "x-go-type-skip-optional-pointer": true,
-                                "x-order": 5,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "metadata",
-                                  "json": "metadata,omitempty"
-                                }
-                              },
-                              "createdAt": {
-                                "description": "Timestamp when the team was created.",
-                                "x-order": 6,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "created_at",
-                                  "json": "createdAt,omitempty"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "updatedAt": {
-                                "description": "Timestamp when the team was last updated.",
-                                "x-order": 7,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "updated_at",
-                                  "json": "updatedAt,omitempty"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "deletedAt": {
-                                "type": "string",
-                                "format": "date-time",
-                                "nullable": true,
-                                "description": "Timestamp when the team was soft-deleted (null if not deleted).",
-                                "x-go-type": "core.NullTime",
-                                "x-order": 8,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "deleted_at",
-                                  "json": "deletedAt,omitempty"
-                                }
-                              },
-                              "roleNames": {
-                                "type": "array",
-                                "x-go-type": "pq.StringArray",
-                                "x-go-type-import": {
-                                  "path": "github.com/lib/pq"
-                                },
-                                "description": "Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration.",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "x-order": 9,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "role_names",
-                                  "json": "roleNames"
-                                }
-                              }
-                            }
-                          },
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "teams_with_roles",
-                            "json": "teamsWithRoles"
-                          }
-                        },
-                        "totalCount": {
-                          "type": "integer",
-                          "description": "Total number of team memberships returned for the user.",
-                          "minimum": 0,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "total_count",
-                            "json": "totalCount"
-                          }
-                        }
-                      }
-                    },
-                    "organizations": {
-                      "type": "object",
-                      "description": "Organizations the user belongs to with role information",
-                      "x-oapi-codegen-extra-tags": {
-                        "db": "organizations",
-                        "json": "organizations"
-                      },
-                      "properties": {
-                        "organizationsWithRoles": {
-                          "type": "array",
-                          "description": "Organization memberships for the user with their assigned roles.",
-                          "items": {
-                            "type": "object",
-                            "additionalProperties": false,
-                            "description": "An organization the user is a member of, together with the names of the roles assigned to that user within the organization. Returned as an item of User.organizations.organizationsWithRoles. The role names are dynamic, user-generated values (no fixed enumeration).",
-                            "required": [
-                              "id",
-                              "name",
-                              "roleNames"
-                            ],
-                            "properties": {
-                              "id": {
-                                "description": "Unique identifier of the organization.",
-                                "x-go-name": "ID",
-                                "x-order": 1,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "id",
-                                  "json": "id,omitempty"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
-                                }
-                              },
-                              "name": {
-                                "type": "string",
-                                "description": "Name of the organization.",
-                                "x-order": 2,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "name",
-                                  "json": "name,omitempty"
-                                }
-                              },
-                              "description": {
-                                "type": "string",
-                                "description": "Human readable description of the organization.",
-                                "x-order": 3,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "description",
-                                  "json": "description,omitempty"
-                                }
-                              },
-                              "country": {
-                                "type": "string",
-                                "description": "Country associated with the organization.",
-                                "x-order": 4,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "country",
-                                  "json": "country,omitempty"
-                                }
-                              },
-                              "region": {
-                                "type": "string",
-                                "description": "Region associated with the organization.",
-                                "x-order": 5,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "region",
-                                  "json": "region,omitempty"
-                                }
-                              },
-                              "owner": {
-                                "description": "Identifier of the organization owner.",
-                                "x-order": 6,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "owner",
-                                  "json": "owner,omitempty"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
-                                }
-                              },
-                              "createdAt": {
-                                "description": "Timestamp when the organization was created.",
-                                "x-order": 7,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "created_at",
-                                  "json": "createdAt,omitempty"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "updatedAt": {
-                                "description": "Timestamp when the organization was last updated.",
-                                "x-order": 8,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "updated_at",
-                                  "json": "updatedAt,omitempty"
-                                },
-                                "type": "string",
-                                "format": "date-time",
-                                "x-go-type-skip-optional-pointer": true
-                              },
-                              "deletedAt": {
-                                "type": "string",
-                                "format": "date-time",
-                                "nullable": true,
-                                "description": "Timestamp when the organization was soft-deleted (null if not deleted).",
-                                "x-go-type": "core.NullTime",
-                                "x-order": 9,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "deleted_at",
-                                  "json": "deletedAt,omitempty"
-                                }
-                              },
-                              "roleNames": {
-                                "type": "array",
-                                "x-go-type": "pq.StringArray",
-                                "x-go-type-import": {
-                                  "path": "github.com/lib/pq"
-                                },
-                                "description": "Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration.",
-                                "items": {
-                                  "type": "string"
-                                },
-                                "x-order": 10,
-                                "x-oapi-codegen-extra-tags": {
-                                  "db": "role_names",
-                                  "json": "roleNames"
-                                }
-                              }
-                            }
-                          },
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "organizations_with_roles",
-                            "json": "organizationsWithRoles"
-                          }
-                        },
-                        "totalCount": {
-                          "type": "integer",
-                          "description": "Total number of organization memberships returned for the user.",
-                          "minimum": 0,
-                          "x-oapi-codegen-extra-tags": {
-                            "db": "total_count",
-                            "json": "totalCount"
-                          }
-                        }
+                        "json": "avatarUrl,omitempty"
                       }
                     }
-                  },
-                  "additionalProperties": false
+                  }
                 },
                 "location": {
                   "description": "Optional structured location metadata (branch, host, path, ...).",
@@ -19681,17 +13694,17 @@ const DesignSchema: Record<string, unknown> = {
             ],
             "properties": {
               "id": {
-                "description": "Unique identifier for the user",
+                "type": "string",
+                "format": "uuid",
+                "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                "x-go-type": "uuid.UUID",
+                "x-go-type-import": {
+                  "path": "github.com/gofrs/uuid"
+                },
                 "x-go-name": "ID",
                 "x-oapi-codegen-extra-tags": {
                   "db": "id",
                   "json": "id"
-                },
-                "type": "string",
-                "format": "uuid",
-                "x-go-type": "uuid.UUID",
-                "x-go-type-import": {
-                  "path": "github.com/gofrs/uuid"
                 }
               },
               "userId": {
@@ -20119,18 +14132,18 @@ const DesignSchema: Record<string, unknown> = {
                       ],
                       "properties": {
                         "id": {
-                          "description": "Unique identifier of the team.",
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
+                          },
                           "x-go-name": "ID",
                           "x-order": 1,
                           "x-oapi-codegen-extra-tags": {
                             "db": "id",
                             "json": "id,omitempty"
-                          },
-                          "type": "string",
-                          "format": "uuid",
-                          "x-go-type": "uuid.UUID",
-                          "x-go-type-import": {
-                            "path": "github.com/gofrs/uuid"
                           }
                         },
                         "name": {
@@ -20152,17 +14165,17 @@ const DesignSchema: Record<string, unknown> = {
                           }
                         },
                         "owner": {
-                          "description": "Identifier of the team owner.",
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
+                          },
                           "x-order": 4,
                           "x-oapi-codegen-extra-tags": {
                             "db": "owner",
                             "json": "owner,omitempty"
-                          },
-                          "type": "string",
-                          "format": "uuid",
-                          "x-go-type": "uuid.UUID",
-                          "x-go-type-import": {
-                            "path": "github.com/gofrs/uuid"
                           }
                         },
                         "metadata": {
@@ -20267,18 +14280,18 @@ const DesignSchema: Record<string, unknown> = {
                       ],
                       "properties": {
                         "id": {
-                          "description": "Unique identifier of the organization.",
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
+                          },
                           "x-go-name": "ID",
                           "x-order": 1,
                           "x-oapi-codegen-extra-tags": {
                             "db": "id",
                             "json": "id,omitempty"
-                          },
-                          "type": "string",
-                          "format": "uuid",
-                          "x-go-type": "uuid.UUID",
-                          "x-go-type-import": {
-                            "path": "github.com/gofrs/uuid"
                           }
                         },
                         "name": {
@@ -20318,17 +14331,17 @@ const DesignSchema: Record<string, unknown> = {
                           }
                         },
                         "owner": {
-                          "description": "Identifier of the organization owner.",
+                          "type": "string",
+                          "format": "uuid",
+                          "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                          "x-go-type": "uuid.UUID",
+                          "x-go-type-import": {
+                            "path": "github.com/gofrs/uuid"
+                          },
                           "x-order": 6,
                           "x-oapi-codegen-extra-tags": {
                             "db": "owner",
                             "json": "owner,omitempty"
-                          },
-                          "type": "string",
-                          "format": "uuid",
-                          "x-go-type": "uuid.UUID",
-                          "x-go-type-import": {
-                            "path": "github.com/gofrs/uuid"
                           }
                         },
                         "createdAt": {
@@ -20591,17 +14604,17 @@ const DesignSchema: Record<string, unknown> = {
                   ],
                   "properties": {
                     "id": {
-                      "description": "Unique identifier for the user",
+                      "type": "string",
+                      "format": "uuid",
+                      "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                      "x-go-type": "uuid.UUID",
+                      "x-go-type-import": {
+                        "path": "github.com/gofrs/uuid"
+                      },
                       "x-go-name": "ID",
                       "x-oapi-codegen-extra-tags": {
                         "db": "id",
                         "json": "id"
-                      },
-                      "type": "string",
-                      "format": "uuid",
-                      "x-go-type": "uuid.UUID",
-                      "x-go-type-import": {
-                        "path": "github.com/gofrs/uuid"
                       }
                     },
                     "userId": {
@@ -21029,18 +15042,18 @@ const DesignSchema: Record<string, unknown> = {
                             ],
                             "properties": {
                               "id": {
-                                "description": "Unique identifier of the team.",
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                },
                                 "x-go-name": "ID",
                                 "x-order": 1,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "id",
                                   "json": "id,omitempty"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
                                 }
                               },
                               "name": {
@@ -21062,17 +15075,17 @@ const DesignSchema: Record<string, unknown> = {
                                 }
                               },
                               "owner": {
-                                "description": "Identifier of the team owner.",
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                },
                                 "x-order": 4,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "owner",
                                   "json": "owner,omitempty"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
                                 }
                               },
                               "metadata": {
@@ -21177,18 +15190,18 @@ const DesignSchema: Record<string, unknown> = {
                             ],
                             "properties": {
                               "id": {
-                                "description": "Unique identifier of the organization.",
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                },
                                 "x-go-name": "ID",
                                 "x-order": 1,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "id",
                                   "json": "id,omitempty"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
                                 }
                               },
                               "name": {
@@ -21228,17 +15241,17 @@ const DesignSchema: Record<string, unknown> = {
                                 }
                               },
                               "owner": {
-                                "description": "Identifier of the organization owner.",
+                                "type": "string",
+                                "format": "uuid",
+                                "description": "A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas.",
+                                "x-go-type": "uuid.UUID",
+                                "x-go-type-import": {
+                                  "path": "github.com/gofrs/uuid"
+                                },
                                 "x-order": 6,
                                 "x-oapi-codegen-extra-tags": {
                                   "db": "owner",
                                   "json": "owner,omitempty"
-                                },
-                                "type": "string",
-                                "format": "uuid",
-                                "x-go-type": "uuid.UUID",
-                                "x-go-type-import": {
-                                  "path": "github.com/gofrs/uuid"
                                 }
                               },
                               "createdAt": {

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -9860,179 +9860,19 @@ export type GetPatternsApiResponse = /** status 200 Designs response */ {
     };
     /** Owning user ID. */
     userId?: string;
-    /** Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
+    /** Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
      */
     user?: {
-      /** Unique identifier for the user */
+      /** Unique identifier for the user. */
       id: string;
-      /** Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email. */
-      userId: string;
-      /** Authentication provider (e.g., Google, Github) */
-      provider: string;
-      /** User's email address */
-      email: string;
-      /** User's first name */
-      firstName: string;
-      /** User's last name */
-      lastName: string;
-      /** URL to user's avatar image */
+      /** Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id. */
+      userId?: string;
+      /** User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+      firstName?: string;
+      /** User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+      lastName?: string;
+      /** URL to the user's avatar image. */
       avatarUrl?: string;
-      /** User account status */
-      status: "active" | "inactive" | "pending" | "anonymous";
-      /** User's biography or description */
-      bio?: string;
-      /** User's country information stored as JSONB */
-      country?: {
-        [key: string]: any;
-      };
-      /** User's region information stored as JSONB */
-      region?: {
-        [key: string]: any;
-      };
-      /** User preferences stored as JSONB */
-      preferences?: {
-        /** The mesh adapters of the preference. */
-        meshAdapters?: object[];
-        grafana?: {
-          /** Grafana URL for the user configuration. */
-          grafanaUrl?: string;
-          /** Grafana API key for the user configuration. */
-          grafanaApiKey?: string;
-          /** Selected Grafana board configurations for the user. */
-          selectedBoardsConfigs?: {
-            /** Placeholder for GrafanaBoard definition (define fields as needed) */
-            board?: object;
-            /** Panels selected for the Grafana board configuration. */
-            panels?: object[];
-            /** Template variables applied to the selected Grafana board configuration. */
-            templateVars?: string[];
-          }[];
-        };
-        prometheus?: {
-          /** The prometheus URL of the prometheus. */
-          prometheusUrl?: string;
-          /** The selected prometheus boards configs of the prometheus. */
-          selectedPrometheusBoardsConfigs?: {
-            /** Placeholder for GrafanaBoard definition (define fields as needed) */
-            board?: object;
-            /** Panels selected for the Grafana board configuration. */
-            panels?: object[];
-            /** Template variables applied to the selected Grafana board configuration. */
-            templateVars?: string[];
-          }[];
-        };
-        loadTestPrefs?: {
-          /** Concurrent requests */
-          c?: number;
-          /** Queries per second */
-          qps?: number;
-          /** Duration */
-          t?: string;
-          /** Load generator */
-          gen?: string;
-        };
-        /** The anonymous usage stats of the preference. */
-        anonymousUsageStats: boolean;
-        /** The anonymous perf results of the preference. */
-        anonymousPerfResults: boolean;
-        /** Timestamp of when the resource was last updated. */
-        updatedAt: string;
-        /** The dashboard preferences of the preference. */
-        dashboardPreferences: {
-          [key: string]: any;
-        };
-        /** ID of the associated selectedOrganization. */
-        selectedOrganizationId: string;
-        /** The selected workspace for organizations of the preference. */
-        selectedWorkspaceForOrganizations: {
-          [key: string]: string;
-        };
-        /** The users extension preferences of the preference. */
-        usersExtensionPreferences: {
-          [key: string]: any;
-        };
-        /** The remote provider preferences of the preference. */
-        remoteProviderPreferences: {
-          [key: string]: any;
-        };
-      };
-      /** Timestamp when user accepted terms and conditions */
-      acceptedTermsAt?: string;
-      /** Timestamp of user's first login */
-      firstLoginTime?: string;
-      /** Timestamp of user's most recent login */
-      lastLoginTime: string;
-      /** Timestamp when the user record was created */
-      createdAt: string;
-      /** Timestamp when the user record was last updated */
-      updatedAt: string;
-      /** Various online profiles associated with the user account */
-      socials?: {
-        /** The site of the social. */
-        site: string;
-        /** The link of the social. */
-        link: string;
-      }[];
-      /** Timestamp when the user record was soft-deleted (null if not deleted) */
-      deletedAt: string | null;
-      /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
-      roleNames?: string[];
-      /** Teams the user belongs to with role information */
-      teams?: {
-        /** Team memberships for the user with their assigned roles. */
-        teamsWithRoles?: {
-          /** Unique identifier of the team. */
-          id: string;
-          /** Name of the team. */
-          name: string;
-          /** Human readable description of the team. */
-          description?: string;
-          /** Identifier of the team owner. */
-          owner?: string;
-          /** Free-form metadata associated with the team. */
-          metadata?: {
-            [key: string]: any;
-          };
-          /** Timestamp when the team was created. */
-          createdAt?: string;
-          /** Timestamp when the team was last updated. */
-          updatedAt?: string;
-          /** Timestamp when the team was soft-deleted (null if not deleted). */
-          deletedAt?: string | null;
-          /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-          roleNames: string[];
-        }[];
-        /** Total number of team memberships returned for the user. */
-        totalCount?: number;
-      };
-      /** Organizations the user belongs to with role information */
-      organizations?: {
-        /** Organization memberships for the user with their assigned roles. */
-        organizationsWithRoles?: {
-          /** Unique identifier of the organization. */
-          id: string;
-          /** Name of the organization. */
-          name: string;
-          /** Human readable description of the organization. */
-          description?: string;
-          /** Country associated with the organization. */
-          country?: string;
-          /** Region associated with the organization. */
-          region?: string;
-          /** Identifier of the organization owner. */
-          owner?: string;
-          /** Timestamp when the organization was created. */
-          createdAt?: string;
-          /** Timestamp when the organization was last updated. */
-          updatedAt?: string;
-          /** Timestamp when the organization was soft-deleted (null if not deleted). */
-          deletedAt?: string | null;
-          /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-          roleNames: string[];
-        }[];
-        /** Total number of organization memberships returned for the user. */
-        totalCount?: number;
-      };
     } | null;
     /** Optional structured location metadata (branch, host, path, ...). */
     location?: {
@@ -10129,179 +9969,19 @@ export type UpsertPatternApiResponse = /** status 200 Design saved */ {
   };
   /** Owning user ID. */
   userId?: string;
-  /** Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
+  /** Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
    */
   user?: {
-    /** Unique identifier for the user */
+    /** Unique identifier for the user. */
     id: string;
-    /** Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email. */
-    userId: string;
-    /** Authentication provider (e.g., Google, Github) */
-    provider: string;
-    /** User's email address */
-    email: string;
-    /** User's first name */
-    firstName: string;
-    /** User's last name */
-    lastName: string;
-    /** URL to user's avatar image */
+    /** Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id. */
+    userId?: string;
+    /** User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+    firstName?: string;
+    /** User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+    lastName?: string;
+    /** URL to the user's avatar image. */
     avatarUrl?: string;
-    /** User account status */
-    status: "active" | "inactive" | "pending" | "anonymous";
-    /** User's biography or description */
-    bio?: string;
-    /** User's country information stored as JSONB */
-    country?: {
-      [key: string]: any;
-    };
-    /** User's region information stored as JSONB */
-    region?: {
-      [key: string]: any;
-    };
-    /** User preferences stored as JSONB */
-    preferences?: {
-      /** The mesh adapters of the preference. */
-      meshAdapters?: object[];
-      grafana?: {
-        /** Grafana URL for the user configuration. */
-        grafanaUrl?: string;
-        /** Grafana API key for the user configuration. */
-        grafanaApiKey?: string;
-        /** Selected Grafana board configurations for the user. */
-        selectedBoardsConfigs?: {
-          /** Placeholder for GrafanaBoard definition (define fields as needed) */
-          board?: object;
-          /** Panels selected for the Grafana board configuration. */
-          panels?: object[];
-          /** Template variables applied to the selected Grafana board configuration. */
-          templateVars?: string[];
-        }[];
-      };
-      prometheus?: {
-        /** The prometheus URL of the prometheus. */
-        prometheusUrl?: string;
-        /** The selected prometheus boards configs of the prometheus. */
-        selectedPrometheusBoardsConfigs?: {
-          /** Placeholder for GrafanaBoard definition (define fields as needed) */
-          board?: object;
-          /** Panels selected for the Grafana board configuration. */
-          panels?: object[];
-          /** Template variables applied to the selected Grafana board configuration. */
-          templateVars?: string[];
-        }[];
-      };
-      loadTestPrefs?: {
-        /** Concurrent requests */
-        c?: number;
-        /** Queries per second */
-        qps?: number;
-        /** Duration */
-        t?: string;
-        /** Load generator */
-        gen?: string;
-      };
-      /** The anonymous usage stats of the preference. */
-      anonymousUsageStats: boolean;
-      /** The anonymous perf results of the preference. */
-      anonymousPerfResults: boolean;
-      /** Timestamp of when the resource was last updated. */
-      updatedAt: string;
-      /** The dashboard preferences of the preference. */
-      dashboardPreferences: {
-        [key: string]: any;
-      };
-      /** ID of the associated selectedOrganization. */
-      selectedOrganizationId: string;
-      /** The selected workspace for organizations of the preference. */
-      selectedWorkspaceForOrganizations: {
-        [key: string]: string;
-      };
-      /** The users extension preferences of the preference. */
-      usersExtensionPreferences: {
-        [key: string]: any;
-      };
-      /** The remote provider preferences of the preference. */
-      remoteProviderPreferences: {
-        [key: string]: any;
-      };
-    };
-    /** Timestamp when user accepted terms and conditions */
-    acceptedTermsAt?: string;
-    /** Timestamp of user's first login */
-    firstLoginTime?: string;
-    /** Timestamp of user's most recent login */
-    lastLoginTime: string;
-    /** Timestamp when the user record was created */
-    createdAt: string;
-    /** Timestamp when the user record was last updated */
-    updatedAt: string;
-    /** Various online profiles associated with the user account */
-    socials?: {
-      /** The site of the social. */
-      site: string;
-      /** The link of the social. */
-      link: string;
-    }[];
-    /** Timestamp when the user record was soft-deleted (null if not deleted) */
-    deletedAt: string | null;
-    /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
-    roleNames?: string[];
-    /** Teams the user belongs to with role information */
-    teams?: {
-      /** Team memberships for the user with their assigned roles. */
-      teamsWithRoles?: {
-        /** Unique identifier of the team. */
-        id: string;
-        /** Name of the team. */
-        name: string;
-        /** Human readable description of the team. */
-        description?: string;
-        /** Identifier of the team owner. */
-        owner?: string;
-        /** Free-form metadata associated with the team. */
-        metadata?: {
-          [key: string]: any;
-        };
-        /** Timestamp when the team was created. */
-        createdAt?: string;
-        /** Timestamp when the team was last updated. */
-        updatedAt?: string;
-        /** Timestamp when the team was soft-deleted (null if not deleted). */
-        deletedAt?: string | null;
-        /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-        roleNames: string[];
-      }[];
-      /** Total number of team memberships returned for the user. */
-      totalCount?: number;
-    };
-    /** Organizations the user belongs to with role information */
-    organizations?: {
-      /** Organization memberships for the user with their assigned roles. */
-      organizationsWithRoles?: {
-        /** Unique identifier of the organization. */
-        id: string;
-        /** Name of the organization. */
-        name: string;
-        /** Human readable description of the organization. */
-        description?: string;
-        /** Country associated with the organization. */
-        country?: string;
-        /** Region associated with the organization. */
-        region?: string;
-        /** Identifier of the organization owner. */
-        owner?: string;
-        /** Timestamp when the organization was created. */
-        createdAt?: string;
-        /** Timestamp when the organization was last updated. */
-        updatedAt?: string;
-        /** Timestamp when the organization was soft-deleted (null if not deleted). */
-        deletedAt?: string | null;
-        /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-        roleNames: string[];
-      }[];
-      /** Total number of organization memberships returned for the user. */
-      totalCount?: number;
-    };
   } | null;
   /** Optional structured location metadata (branch, host, path, ...). */
   location?: {
@@ -10441,179 +10121,19 @@ export type GetPatternApiResponse = /** status 200 Design response */ {
   };
   /** Owning user ID. */
   userId?: string;
-  /** Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
+  /** Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
    */
   user?: {
-    /** Unique identifier for the user */
+    /** Unique identifier for the user. */
     id: string;
-    /** Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email. */
-    userId: string;
-    /** Authentication provider (e.g., Google, Github) */
-    provider: string;
-    /** User's email address */
-    email: string;
-    /** User's first name */
-    firstName: string;
-    /** User's last name */
-    lastName: string;
-    /** URL to user's avatar image */
+    /** Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id. */
+    userId?: string;
+    /** User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+    firstName?: string;
+    /** User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+    lastName?: string;
+    /** URL to the user's avatar image. */
     avatarUrl?: string;
-    /** User account status */
-    status: "active" | "inactive" | "pending" | "anonymous";
-    /** User's biography or description */
-    bio?: string;
-    /** User's country information stored as JSONB */
-    country?: {
-      [key: string]: any;
-    };
-    /** User's region information stored as JSONB */
-    region?: {
-      [key: string]: any;
-    };
-    /** User preferences stored as JSONB */
-    preferences?: {
-      /** The mesh adapters of the preference. */
-      meshAdapters?: object[];
-      grafana?: {
-        /** Grafana URL for the user configuration. */
-        grafanaUrl?: string;
-        /** Grafana API key for the user configuration. */
-        grafanaApiKey?: string;
-        /** Selected Grafana board configurations for the user. */
-        selectedBoardsConfigs?: {
-          /** Placeholder for GrafanaBoard definition (define fields as needed) */
-          board?: object;
-          /** Panels selected for the Grafana board configuration. */
-          panels?: object[];
-          /** Template variables applied to the selected Grafana board configuration. */
-          templateVars?: string[];
-        }[];
-      };
-      prometheus?: {
-        /** The prometheus URL of the prometheus. */
-        prometheusUrl?: string;
-        /** The selected prometheus boards configs of the prometheus. */
-        selectedPrometheusBoardsConfigs?: {
-          /** Placeholder for GrafanaBoard definition (define fields as needed) */
-          board?: object;
-          /** Panels selected for the Grafana board configuration. */
-          panels?: object[];
-          /** Template variables applied to the selected Grafana board configuration. */
-          templateVars?: string[];
-        }[];
-      };
-      loadTestPrefs?: {
-        /** Concurrent requests */
-        c?: number;
-        /** Queries per second */
-        qps?: number;
-        /** Duration */
-        t?: string;
-        /** Load generator */
-        gen?: string;
-      };
-      /** The anonymous usage stats of the preference. */
-      anonymousUsageStats: boolean;
-      /** The anonymous perf results of the preference. */
-      anonymousPerfResults: boolean;
-      /** Timestamp of when the resource was last updated. */
-      updatedAt: string;
-      /** The dashboard preferences of the preference. */
-      dashboardPreferences: {
-        [key: string]: any;
-      };
-      /** ID of the associated selectedOrganization. */
-      selectedOrganizationId: string;
-      /** The selected workspace for organizations of the preference. */
-      selectedWorkspaceForOrganizations: {
-        [key: string]: string;
-      };
-      /** The users extension preferences of the preference. */
-      usersExtensionPreferences: {
-        [key: string]: any;
-      };
-      /** The remote provider preferences of the preference. */
-      remoteProviderPreferences: {
-        [key: string]: any;
-      };
-    };
-    /** Timestamp when user accepted terms and conditions */
-    acceptedTermsAt?: string;
-    /** Timestamp of user's first login */
-    firstLoginTime?: string;
-    /** Timestamp of user's most recent login */
-    lastLoginTime: string;
-    /** Timestamp when the user record was created */
-    createdAt: string;
-    /** Timestamp when the user record was last updated */
-    updatedAt: string;
-    /** Various online profiles associated with the user account */
-    socials?: {
-      /** The site of the social. */
-      site: string;
-      /** The link of the social. */
-      link: string;
-    }[];
-    /** Timestamp when the user record was soft-deleted (null if not deleted) */
-    deletedAt: string | null;
-    /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
-    roleNames?: string[];
-    /** Teams the user belongs to with role information */
-    teams?: {
-      /** Team memberships for the user with their assigned roles. */
-      teamsWithRoles?: {
-        /** Unique identifier of the team. */
-        id: string;
-        /** Name of the team. */
-        name: string;
-        /** Human readable description of the team. */
-        description?: string;
-        /** Identifier of the team owner. */
-        owner?: string;
-        /** Free-form metadata associated with the team. */
-        metadata?: {
-          [key: string]: any;
-        };
-        /** Timestamp when the team was created. */
-        createdAt?: string;
-        /** Timestamp when the team was last updated. */
-        updatedAt?: string;
-        /** Timestamp when the team was soft-deleted (null if not deleted). */
-        deletedAt?: string | null;
-        /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-        roleNames: string[];
-      }[];
-      /** Total number of team memberships returned for the user. */
-      totalCount?: number;
-    };
-    /** Organizations the user belongs to with role information */
-    organizations?: {
-      /** Organization memberships for the user with their assigned roles. */
-      organizationsWithRoles?: {
-        /** Unique identifier of the organization. */
-        id: string;
-        /** Name of the organization. */
-        name: string;
-        /** Human readable description of the organization. */
-        description?: string;
-        /** Country associated with the organization. */
-        country?: string;
-        /** Region associated with the organization. */
-        region?: string;
-        /** Identifier of the organization owner. */
-        owner?: string;
-        /** Timestamp when the organization was created. */
-        createdAt?: string;
-        /** Timestamp when the organization was last updated. */
-        updatedAt?: string;
-        /** Timestamp when the organization was soft-deleted (null if not deleted). */
-        deletedAt?: string | null;
-        /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-        roleNames: string[];
-      }[];
-      /** Total number of organization memberships returned for the user. */
-      totalCount?: number;
-    };
   } | null;
   /** Optional structured location metadata (branch, host, path, ...). */
   location?: {
@@ -10694,179 +10214,19 @@ export type ClonePatternApiResponse = /** status 200 Design cloned */ {
   };
   /** Owning user ID. */
   userId?: string;
-  /** Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
+  /** Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
    */
   user?: {
-    /** Unique identifier for the user */
+    /** Unique identifier for the user. */
     id: string;
-    /** Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email. */
-    userId: string;
-    /** Authentication provider (e.g., Google, Github) */
-    provider: string;
-    /** User's email address */
-    email: string;
-    /** User's first name */
-    firstName: string;
-    /** User's last name */
-    lastName: string;
-    /** URL to user's avatar image */
+    /** Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id. */
+    userId?: string;
+    /** User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+    firstName?: string;
+    /** User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+    lastName?: string;
+    /** URL to the user's avatar image. */
     avatarUrl?: string;
-    /** User account status */
-    status: "active" | "inactive" | "pending" | "anonymous";
-    /** User's biography or description */
-    bio?: string;
-    /** User's country information stored as JSONB */
-    country?: {
-      [key: string]: any;
-    };
-    /** User's region information stored as JSONB */
-    region?: {
-      [key: string]: any;
-    };
-    /** User preferences stored as JSONB */
-    preferences?: {
-      /** The mesh adapters of the preference. */
-      meshAdapters?: object[];
-      grafana?: {
-        /** Grafana URL for the user configuration. */
-        grafanaUrl?: string;
-        /** Grafana API key for the user configuration. */
-        grafanaApiKey?: string;
-        /** Selected Grafana board configurations for the user. */
-        selectedBoardsConfigs?: {
-          /** Placeholder for GrafanaBoard definition (define fields as needed) */
-          board?: object;
-          /** Panels selected for the Grafana board configuration. */
-          panels?: object[];
-          /** Template variables applied to the selected Grafana board configuration. */
-          templateVars?: string[];
-        }[];
-      };
-      prometheus?: {
-        /** The prometheus URL of the prometheus. */
-        prometheusUrl?: string;
-        /** The selected prometheus boards configs of the prometheus. */
-        selectedPrometheusBoardsConfigs?: {
-          /** Placeholder for GrafanaBoard definition (define fields as needed) */
-          board?: object;
-          /** Panels selected for the Grafana board configuration. */
-          panels?: object[];
-          /** Template variables applied to the selected Grafana board configuration. */
-          templateVars?: string[];
-        }[];
-      };
-      loadTestPrefs?: {
-        /** Concurrent requests */
-        c?: number;
-        /** Queries per second */
-        qps?: number;
-        /** Duration */
-        t?: string;
-        /** Load generator */
-        gen?: string;
-      };
-      /** The anonymous usage stats of the preference. */
-      anonymousUsageStats: boolean;
-      /** The anonymous perf results of the preference. */
-      anonymousPerfResults: boolean;
-      /** Timestamp of when the resource was last updated. */
-      updatedAt: string;
-      /** The dashboard preferences of the preference. */
-      dashboardPreferences: {
-        [key: string]: any;
-      };
-      /** ID of the associated selectedOrganization. */
-      selectedOrganizationId: string;
-      /** The selected workspace for organizations of the preference. */
-      selectedWorkspaceForOrganizations: {
-        [key: string]: string;
-      };
-      /** The users extension preferences of the preference. */
-      usersExtensionPreferences: {
-        [key: string]: any;
-      };
-      /** The remote provider preferences of the preference. */
-      remoteProviderPreferences: {
-        [key: string]: any;
-      };
-    };
-    /** Timestamp when user accepted terms and conditions */
-    acceptedTermsAt?: string;
-    /** Timestamp of user's first login */
-    firstLoginTime?: string;
-    /** Timestamp of user's most recent login */
-    lastLoginTime: string;
-    /** Timestamp when the user record was created */
-    createdAt: string;
-    /** Timestamp when the user record was last updated */
-    updatedAt: string;
-    /** Various online profiles associated with the user account */
-    socials?: {
-      /** The site of the social. */
-      site: string;
-      /** The link of the social. */
-      link: string;
-    }[];
-    /** Timestamp when the user record was soft-deleted (null if not deleted) */
-    deletedAt: string | null;
-    /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
-    roleNames?: string[];
-    /** Teams the user belongs to with role information */
-    teams?: {
-      /** Team memberships for the user with their assigned roles. */
-      teamsWithRoles?: {
-        /** Unique identifier of the team. */
-        id: string;
-        /** Name of the team. */
-        name: string;
-        /** Human readable description of the team. */
-        description?: string;
-        /** Identifier of the team owner. */
-        owner?: string;
-        /** Free-form metadata associated with the team. */
-        metadata?: {
-          [key: string]: any;
-        };
-        /** Timestamp when the team was created. */
-        createdAt?: string;
-        /** Timestamp when the team was last updated. */
-        updatedAt?: string;
-        /** Timestamp when the team was soft-deleted (null if not deleted). */
-        deletedAt?: string | null;
-        /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-        roleNames: string[];
-      }[];
-      /** Total number of team memberships returned for the user. */
-      totalCount?: number;
-    };
-    /** Organizations the user belongs to with role information */
-    organizations?: {
-      /** Organization memberships for the user with their assigned roles. */
-      organizationsWithRoles?: {
-        /** Unique identifier of the organization. */
-        id: string;
-        /** Name of the organization. */
-        name: string;
-        /** Human readable description of the organization. */
-        description?: string;
-        /** Country associated with the organization. */
-        country?: string;
-        /** Region associated with the organization. */
-        region?: string;
-        /** Identifier of the organization owner. */
-        owner?: string;
-        /** Timestamp when the organization was created. */
-        createdAt?: string;
-        /** Timestamp when the organization was last updated. */
-        updatedAt?: string;
-        /** Timestamp when the organization was soft-deleted (null if not deleted). */
-        deletedAt?: string | null;
-        /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-        roleNames: string[];
-      }[];
-      /** Total number of organization memberships returned for the user. */
-      totalCount?: number;
-    };
   } | null;
   /** Optional structured location metadata (branch, host, path, ...). */
   location?: {
@@ -10952,179 +10312,19 @@ export type ImportDesignApiResponse =
     };
     /** Owning user ID. */
     userId?: string;
-    /** Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
+    /** Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
      */
     user?: {
-      /** Unique identifier for the user */
+      /** Unique identifier for the user. */
       id: string;
-      /** Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email. */
-      userId: string;
-      /** Authentication provider (e.g., Google, Github) */
-      provider: string;
-      /** User's email address */
-      email: string;
-      /** User's first name */
-      firstName: string;
-      /** User's last name */
-      lastName: string;
-      /** URL to user's avatar image */
+      /** Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id. */
+      userId?: string;
+      /** User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+      firstName?: string;
+      /** User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+      lastName?: string;
+      /** URL to the user's avatar image. */
       avatarUrl?: string;
-      /** User account status */
-      status: "active" | "inactive" | "pending" | "anonymous";
-      /** User's biography or description */
-      bio?: string;
-      /** User's country information stored as JSONB */
-      country?: {
-        [key: string]: any;
-      };
-      /** User's region information stored as JSONB */
-      region?: {
-        [key: string]: any;
-      };
-      /** User preferences stored as JSONB */
-      preferences?: {
-        /** The mesh adapters of the preference. */
-        meshAdapters?: object[];
-        grafana?: {
-          /** Grafana URL for the user configuration. */
-          grafanaUrl?: string;
-          /** Grafana API key for the user configuration. */
-          grafanaApiKey?: string;
-          /** Selected Grafana board configurations for the user. */
-          selectedBoardsConfigs?: {
-            /** Placeholder for GrafanaBoard definition (define fields as needed) */
-            board?: object;
-            /** Panels selected for the Grafana board configuration. */
-            panels?: object[];
-            /** Template variables applied to the selected Grafana board configuration. */
-            templateVars?: string[];
-          }[];
-        };
-        prometheus?: {
-          /** The prometheus URL of the prometheus. */
-          prometheusUrl?: string;
-          /** The selected prometheus boards configs of the prometheus. */
-          selectedPrometheusBoardsConfigs?: {
-            /** Placeholder for GrafanaBoard definition (define fields as needed) */
-            board?: object;
-            /** Panels selected for the Grafana board configuration. */
-            panels?: object[];
-            /** Template variables applied to the selected Grafana board configuration. */
-            templateVars?: string[];
-          }[];
-        };
-        loadTestPrefs?: {
-          /** Concurrent requests */
-          c?: number;
-          /** Queries per second */
-          qps?: number;
-          /** Duration */
-          t?: string;
-          /** Load generator */
-          gen?: string;
-        };
-        /** The anonymous usage stats of the preference. */
-        anonymousUsageStats: boolean;
-        /** The anonymous perf results of the preference. */
-        anonymousPerfResults: boolean;
-        /** Timestamp of when the resource was last updated. */
-        updatedAt: string;
-        /** The dashboard preferences of the preference. */
-        dashboardPreferences: {
-          [key: string]: any;
-        };
-        /** ID of the associated selectedOrganization. */
-        selectedOrganizationId: string;
-        /** The selected workspace for organizations of the preference. */
-        selectedWorkspaceForOrganizations: {
-          [key: string]: string;
-        };
-        /** The users extension preferences of the preference. */
-        usersExtensionPreferences: {
-          [key: string]: any;
-        };
-        /** The remote provider preferences of the preference. */
-        remoteProviderPreferences: {
-          [key: string]: any;
-        };
-      };
-      /** Timestamp when user accepted terms and conditions */
-      acceptedTermsAt?: string;
-      /** Timestamp of user's first login */
-      firstLoginTime?: string;
-      /** Timestamp of user's most recent login */
-      lastLoginTime: string;
-      /** Timestamp when the user record was created */
-      createdAt: string;
-      /** Timestamp when the user record was last updated */
-      updatedAt: string;
-      /** Various online profiles associated with the user account */
-      socials?: {
-        /** The site of the social. */
-        site: string;
-        /** The link of the social. */
-        link: string;
-      }[];
-      /** Timestamp when the user record was soft-deleted (null if not deleted) */
-      deletedAt: string | null;
-      /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
-      roleNames?: string[];
-      /** Teams the user belongs to with role information */
-      teams?: {
-        /** Team memberships for the user with their assigned roles. */
-        teamsWithRoles?: {
-          /** Unique identifier of the team. */
-          id: string;
-          /** Name of the team. */
-          name: string;
-          /** Human readable description of the team. */
-          description?: string;
-          /** Identifier of the team owner. */
-          owner?: string;
-          /** Free-form metadata associated with the team. */
-          metadata?: {
-            [key: string]: any;
-          };
-          /** Timestamp when the team was created. */
-          createdAt?: string;
-          /** Timestamp when the team was last updated. */
-          updatedAt?: string;
-          /** Timestamp when the team was soft-deleted (null if not deleted). */
-          deletedAt?: string | null;
-          /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-          roleNames: string[];
-        }[];
-        /** Total number of team memberships returned for the user. */
-        totalCount?: number;
-      };
-      /** Organizations the user belongs to with role information */
-      organizations?: {
-        /** Organization memberships for the user with their assigned roles. */
-        organizationsWithRoles?: {
-          /** Unique identifier of the organization. */
-          id: string;
-          /** Name of the organization. */
-          name: string;
-          /** Human readable description of the organization. */
-          description?: string;
-          /** Country associated with the organization. */
-          country?: string;
-          /** Region associated with the organization. */
-          region?: string;
-          /** Identifier of the organization owner. */
-          owner?: string;
-          /** Timestamp when the organization was created. */
-          createdAt?: string;
-          /** Timestamp when the organization was last updated. */
-          updatedAt?: string;
-          /** Timestamp when the organization was soft-deleted (null if not deleted). */
-          deletedAt?: string | null;
-          /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-          roleNames: string[];
-        }[];
-        /** Total number of organization memberships returned for the user. */
-        totalCount?: number;
-      };
     } | null;
     /** Optional structured location metadata (branch, host, path, ...). */
     location?: {
@@ -11219,179 +10419,19 @@ export type GetCatalogContentApiResponse = /** status 200 Catalog content page *
     };
     /** Owning user ID. */
     userId?: string;
-    /** Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
+    /** Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
      */
     user?: {
-      /** Unique identifier for the user */
+      /** Unique identifier for the user. */
       id: string;
-      /** Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email. */
-      userId: string;
-      /** Authentication provider (e.g., Google, Github) */
-      provider: string;
-      /** User's email address */
-      email: string;
-      /** User's first name */
-      firstName: string;
-      /** User's last name */
-      lastName: string;
-      /** URL to user's avatar image */
+      /** Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id. */
+      userId?: string;
+      /** User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+      firstName?: string;
+      /** User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+      lastName?: string;
+      /** URL to the user's avatar image. */
       avatarUrl?: string;
-      /** User account status */
-      status: "active" | "inactive" | "pending" | "anonymous";
-      /** User's biography or description */
-      bio?: string;
-      /** User's country information stored as JSONB */
-      country?: {
-        [key: string]: any;
-      };
-      /** User's region information stored as JSONB */
-      region?: {
-        [key: string]: any;
-      };
-      /** User preferences stored as JSONB */
-      preferences?: {
-        /** The mesh adapters of the preference. */
-        meshAdapters?: object[];
-        grafana?: {
-          /** Grafana URL for the user configuration. */
-          grafanaUrl?: string;
-          /** Grafana API key for the user configuration. */
-          grafanaApiKey?: string;
-          /** Selected Grafana board configurations for the user. */
-          selectedBoardsConfigs?: {
-            /** Placeholder for GrafanaBoard definition (define fields as needed) */
-            board?: object;
-            /** Panels selected for the Grafana board configuration. */
-            panels?: object[];
-            /** Template variables applied to the selected Grafana board configuration. */
-            templateVars?: string[];
-          }[];
-        };
-        prometheus?: {
-          /** The prometheus URL of the prometheus. */
-          prometheusUrl?: string;
-          /** The selected prometheus boards configs of the prometheus. */
-          selectedPrometheusBoardsConfigs?: {
-            /** Placeholder for GrafanaBoard definition (define fields as needed) */
-            board?: object;
-            /** Panels selected for the Grafana board configuration. */
-            panels?: object[];
-            /** Template variables applied to the selected Grafana board configuration. */
-            templateVars?: string[];
-          }[];
-        };
-        loadTestPrefs?: {
-          /** Concurrent requests */
-          c?: number;
-          /** Queries per second */
-          qps?: number;
-          /** Duration */
-          t?: string;
-          /** Load generator */
-          gen?: string;
-        };
-        /** The anonymous usage stats of the preference. */
-        anonymousUsageStats: boolean;
-        /** The anonymous perf results of the preference. */
-        anonymousPerfResults: boolean;
-        /** Timestamp of when the resource was last updated. */
-        updatedAt: string;
-        /** The dashboard preferences of the preference. */
-        dashboardPreferences: {
-          [key: string]: any;
-        };
-        /** ID of the associated selectedOrganization. */
-        selectedOrganizationId: string;
-        /** The selected workspace for organizations of the preference. */
-        selectedWorkspaceForOrganizations: {
-          [key: string]: string;
-        };
-        /** The users extension preferences of the preference. */
-        usersExtensionPreferences: {
-          [key: string]: any;
-        };
-        /** The remote provider preferences of the preference. */
-        remoteProviderPreferences: {
-          [key: string]: any;
-        };
-      };
-      /** Timestamp when user accepted terms and conditions */
-      acceptedTermsAt?: string;
-      /** Timestamp of user's first login */
-      firstLoginTime?: string;
-      /** Timestamp of user's most recent login */
-      lastLoginTime: string;
-      /** Timestamp when the user record was created */
-      createdAt: string;
-      /** Timestamp when the user record was last updated */
-      updatedAt: string;
-      /** Various online profiles associated with the user account */
-      socials?: {
-        /** The site of the social. */
-        site: string;
-        /** The link of the social. */
-        link: string;
-      }[];
-      /** Timestamp when the user record was soft-deleted (null if not deleted) */
-      deletedAt: string | null;
-      /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
-      roleNames?: string[];
-      /** Teams the user belongs to with role information */
-      teams?: {
-        /** Team memberships for the user with their assigned roles. */
-        teamsWithRoles?: {
-          /** Unique identifier of the team. */
-          id: string;
-          /** Name of the team. */
-          name: string;
-          /** Human readable description of the team. */
-          description?: string;
-          /** Identifier of the team owner. */
-          owner?: string;
-          /** Free-form metadata associated with the team. */
-          metadata?: {
-            [key: string]: any;
-          };
-          /** Timestamp when the team was created. */
-          createdAt?: string;
-          /** Timestamp when the team was last updated. */
-          updatedAt?: string;
-          /** Timestamp when the team was soft-deleted (null if not deleted). */
-          deletedAt?: string | null;
-          /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-          roleNames: string[];
-        }[];
-        /** Total number of team memberships returned for the user. */
-        totalCount?: number;
-      };
-      /** Organizations the user belongs to with role information */
-      organizations?: {
-        /** Organization memberships for the user with their assigned roles. */
-        organizationsWithRoles?: {
-          /** Unique identifier of the organization. */
-          id: string;
-          /** Name of the organization. */
-          name: string;
-          /** Human readable description of the organization. */
-          description?: string;
-          /** Country associated with the organization. */
-          country?: string;
-          /** Region associated with the organization. */
-          region?: string;
-          /** Identifier of the organization owner. */
-          owner?: string;
-          /** Timestamp when the organization was created. */
-          createdAt?: string;
-          /** Timestamp when the organization was last updated. */
-          updatedAt?: string;
-          /** Timestamp when the organization was soft-deleted (null if not deleted). */
-          deletedAt?: string | null;
-          /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-          roleNames: string[];
-        }[];
-        /** Total number of organization memberships returned for the user. */
-        totalCount?: number;
-      };
     } | null;
     /** Optional structured location metadata (branch, host, path, ...). */
     location?: {
@@ -11534,7 +10574,7 @@ export type PublishCatalogContentApiResponse = /** status 200 Catalog request re
   /** Requesting user record, joined inline by the catalog-request list handler when shaping responses. Server-projected from the users table; not a column on the catalog_requests table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
    */
   user?: {
-    /** Unique identifier for the user */
+    /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
     id: string;
     /** Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email. */
     userId: string;
@@ -11652,13 +10692,13 @@ export type PublishCatalogContentApiResponse = /** status 200 Catalog request re
     teams?: {
       /** Team memberships for the user with their assigned roles. */
       teamsWithRoles?: {
-        /** Unique identifier of the team. */
+        /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
         id: string;
         /** Name of the team. */
         name: string;
         /** Human readable description of the team. */
         description?: string;
-        /** Identifier of the team owner. */
+        /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
         owner?: string;
         /** Free-form metadata associated with the team. */
         metadata?: {
@@ -11680,7 +10720,7 @@ export type PublishCatalogContentApiResponse = /** status 200 Catalog request re
     organizations?: {
       /** Organization memberships for the user with their assigned roles. */
       organizationsWithRoles?: {
-        /** Unique identifier of the organization. */
+        /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
         id: string;
         /** Name of the organization. */
         name: string;
@@ -11690,7 +10730,7 @@ export type PublishCatalogContentApiResponse = /** status 200 Catalog request re
         country?: string;
         /** Region associated with the organization. */
         region?: string;
-        /** Identifier of the organization owner. */
+        /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
         owner?: string;
         /** Timestamp when the organization was created. */
         createdAt?: string;
@@ -11741,7 +10781,7 @@ export type UnPublishCatalogContentApiResponse = /** status 200 Catalog request 
   /** Requesting user record, joined inline by the catalog-request list handler when shaping responses. Server-projected from the users table; not a column on the catalog_requests table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
    */
   user?: {
-    /** Unique identifier for the user */
+    /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
     id: string;
     /** Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email. */
     userId: string;
@@ -11859,13 +10899,13 @@ export type UnPublishCatalogContentApiResponse = /** status 200 Catalog request 
     teams?: {
       /** Team memberships for the user with their assigned roles. */
       teamsWithRoles?: {
-        /** Unique identifier of the team. */
+        /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
         id: string;
         /** Name of the team. */
         name: string;
         /** Human readable description of the team. */
         description?: string;
-        /** Identifier of the team owner. */
+        /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
         owner?: string;
         /** Free-form metadata associated with the team. */
         metadata?: {
@@ -11887,7 +10927,7 @@ export type UnPublishCatalogContentApiResponse = /** status 200 Catalog request 
     organizations?: {
       /** Organization memberships for the user with their assigned roles. */
       organizationsWithRoles?: {
-        /** Unique identifier of the organization. */
+        /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
         id: string;
         /** Name of the organization. */
         name: string;
@@ -11897,7 +10937,7 @@ export type UnPublishCatalogContentApiResponse = /** status 200 Catalog request 
         country?: string;
         /** Region associated with the organization. */
         region?: string;
-        /** Identifier of the organization owner. */
+        /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
         owner?: string;
         /** Timestamp when the organization was created. */
         createdAt?: string;
@@ -12025,7 +11065,7 @@ export type GetCatalogRequestApiResponse = /** status 200 Catalog requests page 
     /** Requesting user record, joined inline by the catalog-request list handler when shaping responses. Server-projected from the users table; not a column on the catalog_requests table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
      */
     user?: {
-      /** Unique identifier for the user */
+      /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
       id: string;
       /** Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email. */
       userId: string;
@@ -12143,13 +11183,13 @@ export type GetCatalogRequestApiResponse = /** status 200 Catalog requests page 
       teams?: {
         /** Team memberships for the user with their assigned roles. */
         teamsWithRoles?: {
-          /** Unique identifier of the team. */
+          /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
           id: string;
           /** Name of the team. */
           name: string;
           /** Human readable description of the team. */
           description?: string;
-          /** Identifier of the team owner. */
+          /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
           owner?: string;
           /** Free-form metadata associated with the team. */
           metadata?: {
@@ -12171,7 +11211,7 @@ export type GetCatalogRequestApiResponse = /** status 200 Catalog requests page 
       organizations?: {
         /** Organization memberships for the user with their assigned roles. */
         organizationsWithRoles?: {
-          /** Unique identifier of the organization. */
+          /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
           id: string;
           /** Name of the organization. */
           name: string;
@@ -12181,7 +11221,7 @@ export type GetCatalogRequestApiResponse = /** status 200 Catalog requests page 
           country?: string;
           /** Region associated with the organization. */
           region?: string;
-          /** Identifier of the organization owner. */
+          /** A Universally Unique Identifier used to uniquely identify entities in Meshery. The UUID core definition is used across different schemas. */
           owner?: string;
           /** Timestamp when the organization was created. */
           createdAt?: string;

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -15445,179 +15445,19 @@ export type ImportDesignApiResponse =
     };
     /** Owning user ID. */
     userId?: string;
-    /** Owning user record, joined inline by the catalog list/get handlers when shaping responses. Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
+    /** Public projection of the owning user joined inline by the catalog list/get handlers when shaping responses. Uses CatalogAuthor instead of the full User schema because catalog endpoints are served to unauthenticated callers and may not expose email addresses (meshery/schemas#1106). Server-projected from the users table via the design's userId; not a column on the meshery_patterns table itself, so the generated Go field is tagged `db:"-"` to keep it out of ORM column scans.
      */
     user?: {
-      /** Unique identifier for the user */
+      /** Unique identifier for the user. */
       id: string;
-      /** Legacy IdP-derived identifier. Removed in v1beta3; resolve users by id or email. */
-      userId: string;
-      /** Authentication provider (e.g., Google, Github) */
-      provider: string;
-      /** User's email address */
-      email: string;
-      /** User's first name */
-      firstName: string;
-      /** User's last name */
-      lastName: string;
-      /** URL to user's avatar image */
+      /** Deprecated duplicate of id kept for consumers that predate the retirement of the legacy user_id column; always equals id. */
+      userId?: string;
+      /** User's first name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+      firstName?: string;
+      /** User's last name. Real names are permitted on public catalog responses under the Cloud privacy ruling. */
+      lastName?: string;
+      /** URL to the user's avatar image. */
       avatarUrl?: string;
-      /** User account status */
-      status: "active" | "inactive" | "pending" | "anonymous";
-      /** User's biography or description */
-      bio?: string;
-      /** User's country information stored as JSONB */
-      country?: {
-        [key: string]: any;
-      };
-      /** User's region information stored as JSONB */
-      region?: {
-        [key: string]: any;
-      };
-      /** User preferences stored as JSONB */
-      preferences?: {
-        /** The mesh adapters of the preference. */
-        meshAdapters?: object[];
-        grafana?: {
-          /** Grafana URL for the user configuration. */
-          grafanaUrl?: string;
-          /** Grafana API key for the user configuration. */
-          grafanaApiKey?: string;
-          /** Selected Grafana board configurations for the user. */
-          selectedBoardsConfigs?: {
-            /** Placeholder for GrafanaBoard definition (define fields as needed) */
-            board?: object;
-            /** Panels selected for the Grafana board configuration. */
-            panels?: object[];
-            /** Template variables applied to the selected Grafana board configuration. */
-            templateVars?: string[];
-          }[];
-        };
-        prometheus?: {
-          /** The prometheus URL of the prometheus. */
-          prometheusUrl?: string;
-          /** The selected prometheus boards configs of the prometheus. */
-          selectedPrometheusBoardsConfigs?: {
-            /** Placeholder for GrafanaBoard definition (define fields as needed) */
-            board?: object;
-            /** Panels selected for the Grafana board configuration. */
-            panels?: object[];
-            /** Template variables applied to the selected Grafana board configuration. */
-            templateVars?: string[];
-          }[];
-        };
-        loadTestPrefs?: {
-          /** Concurrent requests */
-          c?: number;
-          /** Queries per second */
-          qps?: number;
-          /** Duration */
-          t?: string;
-          /** Load generator */
-          gen?: string;
-        };
-        /** The anonymous usage stats of the preference. */
-        anonymousUsageStats: boolean;
-        /** The anonymous perf results of the preference. */
-        anonymousPerfResults: boolean;
-        /** Timestamp of when the resource was last updated. */
-        updatedAt: string;
-        /** The dashboard preferences of the preference. */
-        dashboardPreferences: {
-          [key: string]: any;
-        };
-        /** ID of the associated selectedOrganization. */
-        selectedOrganizationId: string;
-        /** The selected workspace for organizations of the preference. */
-        selectedWorkspaceForOrganizations: {
-          [key: string]: string;
-        };
-        /** The users extension preferences of the preference. */
-        usersExtensionPreferences: {
-          [key: string]: any;
-        };
-        /** The remote provider preferences of the preference. */
-        remoteProviderPreferences: {
-          [key: string]: any;
-        };
-      };
-      /** Timestamp when user accepted terms and conditions */
-      acceptedTermsAt?: string;
-      /** Timestamp of user's first login */
-      firstLoginTime?: string;
-      /** Timestamp of user's most recent login */
-      lastLoginTime: string;
-      /** Timestamp when the user record was created */
-      createdAt: string;
-      /** Timestamp when the user record was last updated */
-      updatedAt: string;
-      /** Various online profiles associated with the user account */
-      socials?: {
-        /** The site of the social. */
-        site: string;
-        /** The link of the social. */
-        link: string;
-      }[];
-      /** Timestamp when the user record was soft-deleted (null if not deleted) */
-      deletedAt: string | null;
-      /** Names of the global roles assigned to the user. Free-form, user-generated values sourced from the roles table (role_name is a varchar, not a fixed enumeration); the seeded system roles such as "admin", "organization admin" and "user" are a subset, not the whole set. */
-      roleNames?: string[];
-      /** Teams the user belongs to with role information */
-      teams?: {
-        /** Team memberships for the user with their assigned roles. */
-        teamsWithRoles?: {
-          /** Unique identifier of the team. */
-          id: string;
-          /** Name of the team. */
-          name: string;
-          /** Human readable description of the team. */
-          description?: string;
-          /** Identifier of the team owner. */
-          owner?: string;
-          /** Free-form metadata associated with the team. */
-          metadata?: {
-            [key: string]: any;
-          };
-          /** Timestamp when the team was created. */
-          createdAt?: string;
-          /** Timestamp when the team was last updated. */
-          updatedAt?: string;
-          /** Timestamp when the team was soft-deleted (null if not deleted). */
-          deletedAt?: string | null;
-          /** Names of the roles assigned to the user within this team. Free-form, user-generated role names; not a fixed enumeration. */
-          roleNames: string[];
-        }[];
-        /** Total number of team memberships returned for the user. */
-        totalCount?: number;
-      };
-      /** Organizations the user belongs to with role information */
-      organizations?: {
-        /** Organization memberships for the user with their assigned roles. */
-        organizationsWithRoles?: {
-          /** Unique identifier of the organization. */
-          id: string;
-          /** Name of the organization. */
-          name: string;
-          /** Human readable description of the organization. */
-          description?: string;
-          /** Country associated with the organization. */
-          country?: string;
-          /** Region associated with the organization. */
-          region?: string;
-          /** Identifier of the organization owner. */
-          owner?: string;
-          /** Timestamp when the organization was created. */
-          createdAt?: string;
-          /** Timestamp when the organization was last updated. */
-          updatedAt?: string;
-          /** Timestamp when the organization was soft-deleted (null if not deleted). */
-          deletedAt?: string | null;
-          /** Names of the roles assigned to the user within this organization. Free-form, user-generated role names; not a fixed enumeration. */
-          roleNames: string[];
-        }[];
-        /** Total number of organization memberships returned for the user. */
-        totalCount?: number;
-      };
     } | null;
     /** Optional structured location metadata (branch, host, path, ...). */
     location?: {


### PR DESCRIPTION
This PR fixes #1106

### Overview
Meshery Cloud enforces a privacy ruling that no user email address may reach an anonymous or unauthenticated caller. The unauthenticated design catalog endpoint (`GET /api/catalog/content/pattern`) serves `MesheryPattern` where the `.user` property previously referenced the full `User` entity schema (`schemas/constructs/v1beta2/user/api.yml`), which requires `email`. This created contract drift against what Cloud actually returns.

Rather than making `email` optional on the core `User` entity schema (which would weaken the contract for authenticated surfaces like user management and the profile form), this PR introduces a dedicated `CatalogAuthor` projection.

### Changes
- **`schemas/constructs/v1beta3/design/api.yml`**:
  - Defined `CatalogAuthor` containing only permitted public fields: `id`, `userId` (deprecated alias), `firstName`, `lastName`, and `avatarUrl`. Email and account-internal data are deliberately omitted.
  - Repointed `MesheryPattern.user` from `User` to `CatalogAuthor`.
- **Regenerated artifacts**:
  - `models/v1beta3/design/design.go`: Generated `CatalogAuthor` struct and updated `MesheryPattern.User`.
  - `typescript/generated/v1beta3/design/`: Updated TypeScript types and JSON schemas.
  - `typescript/rtk/`: Regenerated RTK Query clients for Cloud and Meshery.

### Verification
- `make validate-schemas`: Passed (0 blocking violations)
- `make consumer-audit`: Passed
- `go test ./validation/... ./models/...`: Passed
- `npm run build`: Passed

**[Signed commits](https://github.com/meshery/meshery/blob/master/CONTRIBUTING.md#signing-off-on-commits-developer-certificate-of-origin)**
- [x] Yes, I signed my commits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Catalog designs and patterns now display authors through a privacy-limited profile containing identity, name, and avatar information.
  - Public catalog and import responses now use a consistent author representation across supported interfaces.
  - Author details no longer expose private account, contact, authentication, preference, role, team, or organization information in these responses.
  - Legacy user ID information is supported as an optional field for compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->