### PR TITLE
fix(v1beta3/academy): drop omitempty from required registrationCount

### DIFF
--- a/models/v1beta3/academy/academy.go
+++ b/models/v1beta3/academy/academy.go
@@ -150,7 +150,7 @@ type AcademyCurriculaWithMetrics struct {
 	OrgId AcademyCurriculaOrgId `db:"org_id" json:"orgId" yaml:"orgId"`
 
 	// RegistrationCount Number of registrations associated with this curriculum.
-	RegistrationCount float32 `db:"registration_count,omitempty" json:"registrationCount,omitempty" yaml:"registrationCount,omitempty"`
+	RegistrationCount int `db:"registration_count" json:"registrationCount" yaml:"registrationCount"`
 
 	// Slug slug of the Curricula
 	Slug   string      `json:"slug" yaml:"slug"`
@@ -690,7 +690,7 @@ type SingleAcademyCurriculaResponse struct {
 	OrgId AcademyCurriculaOrgId `db:"org_id" json:"orgId" yaml:"orgId"`
 
 	// RegistrationCount Number of registrations associated with this curriculum.
-	RegistrationCount float32 `db:"registration_count,omitempty" json:"registrationCount,omitempty" yaml:"registrationCount,omitempty"`
+	RegistrationCount int `db:"registration_count" json:"registrationCount" yaml:"registrationCount"`
 
 	// Slug slug of the Curricula
 	Slug   string      `json:"slug" yaml:"slug"`

--- a/schemas/constructs/v1beta3/academy/api.yml
+++ b/schemas/constructs/v1beta3/academy/api.yml
@@ -863,12 +863,12 @@ components:
         - registrationCount
         properties:
           registrationCount:
-            type: number
+            type: integer
             description: Number of registrations associated with this curriculum.
             minimum: 0
             x-oapi-codegen-extra-tags:
-              db: registration_count,omitempty
-              json: registrationCount,omitempty
+              db: registration_count
+              json: registrationCount
           invitation:
             $ref: ../invitation/api.yml#/components/schemas/Invitation
             x-go-type: invitationv1beta3.Invitation
@@ -946,12 +946,12 @@ components:
         - registrationCount
         properties:
           registrationCount:
-            type: number
+            type: integer
             description: Number of registrations associated with this curriculum.
             minimum: 0
             x-oapi-codegen-extra-tags:
-              db: registration_count,omitempty
-              json: registrationCount,omitempty
+              db: registration_count
+              json: registrationCount
     AcademyCurriculaListResponse:
       type: object
       properties:


### PR DESCRIPTION
## Description

`registrationCount` is declared `required` on the v1beta3 academy curricula responses, but the schema also authors `json: registrationCount,omitempty` through `x-oapi-codegen-extra-tags`. A genuine count of **0** was therefore omitted from the payload entirely — indistinguishable from an absent key, and in violation of the schema's own `required` constraint.

This removes `omitempty` from both the `db` and `json` tags, and changes `type: number` to `type: integer`.

Fixes #1160

## Notes for reviewers

**The defect occurs twice.** The issue cites `SingleAcademyCurriculaResponse` (`api.yml:863-871`); `AcademyCurriculaWithMetrics` (`api.yml:946-954`) carries an identical block. Both are fixed here — `models/v1beta3/academy/academy.go:153` and `:693`.

**On `number` → `integer` (`float32` → `int`).** This is the part worth a second opinion. The justification is internal precedent: every other count in this construct is already an integer type — `Total int` (`:118`, `:174`), `TotalCount int64` (`:405`), `TotalCount *int` (`:422`, `:444`). `RegistrationCount float32` was the sole outlier for a `minimum: 0` count of rows. I found no consumers of the field in `meshery/meshery`, but **`meshery-cloud` and `meshery-extensions` are private and I could not check them** — so the `consumer-audit` job may have more to say than I can see. Happy to split the type change into a separate PR if you'd rather land the `omitempty` fix on its own.

**Regeneration.** `models/v1beta3/academy/academy.go` was regenerated with `make generate-golang`. One thing to flag: this had to be done with `oapi-codegen` **v2.5.1**, which is what the committed headers declare — not the **v2.5.0** pinned in `go.mod`. At the pinned version the tool does not build against the pinned `kin-openapi`:

```
pkg/codegen/schema.go:899:13: invalid operation: v == element.Ref
  (mismatched types openapi3.MappingRef and string)
```

and regenerating with it rewrites 77 files with a downgraded version header. That's outside the scope of this PR; I'll open a separate issue for it.

## Verification

All blocking checks from `.github/workflows/schema-audit.yml`, run locally:

```
make validate-schemas                  ✓ no blocking violations
go test ./validation/... ./models/...  ✓ all pass
make test-rtk                          ✓ 2/2 and 3/3
go build ./...                         ✓
gofmt -l models/                       ✓ clean
make generate-ts                       ✓ no committed-file changes
```

## Diff

```diff
-            type: number
+            type: integer
             description: Number of registrations associated with this curriculum.
             minimum: 0
             x-oapi-codegen-extra-tags:
-              db: registration_count,omitempty
-              json: registrationCount,omitempty
+              db: registration_count
+              json: registrationCount
```

```diff
-RegistrationCount float32 `db:"registration_count,omitempty" json:"registrationCount,omitempty" yaml:"registrationCount,omitempty"`
+RegistrationCount int `db:"registration_count" json:"registrationCount" yaml:"registrationCount"`
```

Signed-off-by: Akshay Nazare <akshaynazare3@gmail.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Registration counts are now represented as whole numbers in academy curriculum responses.
  * Registration count fields are consistently included in returned data, including when the value is zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->