### PR TITLE
fix(typescript): give badge and invitation root exports versioned names

### DIFF
--- a/typescript/index.test.ts
+++ b/typescript/index.test.ts
@@ -1,0 +1,128 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Packaging guard for meshery/schemas#1154.
+ *
+ * Root exports of construct documents carry the construct version in the
+ * identifier, so a consumer can see which edition it is getting at the import
+ * site. Exactly two did not: `BadgeSchema` and `InvitationSchema` read as *the*
+ * schema for their construct while resolving to the retired v1beta1 edition.
+ *
+ * That edition still carries the snake_case identifiers (`image_url`, `org_id`,
+ * `owner_id`, `expires_at`). A consumer addressing the live camelCase names got
+ * no error anywhere - property lookups against the wrong document simply return
+ * nothing - so the failure surfaced only as a form field that never rendered
+ * (layer5io/meshery-cloud#5917).
+ *
+ * These assertions fail if a new version-ambiguous root export is introduced.
+ */
+
+const indexSource = readFileSync(join(import.meta.dirname, "index.ts"), "utf-8");
+
+/**
+ * Version-ambiguous root exports retained as deprecated aliases for one
+ * release. Nothing may be added here - entries only leave, when the alias is
+ * dropped.
+ */
+const DEPRECATED_AMBIGUOUS_EXPORTS = new Set(["BadgeSchema", "InvitationSchema"]);
+
+/**
+ * Local binding -> the generated construct path it resolves to, following the
+ * `const alias = binding;` indirection the deprecated aliases are declared with.
+ */
+function importedConstructPaths(): Map<string, string> {
+  const paths = new Map<string, string>();
+  const importLine = /^import\s+(\w+)\s+from\s+"(\.\/generated\/[^"]+)";$/gm;
+  for (const [, binding, path] of indexSource.matchAll(importLine)) {
+    paths.set(binding, path);
+  }
+
+  const constAlias = /^const\s+(\w+)\s*=\s*(\w+);$/gm;
+  for (const [, alias, target] of indexSource.matchAll(constAlias)) {
+    const path = paths.get(target);
+    if (path) paths.set(alias, path);
+  }
+
+  return paths;
+}
+
+/** The `export { ... }` block that publishes the construct documents. */
+function rootSchemaExports(): Array<{ local: string; exported: string }> {
+  const blockStart = indexSource.indexOf("// Export schemas");
+  assert.notEqual(blockStart, -1, "expected an '// Export schemas' block in index.ts");
+
+  const open = indexSource.indexOf("export {", blockStart);
+  const close = indexSource.indexOf("};", open);
+  assert.ok(open !== -1 && close !== -1, "expected a closed export block");
+
+  const body = indexSource
+    .slice(open + "export {".length, close)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/\/\/[^\n]*/g, "");
+
+  return body
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .map((entry) => {
+      const [local, exported] = entry.split(/\s+as\s+/).map((part) => part.trim());
+      return { local, exported: exported ?? local };
+    });
+}
+
+/** "v1beta2" -> "V1Beta2", matching the identifier convention. */
+function versionToken(path: string): string | null {
+  const match = path.match(/\/generated\/(v1)(alpha|beta)(\d+)\//);
+  if (!match) return null;
+  const [, v, stage, ordinal] = match;
+  return `${v.toUpperCase()}${stage[0].toUpperCase()}${stage.slice(1)}${ordinal}`;
+}
+
+test("every root construct-document export names the construct version it resolves to", () => {
+  const paths = importedConstructPaths();
+  const ambiguous: string[] = [];
+
+  for (const { local, exported } of rootSchemaExports()) {
+    if (!exported.endsWith("Schema")) continue;
+    if (DEPRECATED_AMBIGUOUS_EXPORTS.has(exported)) continue;
+
+    const path = paths.get(local);
+    if (!path) continue;
+
+    const version = versionToken(path);
+    assert.ok(version, `could not read a construct version out of ${path}`);
+
+    if (!exported.includes(version)) {
+      ambiguous.push(`${exported} -> ${path} (expected the name to contain ${version})`);
+    }
+  }
+
+  assert.deepEqual(
+    ambiguous,
+    [],
+    `version-ambiguous root export(s) added. A consumer cannot tell which construct edition ` +
+      `these resolve to, and reading the wrong edition fails silently:\n  ${ambiguous.join("\n  ")}`,
+  );
+});
+
+test("each deprecated alias is still exported and still pinned to v1beta1", () => {
+  const paths = importedConstructPaths();
+  const exports = new Map(rootSchemaExports().map(({ exported, local }) => [exported, local]));
+
+  for (const alias of DEPRECATED_AMBIGUOUS_EXPORTS) {
+    const local = exports.get(alias);
+    assert.ok(local, `${alias} is no longer exported - drop it from DEPRECATED_AMBIGUOUS_EXPORTS`);
+
+    const path = paths.get(local);
+    assert.ok(path, `${alias} does not resolve to a generated construct document`);
+    assert.equal(
+      versionToken(path),
+      "V1Beta1",
+      `${alias} was repointed to ${path}. That is a breaking change for consumers still ` +
+        `reading the v1beta1 identifiers - it needs to be deliberate, not incidental.`,
+    );
+  }
+});

--- a/typescript/index.ts
+++ b/typescript/index.ts
@@ -72,13 +72,14 @@ import ModelDefinitionV1Beta1OpenApiSchema from "./generated/v1beta1/model/Model
 // import EvaluationDefinitionV1Beta1OpenApiSchema from "./generated/v1beta1/evaluation/EvaluationSchema";
 import EnvironmentDefinitionV1Beta1OpenApiSchema from "./generated/v1beta1/environment/EnvironmentSchema";
 import WorkspaceDefinitionV1Beta1OpenApiSchema from "./generated/v1beta1/workspace/WorkspaceSchema";
-import InvitationSchema from "./generated/v1beta1/invitation/InvitationSchema";
-import BadgeSchema from "./generated/v1beta1/badge/BadgeSchema";
+import InvitationDefinitionV1Beta1OpenApiSchema from "./generated/v1beta1/invitation/InvitationSchema";
+import BadgeDefinitionV1Beta1OpenApiSchema from "./generated/v1beta1/badge/BadgeSchema";
 // v1beta2
 import ComponentDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/component/ComponentSchema";
 import ConnectionDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/connection/ConnectionSchema";
 import DesignDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/design/DesignSchema";
 import InvitationDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/invitation/InvitationSchema";
+import BadgeDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/badge/BadgeSchema";
 import RelationshipDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/relationship/RelationshipSchema";
 // import AcademyDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/academy/AcademySchema";
 // import CatalogDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/catalog/CatalogSchema";
@@ -86,6 +87,9 @@ import RelationshipDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/rela
 // import PlanDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/plan/PlanSchema";
 // import SubscriptionDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/subscription/SubscriptionSchema";
 // import TokenDefinitionV1Beta2OpenApiSchema from "./generated/v1beta2/token/TokenSchema";
+
+// v1beta3
+import InvitationDefinitionV1Beta3OpenApiSchema from "./generated/v1beta3/invitation/InvitationSchema";
 
 // v1alpha3
 import RelationshipDefinitionV1Alpha3OpenApiSchema from "./generated/v1alpha3/relationship/RelationshipSchema";
@@ -101,6 +105,25 @@ import type * as core from "./generated/v1alpha1/core/Core";
 // open-ended string; that enum only names the kinds with bespoke handling.
 export * from "./constants";
 
+/**
+ * @deprecated Version-ambiguous. Resolves to the retired v1beta1 badge
+ * construct, which still carries the snake_case identifiers (`image_url`,
+ * `org_id`). Reading it while addressing the live camelCase names fails
+ * silently - property lookups just return nothing. Use
+ * `BadgeDefinitionV1Beta2OpenApiSchema`, or import the construct subpath
+ * directly. See meshery/schemas#1154.
+ */
+const BadgeSchema = BadgeDefinitionV1Beta1OpenApiSchema;
+
+/**
+ * @deprecated Version-ambiguous. Resolves to the retired v1beta1 invitation
+ * construct, which still carries the snake_case identifiers (`owner_id`,
+ * `is_default`, `expires_at`). Use
+ * `InvitationDefinitionV1Beta3OpenApiSchema`, or import the construct subpath
+ * directly. See meshery/schemas#1154.
+ */
+const InvitationSchema = InvitationDefinitionV1Beta1OpenApiSchema;
+
 // Export schemas
 export {
   core,
@@ -112,16 +135,22 @@ export {
   ModelDefinitionV1Beta1OpenApiSchema,
   CategoryDefinitionV1Beta1OpenApiSchema,
   SubCategoryDefinitionV1Beta1OpenApiSchema,
-  InvitationSchema,
-  BadgeSchema,
+  InvitationDefinitionV1Beta1OpenApiSchema,
+  BadgeDefinitionV1Beta1OpenApiSchema,
   // v1beta2
   ComponentDefinitionV1Beta2OpenApiSchema,
   ConnectionDefinitionV1Beta2OpenApiSchema,
   DesignDefinitionV1Beta2OpenApiSchema,
   InvitationDefinitionV1Beta2OpenApiSchema,
+  BadgeDefinitionV1Beta2OpenApiSchema,
   RelationshipDefinitionV1Beta2OpenApiSchema,
+  // v1beta3
+  InvitationDefinitionV1Beta3OpenApiSchema,
   // v1alpha3
   RelationshipDefinitionV1Alpha3OpenApiSchema,
+  // Deprecated aliases - see the declarations above.
+  BadgeSchema,
+  InvitationSchema,
 };
 
 // Constructs


### PR DESCRIPTION
## Description

Root exports of construct documents carry the construct version in the identifier, so a consumer can see which edition it is getting at the import site. Exactly two did not — `BadgeSchema` and `InvitationSchema` read as *the* schema for their construct while resolving to the retired v1beta1 edition, which still carries the snake_case identifiers. A consumer addressing the live camelCase names got no error anywhere; property lookups against the wrong document just return nothing.

This adds the correctly-named current editions, names the existing v1beta1 imports explicitly, and keeps the two unsuffixed names as deprecated aliases resolving to exactly what they resolved to before.

Fixes #1154

## Notes for reviewers

**Nothing breaks.** `BadgeSchema` and `InvitationSchema` still export the v1beta1 documents. This is purely additive plus a deprecation marker; the decision about when to drop the aliases is left to you.

**`@deprecated` on an export specifier does not survive the build.** This is the one non-obvious part. `tsup` flattens the export list into a single statement, so a JSDoc attached to a specifier is dropped and never reaches `dist/index.d.ts` — consumers would get no editor signal, which is most of the point. Declaring the aliases as consts emits `declare const BadgeSchema` with the comment intact. Verified in both `dist/index.d.ts` and `dist/index.d.mts`:

```ts
/**
 * @deprecated Version-ambiguous. Resolves to the retired v1beta1 badge
 * construct, which still carries the snake_case identifiers (`image_url`,
 * `org_id`)...
 */
declare const BadgeSchema: Record<string, unknown>;
```

**The packaging guard.** `typescript/index.test.ts` resolves each root export back to the construct path it imports and fails if the exported name doesn't encode that version, with the two aliases explicitly allowlisted. A second assertion pins those aliases to v1beta1, so repointing them cannot happen incidentally — that would be a breaking change and should be deliberate.

I confirmed the guard fails against the pre-fix state rather than passing vacuously:

```
not ok 1 - every root construct-document export names the construct version it resolves to
  BadgeSchema -> ./generated/v1beta1/badge/BadgeSchema (expected the name to contain V1Beta1)
```

**One thing needing your call.** `npm test` only runs in `generate-artifacts-from-schemas.yml`, which triggers on push to master — so this guard will not gate PRs as things stand. I've left the workflows untouched; happy to add a step to the blocking job in `schema-audit.yml` if you want it enforced pre-merge.

## Verification

```
npm test                            ✓ 6 pass, 0 fail (4 before, +2 here)
npm run build                       ✓ builds; @deprecated present in dist/index.d.ts and .d.mts
npx tsc --noEmit                    ✓ no new errors (6 pre-existing node_modules resolution errors, identical on master)
negative test (alias de-allowlisted) ✓ guard fails as intended
```

Signed-off-by: Akshay Nazare <akshaynazare3@gmail.com>
