### PR TITLE
docs(openapi): document credential_id and selectedOrganizationID as deprecated aliases

### DIFF
--- a/models/v1beta1/user/helpers_test.go
+++ b/models/v1beta1/user/helpers_test.go
@@ -36,3 +36,26 @@ func TestPreferenceScan_ValidSelectedOrganizationIdPreserved(t *testing.T) {
 		t.Fatalf("expected %s, got %s", id, p.SelectedOrganizationId)
 	}
 }
+
+// Meshery Server accepts the deprecated all-caps `selectedOrganizationID` on
+// read (meshery/meshery#21191, server/models/preference.go), because rows
+// persisted under that key exist in the wild. core.MapToStruct goes through
+// encoding/json, whose field matching is case-insensitive, so such a row
+// resolves onto the canonical field on its own.
+//
+// That only holds while the alias is NOT declared as its own property. Adding
+// a `selectedOrganizationID` property to the OpenAPI generates a second field
+// whose tag matches the legacy key exactly; encoding/json prefers the exact
+// match, so the value would land on the alias and leave this field zero -
+// silently un-selecting the organization for exactly the rows the alias exists
+// to rescue. See meshery/schemas#1136.
+func TestPreferenceScan_LegacyAllCapsKeyResolvesToCanonicalField(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	p := &Preference{}
+	if err := p.Scan([]byte(`{"selectedOrganizationID":"` + id.String() + `"}`)); err != nil {
+		t.Fatalf("scan with legacy all-caps key should not error, got: %v", err)
+	}
+	if p.SelectedOrganizationId != id {
+		t.Fatalf("legacy all-caps key must resolve onto the canonical field: expected %s, got %s", id, p.SelectedOrganizationId)
+	}
+}

--- a/models/v1beta2/user/helpers_test.go
+++ b/models/v1beta2/user/helpers_test.go
@@ -36,3 +36,26 @@ func TestPreferenceScan_ValidSelectedOrganizationIdPreserved(t *testing.T) {
 		t.Fatalf("expected %s, got %s", id, p.SelectedOrganizationId)
 	}
 }
+
+// Meshery Server accepts the deprecated all-caps `selectedOrganizationID` on
+// read (meshery/meshery#21191, server/models/preference.go), because rows
+// persisted under that key exist in the wild. core.MapToStruct goes through
+// encoding/json, whose field matching is case-insensitive, so such a row
+// resolves onto the canonical field on its own.
+//
+// That only holds while the alias is NOT declared as its own property. Adding
+// a `selectedOrganizationID` property to the OpenAPI generates a second field
+// whose tag matches the legacy key exactly; encoding/json prefers the exact
+// match, so the value would land on the alias and leave this field zero -
+// silently un-selecting the organization for exactly the rows the alias exists
+// to rescue. See meshery/schemas#1136.
+func TestPreferenceScan_LegacyAllCapsKeyResolvesToCanonicalField(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	p := &Preference{}
+	if err := p.Scan([]byte(`{"selectedOrganizationID":"` + id.String() + `"}`)); err != nil {
+		t.Fatalf("scan with legacy all-caps key should not error, got: %v", err)
+	}
+	if p.SelectedOrganizationId != id {
+		t.Fatalf("legacy all-caps key must resolve onto the canonical field: expected %s, got %s", id, p.SelectedOrganizationId)
+	}
+}

--- a/models/v1beta3/user/helpers_test.go
+++ b/models/v1beta3/user/helpers_test.go
@@ -36,3 +36,26 @@ func TestPreferenceScan_ValidSelectedOrganizationIdPreserved(t *testing.T) {
 		t.Fatalf("expected %s, got %s", id, p.SelectedOrganizationId)
 	}
 }
+
+// Meshery Server accepts the deprecated all-caps `selectedOrganizationID` on
+// read (meshery/meshery#21191, server/models/preference.go), because rows
+// persisted under that key exist in the wild. core.MapToStruct goes through
+// encoding/json, whose field matching is case-insensitive, so such a row
+// resolves onto the canonical field on its own.
+//
+// That only holds while the alias is NOT declared as its own property. Adding
+// a `selectedOrganizationID` property to the OpenAPI generates a second field
+// whose tag matches the legacy key exactly; encoding/json prefers the exact
+// match, so the value would land on the alias and leave this field zero -
+// silently un-selecting the organization for exactly the rows the alias exists
+// to rescue. See meshery/schemas#1136.
+func TestPreferenceScan_LegacyAllCapsKeyResolvesToCanonicalField(t *testing.T) {
+	id := uuid.Must(uuid.NewV4())
+	p := &Preference{}
+	if err := p.Scan([]byte(`{"selectedOrganizationID":"` + id.String() + `"}`)); err != nil {
+		t.Fatalf("scan with legacy all-caps key should not error, got: %v", err)
+	}
+	if p.SelectedOrganizationId != id {
+		t.Fatalf("legacy all-caps key must resolve onto the canonical field: expected %s, got %s", id, p.SelectedOrganizationId)
+	}
+}

--- a/schemas/constructs/v1beta2/credential/api.yml
+++ b/schemas/constructs/v1beta2/credential/api.yml
@@ -114,6 +114,7 @@ paths:
       description: Deletes a credential belonging to the authenticated user.
       parameters:
         - $ref: "#/components/parameters/credentialIdQuery"
+        - $ref: "#/components/parameters/credentialIdQueryLegacy"
       responses:
         "204":
           description: Credential deleted
@@ -180,6 +181,17 @@ components:
       in: query
       description: Credential ID
       required: true
+      schema:
+        $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
+    credentialIdQueryLegacy:
+      name: credential_id
+      in: query
+      description:
+        Deprecated snake_case alias of `credentialId`. Meshery Server reads
+        `credentialId` first and falls back to this spelling, so clients
+        generated before the rename keep working. Send `credentialId` instead;
+        never send both.
+      deprecated: true
       schema:
         $ref: "../../v1alpha1/core/api.yml#/components/schemas/uuid"
     page:

--- a/schemas/constructs/v1beta2/user/api.yml
+++ b/schemas/constructs/v1beta2/user/api.yml
@@ -1061,7 +1061,14 @@ components:
           description: The dashboard preferences of the preference.
         selectedOrganizationId:
           type: string
-          description: ID of the associated selectedOrganization.
+          description:
+            ID of the associated selectedOrganization. Meshery Server also
+            accepts the deprecated all-caps spelling `selectedOrganizationID`
+            on read, so preferences persisted under the legacy key survive.
+            That alias is described here rather than declared as its own
+            property on purpose - declaring it binds legacy rows to the alias
+            and leaves this field zero. Always read and write
+            `selectedOrganizationId`.
           maxLength: 500
           format: uuid
         selectedWorkspaceForOrganizations:

--- a/schemas/constructs/v1beta3/user/api.yml
+++ b/schemas/constructs/v1beta3/user/api.yml
@@ -865,7 +865,14 @@ components:
           description: The dashboard preferences of the preference.
         selectedOrganizationId:
           type: string
-          description: ID of the associated selectedOrganization.
+          description:
+            ID of the associated selectedOrganization. Meshery Server also
+            accepts the deprecated all-caps spelling `selectedOrganizationID`
+            on read, so preferences persisted under the legacy key survive.
+            That alias is described here rather than declared as its own
+            property on purpose - declaring it binds legacy rows to the alias
+            and leaves this field zero. Always read and write
+            `selectedOrganizationId`.
           maxLength: 500
           format: uuid
         selectedWorkspaceForOrganizations:


### PR DESCRIPTION
## Description

Fixes #1136

Meshery Server accepts two legacy wire spellings that the OpenAPI does not describe. Because `docs/data/openapi.yml` is generated here and copied into `meshery/meshery` by its `[Docs] Update REST API Documentation` job, the description has to originate in this repo.

**The issue's `meshery/meshery#PR_PLACEHOLDER` resolves to meshery/meshery#21191** ("[Server][UI] Repoint schemas-owned contracts at `@meshery/schemas`", merged 2026-08-07, commit `baa98b5`). Both fallbacks landed there and are on `master` today:

| Alias | Server code | Behavior |
|---|---|---|
| `credential_id` | `server/handlers/credentials_handlers.go:150-153` | reads `credentialId`, falls back to `credential_id` |
| `selectedOrganizationID` | `server/models/preference.go:76-95` | custom `UnmarshalJSON` accepting both spellings |

## The two halves are documented differently, on purpose

### `credential_id` — a real deprecated parameter

Added to `v1beta2/credential/api.yml` only, since `v1beta1/credential` carries `x-deprecated: true`. It follows the `pagesize` parameter already sitting in the same `components/parameters` block: `deprecated: true` plus a description naming the canonical spelling.

The canonical `credentialIdQuery` stays `required: true` and the alias is optional, so a generated client never sends both.

### `selectedOrganizationID` — described, *not* declared

My first push declared this as its own `deprecated: true` property on `Preference`. **That was wrong, and it would have caused the exact bug the alias exists to prevent.** I caught it self-reviewing and have reverted it.

`Preference.Scan` (`models/*/user/helpers.go`) routes through `core.MapToStruct` → `encoding/json`, whose field matching **is case-insensitive**. So a legacy row stored under the all-caps key already resolves onto `SelectedOrganizationId` on its own, with no schema change at all:

```
{"selectedOrganizationID":"3f2504e0-4f89-11d3-9a0c-0305e82c3301"}

  on master        → SelectedOrganizationId = 3f2504e0-4f89-11d3-9a0c-0305e82c3301  ✅
  with the property → SelectedOrganizationId = 00000000-0000-0000-0000-000000000000  ❌
```

Declaring the property generates a second field whose tag matches the legacy key **exactly**, and `encoding/json` prefers an exact match over a case-insensitive one. The value lands on the alias field and the canonical field stays zero — silently un-selecting the organization for precisely the rows the alias was added to rescue. No error, no failing type check.

So the alias is documented in the canonical property's `description` instead, and `TestPreferenceScan_LegacyAllCapsKeyResolvesToCanonicalField` pins the behavior in v1beta1, v1beta2 and v1beta3 so nobody re-adds the property later.

## A separate pre-existing bug this turned up

Not fixed here — flagging it because it is in the same code path and I would rather not bundle it.

`Preference.Scan` deliberately sanitizes junk out of `selectedOrganizationId`, because legacy rows hold empty strings there and `MapToStruct` would otherwise fail and block callers like OAuth sign-in. The guard deletes only the exact lowercase key:

```go
if v, ok := mapVal["selectedOrganizationId"]; ok { … }
```

But since matching is case-insensitive, a legacy row under the **all-caps** key reaches `MapToStruct` unsanitized. On current `master`:

```
{"selectedOrganizationID":""}  → uuid: incorrect UUID length 0 in string ""
```

That is the same sign-in-blocking failure the guard was written to prevent, still open for the all-caps population — which is exactly the population meshery/meshery#21191 added the fallback for. Happy to open an issue, or fold the fix in here if you would rather have it in one PR.

## Verification

Everything the `Schema Audit` blocking job runs, locally:

| Check | Result |
|---|---|
| `make validate-schemas` | ✅ no blocking violations |
| `go test ./validation/... ./models/...` | ✅ pass |
| `make test-rtk` | ✅ pass |
| `make test-ts` | ✅ 4/4 |
| `make consumer-audit` | ✅ exit 0 |

I also diffed the advisory audit across the change: `make audit-schemas-full` emits **2014 lines before and 2014 after**, with no new findings — the only textual difference is map-iteration ordering.

Per `AGENTS.md` ("do not manually commit regenerated output in normal PRs"), the regenerated `models/` and `typescript/rtk/` output is **not** included; the automation on `master` commits it. I did regenerate locally with `oapi-codegen v2.5.1` — matching what `generate-artifacts-from-schemas.yml` installs — to confirm the output is what I expect before dropping it. (`go.mod` still pins `v2.5.0`; that drift is #1194 and deliberately untouched here.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Credential deletion now accepts the deprecated `credential_id` query parameter as a legacy alias for `credentialId`. Use `credentialId` for new integrations; both parameters cannot be provided together.
  * User preferences continue to recognize the legacy `selectedOrganizationID` spelling when reading existing data.
  * Use `selectedOrganizationId` when reading and writing preferences. The legacy spelling is deprecated and should not be sent alongside the canonical property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->