### PR TITLE
Fix design import form label

### DIFF
--- a/schemas/constructs/v1beta3/design/forms/import.json
+++ b/schemas/constructs/v1beta3/design/forms/import.json
@@ -5,7 +5,7 @@
   "properties": {
     "name": {
       "type": "string",
-      "title": "Design file name",
+      "title": "Design Name",
       "description": "Provide a name for your design. This name will help you identify the design later. You can also change the name of your design after importing it.",
       "x-rjsf-grid-area": "12"
     },


### PR DESCRIPTION
## Summary
- Update the design import form label from `Design file name` to `Design Name`.

## Validation
- Confirmed the form remains valid JSON.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the import-design form label from “Design file name” to “Design Name.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->