### PR TITLE
Add youtube to an organization's social brand profiles

### DIFF
--- a/models/v1beta2/organization/organization.go
+++ b/models/v1beta2/organization/organization.go
@@ -244,6 +244,9 @@ type Social struct {
 
 	// X URL of the organization's X (formerly Twitter) profile.
 	X *string `json:"x,omitempty" yaml:"x,omitempty"`
+
+	// YouTube URL of the organization's YouTube channel.
+	YouTube *string `json:"youtube,omitempty" yaml:"youtube,omitempty"`
 }
 
 // TeamsOrganizationsMapping Junction record linking a team to an organization.

--- a/schemas/constructs/v1beta2/organization/api.yml
+++ b/schemas/constructs/v1beta2/organization/api.yml
@@ -557,6 +557,12 @@ components:
           maxLength: 2048
           description: URL of the organization's X (formerly Twitter) profile.
           x-go-name: X
+        youtube:
+          type: string
+          format: uri
+          maxLength: 2048
+          description: URL of the organization's YouTube channel.
+          x-go-name: YouTube
 
     CarouselSlide:
       type: object

--- a/typescript/generated/v1beta2/organization/Organization.ts
+++ b/typescript/generated/v1beta2/organization/Organization.ts
@@ -289,6 +289,11 @@ export interface components {
                  * @description URL of the organization's X (formerly Twitter) profile.
                  */
                 x?: string;
+                /**
+                 * Format: uri
+                 * @description URL of the organization's YouTube channel.
+                 */
+                youtube?: string;
             };
         };
         /** @description The organization's social brand profiles. Deliberately a sibling of support rather than an entry in it: support renders as support contacts on the auth and error pages, where a brand profile does not belong. Each platform is a named, individually validated URL so consumers can render the matching platform icon. Empty or omitted fields fall back to the platform defaults. */
@@ -303,6 +308,11 @@ export interface components {
              * @description URL of the organization's X (formerly Twitter) profile.
              */
             x?: string;
+            /**
+             * Format: uri
+             * @description URL of the organization's YouTube channel.
+             */
+            youtube?: string;
         };
         /** @description A single slide in the auth-page feature carousel. */
         CarouselSlide: {
@@ -444,6 +454,11 @@ export interface components {
                      * @description URL of the organization's X (formerly Twitter) profile.
                      */
                     x?: string;
+                    /**
+                     * Format: uri
+                     * @description URL of the organization's YouTube channel.
+                     */
+                    youtube?: string;
                 };
             };
             /**
@@ -553,6 +568,11 @@ export interface components {
                          * @description URL of the organization's X (formerly Twitter) profile.
                          */
                         x?: string;
+                        /**
+                         * Format: uri
+                         * @description URL of the organization's YouTube channel.
+                         */
+                        youtube?: string;
                     };
                 };
                 /**
@@ -722,6 +742,11 @@ export interface components {
                              * @description URL of the organization's X (formerly Twitter) profile.
                              */
                             x?: string;
+                            /**
+                             * Format: uri
+                             * @description URL of the organization's YouTube channel.
+                             */
+                            youtube?: string;
                         };
                     };
                     /**
@@ -875,6 +900,11 @@ export interface components {
                                  * @description URL of the organization's X (formerly Twitter) profile.
                                  */
                                 x?: string;
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's YouTube channel.
+                                 */
+                                youtube?: string;
                             };
                         };
                         /**
@@ -1029,6 +1059,11 @@ export interface components {
                                  * @description URL of the organization's X (formerly Twitter) profile.
                                  */
                                 x?: string;
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's YouTube channel.
+                                 */
+                                youtube?: string;
                             };
                         };
                         /**
@@ -1166,6 +1201,11 @@ export interface components {
                          * @description URL of the organization's X (formerly Twitter) profile.
                          */
                         x?: string;
+                        /**
+                         * Format: uri
+                         * @description URL of the organization's YouTube channel.
+                         */
+                        youtube?: string;
                     };
                 };
                 /**
@@ -1590,6 +1630,11 @@ export interface components {
                                  * @description URL of the organization's X (formerly Twitter) profile.
                                  */
                                 x?: string;
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's YouTube channel.
+                                 */
+                                youtube?: string;
                             };
                         };
                         /**
@@ -1760,6 +1805,11 @@ export interface operations {
                                              * @description URL of the organization's X (formerly Twitter) profile.
                                              */
                                             x?: string;
+                                            /**
+                                             * Format: uri
+                                             * @description URL of the organization's YouTube channel.
+                                             */
+                                            youtube?: string;
                                         };
                                     };
                                     /**
@@ -1935,6 +1985,11 @@ export interface operations {
                                  * @description URL of the organization's X (formerly Twitter) profile.
                                  */
                                 x?: string;
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's YouTube channel.
+                                 */
+                                youtube?: string;
                             };
                         };
                         /**
@@ -2080,6 +2135,11 @@ export interface operations {
                                              * @description URL of the organization's X (formerly Twitter) profile.
                                              */
                                             x?: string;
+                                            /**
+                                             * Format: uri
+                                             * @description URL of the organization's YouTube channel.
+                                             */
+                                            youtube?: string;
                                         };
                                     };
                                     /**
@@ -2375,6 +2435,11 @@ export interface operations {
                                              * @description URL of the organization's X (formerly Twitter) profile.
                                              */
                                             x?: string;
+                                            /**
+                                             * Format: uri
+                                             * @description URL of the organization's YouTube channel.
+                                             */
+                                            youtube?: string;
                                         };
                                     };
                                     /**
@@ -2564,6 +2629,11 @@ export interface operations {
                                  * @description URL of the organization's X (formerly Twitter) profile.
                                  */
                                 x?: string;
+                                /**
+                                 * Format: uri
+                                 * @description URL of the organization's YouTube channel.
+                                 */
+                                youtube?: string;
                             };
                         };
                         /**
@@ -2709,6 +2779,11 @@ export interface operations {
                                              * @description URL of the organization's X (formerly Twitter) profile.
                                              */
                                             x?: string;
+                                            /**
+                                             * Format: uri
+                                             * @description URL of the organization's YouTube channel.
+                                             */
+                                            youtube?: string;
                                         };
                                     };
                                     /**
@@ -2968,6 +3043,11 @@ export interface operations {
                                      * @description URL of the organization's X (formerly Twitter) profile.
                                      */
                                     x?: string;
+                                    /**
+                                     * Format: uri
+                                     * @description URL of the organization's YouTube channel.
+                                     */
+                                    youtube?: string;
                                 };
                             };
                             /**

--- a/typescript/generated/v1beta2/organization/OrganizationSchema.ts
+++ b/typescript/generated/v1beta2/organization/OrganizationSchema.ts
@@ -428,6 +428,13 @@ const OrganizationSchema: Record<string, unknown> = {
                                             "maxLength": 2048,
                                             "description": "URL of the organization's X (formerly Twitter) profile.",
                                             "x-go-name": "X"
+                                          },
+                                          "youtube": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "maxLength": 2048,
+                                            "description": "URL of the organization's YouTube channel.",
+                                            "x-go-name": "YouTube"
                                           }
                                         }
                                       }
@@ -809,6 +816,13 @@ const OrganizationSchema: Record<string, unknown> = {
                                 "maxLength": 2048,
                                 "description": "URL of the organization's X (formerly Twitter) profile.",
                                 "x-go-name": "X"
+                              },
+                              "youtube": {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 2048,
+                                "description": "URL of the organization's YouTube channel.",
+                                "x-go-name": "YouTube"
                               }
                             }
                           }
@@ -1168,6 +1182,13 @@ const OrganizationSchema: Record<string, unknown> = {
                                             "maxLength": 2048,
                                             "description": "URL of the organization's X (formerly Twitter) profile.",
                                             "x-go-name": "X"
+                                          },
+                                          "youtube": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "maxLength": 2048,
+                                            "description": "URL of the organization's YouTube channel.",
+                                            "x-go-name": "YouTube"
                                           }
                                         }
                                       }
@@ -1833,6 +1854,13 @@ const OrganizationSchema: Record<string, unknown> = {
                                             "maxLength": 2048,
                                             "description": "URL of the organization's X (formerly Twitter) profile.",
                                             "x-go-name": "X"
+                                          },
+                                          "youtube": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "maxLength": 2048,
+                                            "description": "URL of the organization's YouTube channel.",
+                                            "x-go-name": "YouTube"
                                           }
                                         }
                                       }
@@ -2347,6 +2375,13 @@ const OrganizationSchema: Record<string, unknown> = {
                                 "maxLength": 2048,
                                 "description": "URL of the organization's X (formerly Twitter) profile.",
                                 "x-go-name": "X"
+                              },
+                              "youtube": {
+                                "type": "string",
+                                "format": "uri",
+                                "maxLength": 2048,
+                                "description": "URL of the organization's YouTube channel.",
+                                "x-go-name": "YouTube"
                               }
                             }
                           }
@@ -2706,6 +2741,13 @@ const OrganizationSchema: Record<string, unknown> = {
                                             "maxLength": 2048,
                                             "description": "URL of the organization's X (formerly Twitter) profile.",
                                             "x-go-name": "X"
+                                          },
+                                          "youtube": {
+                                            "type": "string",
+                                            "format": "uri",
+                                            "maxLength": 2048,
+                                            "description": "URL of the organization's YouTube channel.",
+                                            "x-go-name": "YouTube"
                                           }
                                         }
                                       }
@@ -3118,6 +3160,13 @@ const OrganizationSchema: Record<string, unknown> = {
                                   "maxLength": 2048,
                                   "description": "URL of the organization's X (formerly Twitter) profile.",
                                   "x-go-name": "X"
+                                },
+                                "youtube": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "maxLength": 2048,
+                                  "description": "URL of the organization's YouTube channel.",
+                                  "x-go-name": "YouTube"
                                 }
                               }
                             }
@@ -4371,6 +4420,13 @@ const OrganizationSchema: Record<string, unknown> = {
                               "maxLength": 2048,
                               "description": "URL of the organization's X (formerly Twitter) profile.",
                               "x-go-name": "X"
+                            },
+                            "youtube": {
+                              "type": "string",
+                              "format": "uri",
+                              "maxLength": 2048,
+                              "description": "URL of the organization's YouTube channel.",
+                              "x-go-name": "YouTube"
                             }
                           }
                         }
@@ -4724,6 +4780,13 @@ const OrganizationSchema: Record<string, unknown> = {
                 "maxLength": 2048,
                 "description": "URL of the organization's X (formerly Twitter) profile.",
                 "x-go-name": "X"
+              },
+              "youtube": {
+                "type": "string",
+                "format": "uri",
+                "maxLength": 2048,
+                "description": "URL of the organization's YouTube channel.",
+                "x-go-name": "YouTube"
               }
             }
           }
@@ -4749,6 +4812,13 @@ const OrganizationSchema: Record<string, unknown> = {
             "maxLength": 2048,
             "description": "URL of the organization's X (formerly Twitter) profile.",
             "x-go-name": "X"
+          },
+          "youtube": {
+            "type": "string",
+            "format": "uri",
+            "maxLength": 2048,
+            "description": "URL of the organization's YouTube channel.",
+            "x-go-name": "YouTube"
           }
         }
       },
@@ -5131,6 +5201,13 @@ const OrganizationSchema: Record<string, unknown> = {
                     "maxLength": 2048,
                     "description": "URL of the organization's X (formerly Twitter) profile.",
                     "x-go-name": "X"
+                  },
+                  "youtube": {
+                    "type": "string",
+                    "format": "uri",
+                    "maxLength": 2048,
+                    "description": "URL of the organization's YouTube channel.",
+                    "x-go-name": "YouTube"
                   }
                 }
               }
@@ -5405,6 +5482,13 @@ const OrganizationSchema: Record<string, unknown> = {
                         "maxLength": 2048,
                         "description": "URL of the organization's X (formerly Twitter) profile.",
                         "x-go-name": "X"
+                      },
+                      "youtube": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2048,
+                        "description": "URL of the organization's YouTube channel.",
+                        "x-go-name": "YouTube"
                       }
                     }
                   }
@@ -5865,6 +5949,13 @@ const OrganizationSchema: Record<string, unknown> = {
                             "maxLength": 2048,
                             "description": "URL of the organization's X (formerly Twitter) profile.",
                             "x-go-name": "X"
+                          },
+                          "youtube": {
+                            "type": "string",
+                            "format": "uri",
+                            "maxLength": 2048,
+                            "description": "URL of the organization's YouTube channel.",
+                            "x-go-name": "YouTube"
                           }
                         }
                       }
@@ -6248,6 +6339,13 @@ const OrganizationSchema: Record<string, unknown> = {
                                   "maxLength": 2048,
                                   "description": "URL of the organization's X (formerly Twitter) profile.",
                                   "x-go-name": "X"
+                                },
+                                "youtube": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "maxLength": 2048,
+                                  "description": "URL of the organization's YouTube channel.",
+                                  "x-go-name": "YouTube"
                                 }
                               }
                             }
@@ -6635,6 +6733,13 @@ const OrganizationSchema: Record<string, unknown> = {
                                   "maxLength": 2048,
                                   "description": "URL of the organization's X (formerly Twitter) profile.",
                                   "x-go-name": "X"
+                                },
+                                "youtube": {
+                                  "type": "string",
+                                  "format": "uri",
+                                  "maxLength": 2048,
+                                  "description": "URL of the organization's YouTube channel.",
+                                  "x-go-name": "YouTube"
                                 }
                               }
                             }
@@ -6967,6 +7072,13 @@ const OrganizationSchema: Record<string, unknown> = {
                         "maxLength": 2048,
                         "description": "URL of the organization's X (formerly Twitter) profile.",
                         "x-go-name": "X"
+                      },
+                      "youtube": {
+                        "type": "string",
+                        "format": "uri",
+                        "maxLength": 2048,
+                        "description": "URL of the organization's YouTube channel.",
+                        "x-go-name": "YouTube"
                       }
                     }
                   }

--- a/typescript/rtk/cloud.ts
+++ b/typescript/rtk/cloud.ts
@@ -3353,6 +3353,8 @@ export type GetOrgsApiResponse = /** status 200 Organizations response */ {
             linkedin?: string;
             /** URL of the organization's X (formerly Twitter) profile. */
             x?: string;
+            /** URL of the organization's YouTube channel. */
+            youtube?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -3485,6 +3487,8 @@ export type CreateOrgApiResponse = /** status 201 Single-organization page respo
             linkedin?: string;
             /** URL of the organization's X (formerly Twitter) profile. */
             x?: string;
+            /** URL of the organization's YouTube channel. */
+            youtube?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -3593,6 +3597,8 @@ export type CreateOrgApiArg = {
           linkedin?: string;
           /** URL of the organization's X (formerly Twitter) profile. */
           x?: string;
+          /** URL of the organization's YouTube channel. */
+          youtube?: string;
         };
       };
       /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -3734,6 +3740,8 @@ export type GetOrgApiResponse = /** status 200 Single-organization page response
             linkedin?: string;
             /** URL of the organization's X (formerly Twitter) profile. */
             x?: string;
+            /** URL of the organization's YouTube channel. */
+            youtube?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -3863,6 +3871,8 @@ export type UpdateOrgApiResponse = /** status 200 Single-organization page respo
             linkedin?: string;
             /** URL of the organization's X (formerly Twitter) profile. */
             x?: string;
+            /** URL of the organization's YouTube channel. */
+            youtube?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -3973,6 +3983,8 @@ export type UpdateOrgApiArg = {
           linkedin?: string;
           /** URL of the organization's X (formerly Twitter) profile. */
           x?: string;
+          /** URL of the organization's YouTube channel. */
+          youtube?: string;
         };
       };
       /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -4062,6 +4074,8 @@ export type GetOrgPreferencesApiResponse = /** status 200 Organization metadata,
         linkedin?: string;
         /** URL of the organization's X (formerly Twitter) profile. */
         x?: string;
+        /** URL of the organization's YouTube channel. */
+        youtube?: string;
       };
     };
     /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */

--- a/typescript/rtk/meshery.ts
+++ b/typescript/rtk/meshery.ts
@@ -11590,6 +11590,8 @@ export type GetOrgsApiResponse = /** status 200 Organizations response */ {
             linkedin?: string;
             /** URL of the organization's X (formerly Twitter) profile. */
             x?: string;
+            /** URL of the organization's YouTube channel. */
+            youtube?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -11722,6 +11724,8 @@ export type CreateOrgApiResponse = /** status 201 Single-organization page respo
             linkedin?: string;
             /** URL of the organization's X (formerly Twitter) profile. */
             x?: string;
+            /** URL of the organization's YouTube channel. */
+            youtube?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -11830,6 +11834,8 @@ export type CreateOrgApiArg = {
           linkedin?: string;
           /** URL of the organization's X (formerly Twitter) profile. */
           x?: string;
+          /** URL of the organization's YouTube channel. */
+          youtube?: string;
         };
       };
       /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -11971,6 +11977,8 @@ export type GetOrgApiResponse = /** status 200 Single-organization page response
             linkedin?: string;
             /** URL of the organization's X (formerly Twitter) profile. */
             x?: string;
+            /** URL of the organization's YouTube channel. */
+            youtube?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -12100,6 +12108,8 @@ export type UpdateOrgApiResponse = /** status 200 Single-organization page respo
             linkedin?: string;
             /** URL of the organization's X (formerly Twitter) profile. */
             x?: string;
+            /** URL of the organization's YouTube channel. */
+            youtube?: string;
           };
         };
         /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -12210,6 +12220,8 @@ export type UpdateOrgApiArg = {
           linkedin?: string;
           /** URL of the organization's X (formerly Twitter) profile. */
           x?: string;
+          /** URL of the organization's YouTube channel. */
+          youtube?: string;
         };
       };
       /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */
@@ -12299,6 +12311,8 @@ export type GetOrgPreferencesApiResponse = /** status 200 Organization metadata,
         linkedin?: string;
         /** URL of the organization's X (formerly Twitter) profile. */
         x?: string;
+        /** URL of the organization's YouTube channel. */
+        youtube?: string;
       };
     };
     /** Whether the feature carousel renders on the organization's auth pages. Unset is treated as true (shown); set false to hide it. */


### PR DESCRIPTION
## Symptom

The Edit Organization modal in Layer5 Cloud offers no YouTube field, and a custom-branded organization's emails therefore carry the **provider** organization's YouTube URL in their footer. The consuming email template hard-codes `https://www.youtube.com/c/Layer5io` precisely because there is no tenant field to read.

## Root cause

`Social` in `schemas/constructs/v1beta2/organization/api.yml` declares exactly `linkedin` and `x`. There is no `youtube` in the contract, so there is nothing for the modal to render or the template to read. This repository is the source of truth for that contract, so the field has to originate here - meshery-cloud cannot and should not add it locally.

## Fix

Adds `youtube` to the `Social` object, matching its siblings exactly:

```yaml
youtube:
  type: string
  format: uri
  maxLength: 2048
  description: URL of the organization's YouTube channel.
  x-go-name: YouTube
```

- **Wire name** `youtube` - camelCase-consistent, single word, matching `linkedin` and `x`.
- **Go name** `YouTube` - the siblings spell theirs by the brand's own capitalization (`LinkedIn`, `X`; and `ImageURL` nearby follows Go initialism style), so `YouTube` is the consistent choice over `Youtube`.
- **"channel", not "profile"** - YouTube's own noun for the thing an organization brands.

Purely additive and optional, so no consumer breaks.

## Versions touched, and not touched

- **Touched:** `v1beta2/organization` only. This is the sole place the branding `Links.social` object exists.
- **Deliberately not touched:** `v1beta1/organization` is marked `x-deprecated: true` / `x-superseded-by: v1beta2` and has no `Links` or `Social` object at all - there is nothing there to keep in step.
- **Not the same object:** `Social` also appears in `v1beta1`, `v1beta2`, and `v1beta3` of the **user** construct, but that is an unrelated shape - a `{site, link}` pair in a `socials` array describing a user's online profiles, not an organization's per-platform branded URLs. These are not divergent copies of one object and are not meant to be synced.

## Generated output

Regenerated with `make build` (no hand edits):

- `models/v1beta2/organization/organization.go` - `YouTube *string \`json:"youtube,omitempty"\``
- `typescript/generated/v1beta2/organization/Organization.ts` and `OrganizationSchema.ts`
- `typescript/rtk/cloud.ts`, `typescript/rtk/meshery.ts`

The generated TypeScript now carries `youtube?: string` under `Links.social`.

Verified: `make build`, `make validate-schemas` (no blocking violations), `make consumer-audit`, `go test ./...`, `npm run build` - all pass.

## Watch for - a prose claim this change does not fix

`Social`'s description still ends:

> Each platform is a named, individually validated URL so consumers can render the matching platform icon. **Empty or omitted fields fall back to the platform defaults.**

The first sentence holds for `youtube` - it is a named, individually validated URL and renders with its own platform icon, exactly like its siblings.

The **fallback sentence is the problem**, and it is the reason this bug exists at all. "Fall back to the platform defaults" is the documented behavior that puts Layer5's own YouTube URL into a tenant's footer; adding the field gives a tenant a way to override it but does not change what an omitted field does. If Layer5 Cloud is moving to rendering only tenant-provided links - dropping the icon entirely when a tenant has not set one - then that sentence becomes wrong for every platform in this object, not just for `youtube`.

Reporting rather than editing: that is a contract change affecting `linkedin` and `x` as well as the new field, it needs the consumer's rendering behavior to change in step, and it is wider than this PR's scope. Worth a follow-up issue against meshery-cloud and a matching description change here once the consumer behavior is settled.

## Downstream

meshery-cloud picks this up on its next `@meshery/schemas` bump: add the YouTube input to the Edit Organization modal and read `social.youtube` in the email footer template in place of the hard-coded `https://www.youtube.com/c/Layer5io`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Organization social profiles can now include a YouTube channel URL.
  - YouTube links are supported across organization configuration and API representations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->