### PR TITLE
Declare 403 for environment purpose refusals

### DIFF
--- a/schemas/constructs/v1beta3/connection/api.yml
+++ b/schemas/constructs/v1beta3/connection/api.yml
@@ -346,6 +346,8 @@ paths:
           $ref: "#/components/responses/400"
         "401":
           $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/EnvironmentPurposeForbidden"
         "404":
           $ref: "#/components/responses/404"
         "500":
@@ -366,6 +368,8 @@ paths:
           description: Connection removed from environment
         "401":
           $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/EnvironmentPurposeForbidden"
         "404":
           $ref: "#/components/responses/404"
         "500":
@@ -519,6 +523,18 @@ components:
       $ref: "../../v1beta2/core/api.yml#/components/responses/400"
     401:
       $ref: "../../v1beta2/core/api.yml#/components/responses/401"
+    403:
+      $ref: "../../v1beta2/core/api.yml#/components/responses/403"
+    EnvironmentPurposeForbidden:
+      description: >-
+        Refusal to operate on an environment whose purpose is not user.
+        This concerns the target's designation rather than the caller's
+        identity; the same caller remains authorized for this route on
+        other environments in the same organization.
+      content:
+        text/plain:
+          schema:
+            type: string
     404:
       $ref: "../../v1beta2/core/api.yml#/components/responses/404"
     500:

--- a/schemas/constructs/v1beta3/environment/api.yml
+++ b/schemas/constructs/v1beta3/environment/api.yml
@@ -28,6 +28,18 @@ components:
       $ref: "../../v1alpha1/core/api.yml#/components/responses/400"
     401:
       $ref: "../../v1alpha1/core/api.yml#/components/responses/401"
+    403:
+      $ref: "../../v1alpha1/core/api.yml#/components/responses/403"
+    EnvironmentPurposeForbidden:
+      description: >-
+        Refusal to operate on an environment whose purpose is not user.
+        This concerns the target's designation rather than the caller's
+        identity; the same caller remains authorized for this route on
+        other environments in the same organization.
+      content:
+        text/plain:
+          schema:
+            type: string
     404:
       $ref: "../../v1alpha1/core/api.yml#/components/responses/404"
     500:
@@ -366,6 +378,8 @@ paths:
           $ref: "#/components/responses/400"
         "401":
           $ref: "#/components/responses/401"
+        "403":
+          $ref: "#/components/responses/EnvironmentPurposeForbidden"
         "404":
           $ref: "#/components/responses/404"
         "500":


### PR DESCRIPTION
## Summary
- Adds a `403` (`EnvironmentPurposeForbidden`) response to `deleteEnvironment`, `addConnectionToEnvironment`, and `removeConnectionFromEnvironment`
- Documents that the refusal is about the target environment's `purpose` designation (not `user`), not the caller's identity

Fixes #1190

## Test plan
- [ ] Confirm OpenAPI YAML still validates in schema CI
- [ ] Confirm generated consumers surface `403` on the three operations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated API documentation to describe `403 Forbidden` responses when attempting to add, remove, or delete connections and environments that are not intended for user operations.
  - Added a reusable response description with a plain-text explanation of the restriction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->